### PR TITLE
fix: add div's with bx--form-item where missing

### DIFF
--- a/src/components/cv-date-picker/cv-date-picker.vue
+++ b/src/components/cv-date-picker/cv-date-picker.vue
@@ -1,33 +1,35 @@
 <template>
-  <div :data-date-picker="['single', 'range'].includes(kind)"
-    :data-date-picker-type="kind"
-    class="cv-date-picker bx--date-picker"
-    :class="[kindClass, {'bx--date-picker--light': theme==='light'}]" ref="date-picker">
-    <div :class="{'bx--date-picker-container': ['single', 'range'].includes(kind)}" @change="onSimpleChange">
-      <svg v-if="kind === 'single'" data-date-picker-icon class="bx--date-picker__icon"
+  <div class="bx--form-item">
+    <div :data-date-picker="['single', 'range'].includes(kind)"
+      :data-date-picker-type="kind"
+      class="cv-date-picker bx--date-picker"
+      :class="[kindClass, {'bx--date-picker--light': theme==='light'}]" ref="date-picker">
+      <div :class="{'bx--date-picker-container': ['single', 'range'].includes(kind)}" @change="onSimpleChange">
+        <svg v-if="kind === 'single'" data-date-picker-icon class="bx--date-picker__icon"
+          width="14" height="16" viewBox="0 0 14 16">
+          <path d="M0 5h14v1H0V5zm3-5h1v4H3V0zm7 0h1v4h-1V0zM0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14.5v-12zm1 0v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-12a.5.5 0 0 0-.5-.5h-11a.5.5 0 0 0-.5.5z"
+            fill-rule="nonzero" />
+        </svg>
+        <label :for="`${uid}-input-1`" class="bx--label">{{dateLabelValue}}</label>
+        <input :data-invalid="invalid" type="text" :id="`${uid}-input-1`"
+          class="bx--date-picker__input"  :pattern="pattern" :placeholder="placeholder"
+          data-date-picker-input :data-date-picker-input-from="kind === 'range'"/>
+        <div class="bx--form-requirement" v-if="invalid">
+          {{invalidDateMessage}}
+        </div>
+      </div>
+      <div :class="{'bx--date-picker-container': kind === 'range'}" v-if="kind === 'range'">
+        <label :for="`${uid}-input-2`" class="bx--label">{{dateEndLabelValue}}</label>
+        <input type="text" :id="`${uid}-input-2`"
+          class="bx--date-picker__input" :pattern="pattern" :placeholder="placeholder"
+          data-date-picker-input :data-date-picker-input-to="kind === 'range'"/>
+      </div>
+      <svg v-if="kind === 'range'" data-date-picker-icon class="bx--date-picker__icon"
         width="14" height="16" viewBox="0 0 14 16">
         <path d="M0 5h14v1H0V5zm3-5h1v4H3V0zm7 0h1v4h-1V0zM0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14.5v-12zm1 0v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-12a.5.5 0 0 0-.5-.5h-11a.5.5 0 0 0-.5.5z"
           fill-rule="nonzero" />
       </svg>
-      <label :for="`${uid}-input-1`" class="bx--label">{{dateLabelValue}}</label>
-      <input :data-invalid="invalid" type="text" :id="`${uid}-input-1`"
-        class="bx--date-picker__input"  :pattern="pattern" :placeholder="placeholder"
-        data-date-picker-input :data-date-picker-input-from="kind === 'range'"/>
-      <div class="bx--form-requirement" v-if="invalid">
-        {{invalidDateMessage}}
-      </div>
     </div>
-    <div :class="{'bx--date-picker-container': kind === 'range'}" v-if="kind === 'range'">
-      <label :for="`${uid}-input-2`" class="bx--label">{{dateEndLabelValue}}</label>
-      <input type="text" :id="`${uid}-input-2`"
-        class="bx--date-picker__input" :pattern="pattern" :placeholder="placeholder"
-        data-date-picker-input :data-date-picker-input-to="kind === 'range'"/>
-    </div>
-    <svg v-if="kind === 'range'" data-date-picker-icon class="bx--date-picker__icon"
-      width="14" height="16" viewBox="0 0 14 16">
-      <path d="M0 5h14v1H0V5zm3-5h1v4H3V0zm7 0h1v4h-1V0zM0 2.5A1.5 1.5 0 0 1 1.5 1h11A1.5 1.5 0 0 1 14 2.5v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14.5v-12zm1 0v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5v-12a.5.5 0 0 0-.5-.5h-11a.5.5 0 0 0-.5.5z"
-        fill-rule="nonzero" />
-    </svg>
   </div>
 </template>
 

--- a/src/components/cv-number-input/cv-number-input.vue
+++ b/src/components/cv-number-input/cv-number-input.vue
@@ -1,33 +1,35 @@
 <template>
-  <div data-numberinput class="cv-number-input bx--number"
-    :class="{
-      'bx--number--light': theme === 'light',
-      'bx--number--helpertext': $slots['helper-text']
-    }" :data-invalid="invalid">
-    <div class="bx--number__controls">
-      <button class="bx--number__control-btn up-icon">
-        <svg width="10" height="5" viewBox="0 0 10 5">
-          <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
-        </svg>
-      </button>
-      <button class="bx--number__control-btn down-icon">
-        <svg width="10" height="5" viewBox="0 0 10 5">
-          <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
-        </svg>
-      </button>
-    </div>
-    <input
-      :id="uid"
-      type="number"
-      :value="value"
-      v-bind="$attrs"
-      v-on="inputListeners">
-    <label :for="uid" class="bx--label">{{label}}</label>
-    <div class="bx--form-requirement" v-if="$slots['invalid-message']">
-      <slot name="invalid-message">Invalid number</slot>
-    </div>
-    <div class="bx--form__helper-text" v-if="$slots['helper-text']">
-      <slot name="helper-text"></slot>
+  <div class="bx--form-item">
+    <div data-numberinput class="cv-number-input bx--number"
+      :class="{
+        'bx--number--light': theme === 'light',
+        'bx--number--helpertext': $slots['helper-text']
+      }" :data-invalid="invalid">
+      <div class="bx--number__controls">
+        <button class="bx--number__control-btn up-icon">
+          <svg width="10" height="5" viewBox="0 0 10 5">
+            <path d="M0 5L5 .002 10 5z" fill-rule="evenodd" />
+          </svg>
+        </button>
+        <button class="bx--number__control-btn down-icon">
+          <svg width="10" height="5" viewBox="0 0 10 5">
+            <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd" />
+          </svg>
+        </button>
+      </div>
+      <input
+        :id="uid"
+        type="number"
+        :value="value"
+        v-bind="$attrs"
+        v-on="inputListeners">
+      <label :for="uid" class="bx--label">{{label}}</label>
+      <div class="bx--form-requirement" v-if="$slots['invalid-message']">
+        <slot name="invalid-message">Invalid number</slot>
+      </div>
+      <div class="bx--form__helper-text" v-if="$slots['helper-text']">
+        <slot name="helper-text"></slot>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Part of fix for issue #68 

#### Changelog

**Changed**

- Adds \<div\>s with bx--form-item to the templates for cv-number-input and cv-date-picker, to match the Carbon components boilerplate.
