### PR TITLE
chore: make vue native

### DIFF
--- a/src/components/cv-content-switcher/cv-content-switcher-button.vue
+++ b/src/components/cv-content-switcher/cv-content-switcher-button.vue
@@ -15,20 +15,72 @@
     class="cv-content-switcher-button"
     :class="[
       'bx--content-switcher-btn', {
-        'bx--content-switcher--selected' : selected
+        'bx--content-switcher--selected' : dataSelected
       }]"
     :data-target="contentSelector"
+    :aria-selected="`${dataSelected}`"
+    @click="open"
   >
     <slot></slot>
   </button>
 </template>
 
 <script>
+const toggleContent = (selector, on) => {
+  // hide content
+  const content = document.querySelectorAll(selector);
+  for (const element of content) {
+    // element.style.visibility = on;
+    if (!on) {
+      element.setAttribute('hidden', 'hidden');
+    } else {
+      element.removeAttribute('hidden');
+    }
+    element.setAttribute('aria-hidden', `${!on}`);
+  }
+};
+
 export default {
   name: 'CvContentSwitcherButton',
   props: {
     contentSelector: String,
     selected: Boolean,
+  },
+  data() {
+    return {
+      buttonId: undefined,
+      dataSelected: false,
+      onOpenFunction: undefined,
+    };
+  },
+  mounted() {
+    this.buttonId = Symbol('content switcher button');
+    this.dataSelected = this.selected;
+    this.onOpenFunction = this.$parent.register(
+      this.buttonId,
+      this.contentSelector,
+      this.close
+    );
+
+    if (this.selected) {
+      this.open();
+    } else {
+      this.close();
+    }
+  },
+  beforeDestroy() {
+    this.$parent.deregister(this.buttonId);
+  },
+  methods: {
+    close() {
+      this.dataSelected = false;
+      toggleContent(this.contentSelector, false);
+    },
+    open() {
+      this.onOpenFunction(this.buttonId);
+      this.dataSelected = true;
+      toggleContent(this.contentSelector, true);
+    },
   },
 };
 </script>

--- a/src/components/cv-content-switcher/cv-content-switcher-notes.md
+++ b/src/components/cv-content-switcher/cv-content-switcher-notes.md
@@ -33,6 +33,11 @@ http://www.carbondesignsystem.com/components/content-switcher/code
 
 N/A
 
+## Events
+
+- selected
+  - contentSelector
+
 ### Additional
 
 N/A

--- a/src/components/cv-content-switcher/cv-content-switcher-story.js
+++ b/src/components/cv-content-switcher/cv-content-switcher-story.js
@@ -38,8 +38,7 @@ const preKnobs = {
     value: val =>
       val
         ? `
-  @content-switcher-selected="actionSelected"
-  @content-switcher-beingselected="actionBeingSelected"`
+  @selected="actionSelected"`
         : '',
   },
   otherAttributes: {
@@ -76,13 +75,13 @@ for (const story of storySet) {
     <div class="content-1">
       <p>This is the content for option 1</p>
     </div>
-    <div class="content-2" hidden>
+    <div class="content-2">
       <p>This is the content for option 2</p>
     </div>
-    <div class="content-2" hidden >
+    <div class="content-2" >
       <p>This is more content for option 2</p>
     </div>
-    <div class="content-3" hidden>
+    <div class="content-3">
       <p>This is the content for option 3</p>
     </div>
   </section>
@@ -105,12 +104,7 @@ for (const story of storySet) {
           SvTemplateView,
         },
         methods: {
-          actionSelected: action(
-            'Cv Content Switcher - content-switcher-selected'
-          ),
-          actionBeingSelected: action(
-            'Cv Content Switcher - content-switcher-beingselected'
-          ),
+          actionSelected: action('Cv Content Switcher - selected'),
         },
         template: templateViewString,
       };

--- a/src/components/cv-content-switcher/cv-content-switcher.vue
+++ b/src/components/cv-content-switcher/cv-content-switcher.vue
@@ -1,19 +1,44 @@
 <template>
-  <div data-content-switcher class="cv-content-switcher bx--content-switcher" v-on="$listeners">
+  <div data-content-switcher class="cv-content-switcher bx--content-switcher">
     <slot></slot>
   </div>
 </template>
 
 <script>
-import { ContentSwitcher } from 'carbon-components';
-
 export default {
   name: 'CvContentSwitcher',
-  mounted() {
-    this.carbonComponent = ContentSwitcher.create(this.$el);
+  data() {
+    return {
+      switcherButtons: [],
+    };
   },
-  beforeDestroy() {
-    this.carbonComponent.release();
+  methods: {
+    onOpen(buttonId) {
+      let openButton;
+
+      for (let index in this.switcherButtons) {
+        if (this.switcherButtons[index].buttonId !== buttonId) {
+          this.switcherButtons[index].closeFunction();
+        } else {
+          openButton = this.switcherButtons[index];
+        }
+      }
+      if (openButton !== undefined) {
+        this.$emit('selected', openButton.contentSelector);
+      }
+    },
+    register(buttonId, contentSelector, closeFunction) {
+      this.deregister(buttonId);
+      this.switcherButtons.push({ buttonId, contentSelector, closeFunction });
+
+      return this.onOpen;
+    },
+    deregister(buttonId) {
+      let index = this.switcherButtons.findIndex(
+        item => item.buttonId === buttonId
+      );
+      this.switcherButtons.slice(index, index + 1);
+    },
   },
 };
 </script>


### PR DESCRIPTION
Making the content switcher completely native would involve turning the content panels into Vue components. The implementation directly manipulates the dom attributes for the content sections to show and hide content.