### PR TITLE
chore(deploy): add in steps to deploy storybook

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,3 @@
+*
+!Staticfile
+!storybook-static

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,3 +12,24 @@ jobs:
       - run:
           name: Run all Continuous Integration checks
           command: yarn ci-check
+      - deploy:
+          name: deploy to IBM Cloud
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              # Install `ibmcloud` CLI
+              curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
+
+              # Login and push staging manifest
+              ibmcloud login \
+                --apikey $CLOUD_API_KEY \
+                -a https://api.ng.bluemix.net \
+                -o carbon-design-system \
+                -s production
+              ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+              ibmcloud cf install-plugin blue-green-deploy -f -r CF-Community
+
+              yarn storybook-build
+              ibmcloud cf blue-green-deploy carbon-storybook-vue \
+                -f .circleci/manifest.yml \
+                --delete-old-apps
+            fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
               # Install `ibmcloud` CLI
               curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
 
-              # Login and push storybook
+              # Login and install blue-green-deploy plugin
               ibmcloud login \
                 --apikey $CLOUD_API_KEY \
                 -a https://api.ng.bluemix.net \
@@ -28,8 +28,10 @@ jobs:
               ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
               ibmcloud cf install-plugin blue-green-deploy -f -r CF-Community
 
+              # Build default storybook
               yarn storybook-build
 
+              # Use blue-green-deploy for our buildpack
               ibmcloud cf blue-green-deploy carbon-storybook-vue \
                 -f .circleci/manifest.yml \
                 --delete-old-apps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
               # Install `ibmcloud` CLI
               curl -fsSL https://clis.ng.bluemix.net/install/linux | sh
 
-              # Login and push staging manifest
+              # Login and push storybook
               ibmcloud login \
                 --apikey $CLOUD_API_KEY \
                 -a https://api.ng.bluemix.net \
@@ -29,6 +29,7 @@ jobs:
               ibmcloud cf install-plugin blue-green-deploy -f -r CF-Community
 
               yarn storybook-build
+
               ibmcloud cf blue-green-deploy carbon-storybook-vue \
                 -f .circleci/manifest.yml \
                 --delete-old-apps

--- a/.circleci/manifest.yml
+++ b/.circleci/manifest.yml
@@ -1,0 +1,8 @@
+---
+applications:
+- name: carbon-storybook-vue
+  memory: 64M
+  buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+  routes:
+  - route: vue.carbondesignsystem.com
+  - route: carbon-vue-storybook.mybluemix.net

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ es
 lib
 dist
 umd
+storybook-static
 
 # Config files
 .npmrc

--- a/Staticfile
+++ b/Staticfile
@@ -1,0 +1,1 @@
+root: storybook-static


### PR DESCRIPTION
Closes #45 

Adds in CI/CD process for deploying our storybook to IBM Cloud.

#### Changelog

**New**

- Deployment-related files

**Changed**

- Add `storybook-static` to `.gitignore`

**Removed**
