### PR TITLE
fix: carbon styling of the <body> tag, and prevent duplicate CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ storybook-static
 
 # Config files
 .npmrc
+.nvmrc
 
 # Cache folders
 .cache

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ View available Vue.js components [here](http://vue.carbondesignsystem.com). Usag
 
 ## Usage
 
+### General
+
+The components do not import any of the carbon styles themselves. Use the SCSS or CSS from carbon-components to provide the styling.
+You can also use the unpkg cdn to bring in the styles wholesale - unpkg.com/carbon-components/css/carbon-components.css aliases the latest css file.
+
 ### All at once
 
 In your main js file (where you include Vue)

--- a/src/assets/styles/_carbon-helpers.scss
+++ b/src/assets/styles/_carbon-helpers.scss
@@ -1,0 +1,8 @@
+//---------------------------------------------------------------------------
+// Carbon SCSS vars, mixins, functions, etc. for @import'ing into components.
+//---------------------------------------------------------------------------
+
+@import '~carbon-components/scss/globals/scss/colors';
+@import '~carbon-components/scss/globals/scss/layer';
+@import '~carbon-components/scss/globals/scss/typography';
+@import '~carbon-components/scss/globals/scss/vars';

--- a/src/components/cv-accordion/cv-accordion-item.vue
+++ b/src/components/cv-accordion/cv-accordion-item.vue
@@ -37,6 +37,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/accordion/accordion';
 </style>

--- a/src/components/cv-accordion/cv-accordion.vue
+++ b/src/components/cv-accordion/cv-accordion.vue
@@ -28,6 +28,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/accordion/accordion';
 </style>

--- a/src/components/cv-breadcrumb/cv-breadcrumb.vue
+++ b/src/components/cv-breadcrumb/cv-breadcrumb.vue
@@ -17,5 +17,4 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~carbon-components/scss/components/breadcrumb/breadcrumb';
 </style>

--- a/src/components/cv-button/cv-button.vue
+++ b/src/components/cv-button/cv-button.vue
@@ -34,6 +34,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/button/button';
 </style>

--- a/src/components/cv-checkbox/cv-checkbox.vue
+++ b/src/components/cv-checkbox/cv-checkbox.vue
@@ -43,6 +43,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/checkbox/checkbox';
 </style>

--- a/src/components/cv-code-snippet/_cv-feedback-button.vue
+++ b/src/components/cv-code-snippet/_cv-feedback-button.vue
@@ -43,5 +43,4 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~carbon-components/scss/components/copy-button/copy-button';
 </style>

--- a/src/components/cv-code-snippet/cv-code-snippet.vue
+++ b/src/components/cv-code-snippet/cv-code-snippet.vue
@@ -60,7 +60,6 @@ export default {
 </script>
 
 <style lang="scss">
-@import '../../assets/styles/carbon-helpers';
 .cv-code-snippet__clippy {
   // cannot be hidden for clipboard to work
   position: absolute;

--- a/src/components/cv-code-snippet/cv-code-snippet.vue
+++ b/src/components/cv-code-snippet/cv-code-snippet.vue
@@ -60,9 +60,7 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/code-snippet/code-snippet';
-
+@import '../../assets/styles/carbon-helpers';
 .cv-code-snippet__clippy {
   // cannot be hidden for clipboard to work
   position: absolute;

--- a/src/components/cv-content-switcher/cv-content-switcher.vue
+++ b/src/components/cv-content-switcher/cv-content-switcher.vue
@@ -26,6 +26,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/content-switcher/content-switcher';
 </style>

--- a/src/components/cv-date-picker/cv-date-picker.vue
+++ b/src/components/cv-date-picker/cv-date-picker.vue
@@ -131,9 +131,6 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/date-picker/date-picker';
-
 .cv-date-picker {
   display: inline-flex; // otherwise 100% width
 }

--- a/src/components/cv-file-uploader/cv-file-uploader.vue
+++ b/src/components/cv-file-uploader/cv-file-uploader.vue
@@ -151,9 +151,6 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/file-uploader/file-uploader';
-
 .cv-file-uploader__close {
   width: 16px;
   height: 16px;

--- a/src/components/cv-form/cv-form-group.vue
+++ b/src/components/cv-form/cv-form-group.vue
@@ -18,6 +18,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/form/form';
 </style>

--- a/src/components/cv-form/cv-form-item.vue
+++ b/src/components/cv-form/cv-form-item.vue
@@ -11,6 +11,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/form/form';
 </style>

--- a/src/components/cv-form/cv-form.vue
+++ b/src/components/cv-form/cv-form.vue
@@ -13,6 +13,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/form/form';
 </style>

--- a/src/components/cv-inline-notification/cv-inline-notification.vue
+++ b/src/components/cv-inline-notification/cv-inline-notification.vue
@@ -53,5 +53,4 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~carbon-components/scss/components/notification/inline-notification';
 </style>

--- a/src/components/cv-link/cv-link.vue
+++ b/src/components/cv-link/cv-link.vue
@@ -11,5 +11,4 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~carbon-components/scss/components/link/link';
 </style>

--- a/src/components/cv-list/cv-list.vue
+++ b/src/components/cv-list/cv-list.vue
@@ -36,5 +36,4 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~carbon-components/scss/components/list/list';
 </style>

--- a/src/components/cv-loading/cv-loading.vue
+++ b/src/components/cv-loading/cv-loading.vue
@@ -77,5 +77,4 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~carbon-components/scss/components/loading/loading';
 </style>

--- a/src/components/cv-modal/cv-modal.vue
+++ b/src/components/cv-modal/cv-modal.vue
@@ -125,6 +125,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/modal/modal';
 </style>

--- a/src/components/cv-number-input/cv-number-input.vue
+++ b/src/components/cv-number-input/cv-number-input.vue
@@ -75,6 +75,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/number-input/number-input';
 </style>

--- a/src/components/cv-overflow-menu/cv-overflow-menu.vue
+++ b/src/components/cv-overflow-menu/cv-overflow-menu.vue
@@ -57,6 +57,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/overflow-menu/overflow-menu';
 </style>

--- a/src/components/cv-pagination/cv-pagination.vue
+++ b/src/components/cv-pagination/cv-pagination.vue
@@ -196,9 +196,6 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/pagination/pagination';
-
 .cv-pagination .cv-select {
   margin-bottom: 0;
 }

--- a/src/components/cv-progress/cv-progress.vue
+++ b/src/components/cv-progress/cv-progress.vue
@@ -68,6 +68,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/progress-indicator/progress-indicator';
 </style>

--- a/src/components/cv-radio-button/cv-radio-button.vue
+++ b/src/components/cv-radio-button/cv-radio-button.vue
@@ -64,6 +64,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/radio-button/radio-button';
 </style>

--- a/src/components/cv-search/cv-search.vue
+++ b/src/components/cv-search/cv-search.vue
@@ -83,6 +83,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/search/search';
 </style>

--- a/src/components/cv-select/cv-select.vue
+++ b/src/components/cv-select/cv-select.vue
@@ -96,9 +96,6 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/select/select';
-
 .bx--visually-hidden {
   visibility: visible;
   position: absolute;

--- a/src/components/cv-slider/cv-slider.vue
+++ b/src/components/cv-slider/cv-slider.vue
@@ -216,5 +216,4 @@ export default {
 </script>
 
 <style lang="sass">
-@import '~carbon-components/scss/components/slider/slider';
 </style>

--- a/src/components/cv-structured-list/cv-structured-list.vue
+++ b/src/components/cv-structured-list/cv-structured-list.vue
@@ -67,6 +67,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/structured-list/structured-list';
 </style>

--- a/src/components/cv-tabs/cv-tabs.vue
+++ b/src/components/cv-tabs/cv-tabs.vue
@@ -36,6 +36,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/tabs/tabs';
 </style>

--- a/src/components/cv-tag/cv-tag.vue
+++ b/src/components/cv-tag/cv-tag.vue
@@ -29,6 +29,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/tag/tag';
 </style>

--- a/src/components/cv-text-area/cv-text-area.vue
+++ b/src/components/cv-text-area/cv-text-area.vue
@@ -32,6 +32,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/text-area/text-area';
 </style>

--- a/src/components/cv-text-input/cv-text-input.vue
+++ b/src/components/cv-text-input/cv-text-input.vue
@@ -32,6 +32,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/text-input/text-input';
 </style>

--- a/src/components/cv-tile/cv-tile.vue
+++ b/src/components/cv-tile/cv-tile.vue
@@ -53,6 +53,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/tile/tile';
 </style>

--- a/src/components/cv-time-picker/cv-time-picker.vue
+++ b/src/components/cv-time-picker/cv-time-picker.vue
@@ -101,6 +101,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/time-picker/time-picker';
 </style>

--- a/src/components/cv-toast-notification/cv-toast-notification.vue
+++ b/src/components/cv-toast-notification/cv-toast-notification.vue
@@ -38,5 +38,4 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~carbon-components/scss/components/notification/toast-notification';
 </style>

--- a/src/components/cv-toggle/cv-toggle.vue
+++ b/src/components/cv-toggle/cv-toggle.vue
@@ -35,6 +35,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/toggle/toggle';
 </style>

--- a/src/components/cv-tooltip/cv-definition-tooltip.vue
+++ b/src/components/cv-tooltip/cv-definition-tooltip.vue
@@ -33,6 +33,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/tooltip/tooltip';
 </style>

--- a/src/components/cv-tooltip/cv-interactive-tooltip.vue
+++ b/src/components/cv-tooltip/cv-interactive-tooltip.vue
@@ -73,6 +73,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/tooltip/tooltip';
 </style>

--- a/src/components/cv-tooltip/cv-tooltip.vue
+++ b/src/components/cv-tooltip/cv-tooltip.vue
@@ -38,6 +38,4 @@ export default {
 </script>
 
 <style lang="scss">
-// Import Style Definitions
-@import '~carbon-components/scss/components/tooltip/tooltip';
 </style>

--- a/src/views/sv-template-view/sv-template-view.vue
+++ b/src/views/sv-template-view/sv-template-view.vue
@@ -54,6 +54,7 @@ export default {
 </script>
 
 <style lang="scss">
+@import '~carbon-components/scss/globals/scss/styles.scss';
 @import '~highlight.js/styles/default.css';
 $back-color: #f5f7fa;
 $alt-back-color: #fff;


### PR DESCRIPTION
Closes #60 

fix: carbon styling of the <body> tag, and prevent duplicate CSS

#### Changelog

**New**

Add carbon styles to <body> so that it can be inherited by components.
Prevent single file components generating duplicate CSS.
