### PR TITLE
feat(component): add pie chart component

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Current Version: 0.1
 | **CvNumberInput**        | :white_check_mark: | http://vue.carbondesignsystem.com/?selectedKind=CvNumberInput                    |
 | **CvOverflowMenu**       | :white_check_mark: | http://vue.carbondesignsystem.com/?selectedKind=CvOverflowMenu                   |
 | **CvPagination**         | :white_check_mark: | http://vue.carbondesignsystem.com/?selectedKind=CvPagination&selectedStory=All   |
-| CvPieChart               | :heavy_minus_sign: | https://github.com/carbon-design-system/carbon-components-vue/issues/52          |
+| CvPieChart               | :warning:          | https://github.com/carbon-design-system/carbon-components-vue/issues/52          |
 |                          |
 | **CvProgress**           | :white_check_mark: | http://vue.carbondesignsystem.com/?selectedKind=CvProgress                       |
 | **CvRadioButton**        | :white_check_mark: | http://vue.carbondesignsystem.com/?selectedKind=CvRadioButton                    |

--- a/src/data-viz/cv-pie-chart/cv-pie-chart-notes.md
+++ b/src/data-viz/cv-pie-chart/cv-pie-chart-notes.md
@@ -1,0 +1,24 @@
+# CV Pie Chart
+
+A Vue implementation of a Carbon Pie Chart Component. Pie charts show individual values that make up a whole data set so users can compare the values to each other and see how each value compares to the whole. A common way to express the part-to-whole relationship is to use percentages, with the whole equaling 100% and each of its parts equaling smaller percentages corresponding to its value relative to the whole. Expressing exact values is useful as long as the total is also shown.
+
+https://www.carbondesignsystem.com/data-visualization/pie-chart/code
+
+## Usage
+
+```html
+<cv-pie-chart
+  :dataArray="[['Gryffindor', 23],['Slytherin', 12],['Ravenclaw', 19],['Hufflepuff', 15],['Teachers', 5]]"
+  :colors="['#3b1a40', '#473793', '#3c6df0', '#00a68f', '#56D2BB']"
+  header="Example Pie Chart"
+>
+</cv-pie-chart>
+```
+
+## Attributes
+
+### cv-gauge
+
+- dataArray - array of arrays in the following form [['label1', value1], ['label2', value2], ..., ['labelN', valueN]]
+- colors - array of colors that are used for pie chart parts
+- header - text that will appear on top of this pie chart (optional)

--- a/src/data-viz/cv-pie-chart/cv-pie-chart-story.js
+++ b/src/data-viz/cv-pie-chart/cv-pie-chart-story.js
@@ -43,7 +43,7 @@ const storySet = knobsHelper.getStorySet(variants, preKnobs);
 for (const story of storySet) {
   stories.add(
     story.name,
-    withNotes(CvPieChartNotesMD)(() => {
+    () => {
       const settings = story.knobs();
 
       const templateString = `
@@ -69,6 +69,9 @@ for (const story of storySet) {
         props: settings.props,
         template: templateViewString,
       };
-    })
+    },
+    {
+      notes: { markdown: CvPieChartNotesMD },
+    }
   );
 }

--- a/src/data-viz/cv-pie-chart/cv-pie-chart-story.js
+++ b/src/data-viz/cv-pie-chart/cv-pie-chart-story.js
@@ -1,0 +1,74 @@
+import { storiesOf } from '@storybook/vue';
+import { withKnobs, text, array, object } from '@storybook/addon-knobs/vue';
+import { withNotes } from '@storybook/addon-notes';
+
+import SvTemplateView from '../../_storybook/views/sv-template-view/sv-template-view';
+import knobsHelper from '../../_storybook/utils/knobs-helper';
+
+import CvPieChartNotesMD from './cv-pie-chart-notes.md';
+import CvPieChart from './cv-pie-chart';
+
+const stories = storiesOf('Data-Viz/CvPieChart', module);
+stories.addDecorator(withKnobs);
+stories.addDecorator(withNotes);
+
+const preKnobs = {
+  dataArray: {
+    group: 'attr',
+    type: object,
+    config: [
+      'dataArray',
+      [['Gryffindor', 23], ['Slytherin', 12], ['Ravenclaw', 19]],
+    ],
+    prop: { name: 'dataArray', type: Array },
+  },
+  colors: {
+    group: 'attr',
+    type: array,
+    config: ['colors', ['#3b1a40', '#473793', '#3c6df0']],
+    prop: { name: 'colors', type: Array },
+  },
+  header: {
+    group: 'attr',
+    type: text,
+    config: ['header', 'Example Header'],
+    prop: { name: 'header', type: String },
+  },
+};
+
+const variants = [{ name: 'default' }];
+
+const storySet = knobsHelper.getStorySet(variants, preKnobs);
+
+for (const story of storySet) {
+  stories.add(
+    story.name,
+    withNotes(CvPieChartNotesMD)(() => {
+      const settings = story.knobs();
+
+      const templateString = `
+  <cv-pie-chart ${settings.group.attr}>
+  </cv-pie-chart>
+  `;
+
+      // ----------------------------------------------------------------
+      const templateViewString = `
+  <sv-template-view
+    sv-margin
+    :sv-alt-back="this.$options.propsData.theme !== 'light'"
+    sv-source='${templateString.trim()}'>
+    <template slot="component">${templateString}</template>
+  </sv-template-view>
+  `;
+
+      return {
+        components: {
+          CvPieChart,
+          SvTemplateView,
+        },
+        props: settings.props,
+        template: templateViewString,
+      };
+    })
+  );
+}

--- a/src/data-viz/cv-pie-chart/cv-pie-chart.vue
+++ b/src/data-viz/cv-pie-chart/cv-pie-chart.vue
@@ -1,0 +1,190 @@
+<!--
+  Carbon Style Pie Chart
+
+  Attributes:
+    dataArray: array of arrays in the following form [['label1', value1], ['label2', value2], ..., ['labelN', valueN]]
+    colors: array of colors that are used for pie chart parts
+    header: text that will appear on top of this pie chart (optional)
+
+  Usage:
+    <cv-pie-chart
+      :dataArray="[['Gryffindor', 23],['Slytherin', 12],['Ravenclaw', 19],['Hufflepuff', 15],['Teachers', 5]]"
+      :colors="['#3b1a40', '#473793', '#3c6df0', '#00a68f', '#56D2BB']"
+      header="Example Pie Chart">
+    </cv-pie-chart>
+
+-->
+
+<template>
+  <div class="cv-pie-chart">
+    <h2 class="bx--graph-header">{{ header }}</h2>
+    <div class="cv-pie-chart__container">
+      <svg :width="width" :height="height"><g /></svg>
+      <div class="cv-pie-chart__tooltip">
+        <p class="cv-pie-chart__amount"></p>
+        <p class="cv-pie-chart__item"></p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import * as d3 from 'd3';
+
+const radius = 96;
+
+const pie = d3
+  .pie()
+  .sort(null)
+  .value(d => d[1]);
+
+const path = d3
+  .arc()
+  .outerRadius(radius - 10)
+  .innerRadius(radius - 40);
+
+const pathTwo = d3
+  .arc()
+  .outerRadius(radius)
+  .innerRadius(radius - 40);
+
+export default {
+  name: 'CvPieChart',
+  props: {
+    dataArray: {
+      type: Array,
+      default: () => [
+        ['Gryffindor', 23],
+        ['Slytherin', 12],
+        ['Ravenclaw', 19],
+        ['Hufflepuff', 15],
+        ['Teachers', 5],
+      ],
+    },
+    colors: {
+      type: Array,
+      default: () => ['#3b1a40', '#473793', '#3c6df0', '#00a68f', '#56D2BB'],
+    },
+    header: {
+      type: String,
+      default: '',
+    },
+  },
+  data: function() {
+    return {
+      g: null,
+      scaledColors: null,
+      width: radius * 2, // TODO
+      height: radius * 2, // TODO
+    };
+  },
+  watch: {
+    dataArray(newVal) {
+      this.dataArray = newVal;
+      this.$nextTick(() => {
+        this.visualizePieChart();
+      });
+    },
+    colors(newVal) {
+      this.colors = newVal;
+      this.scaledColors = d3.scaleOrdinal(newVal);
+      this.$nextTick(() => {
+        this.visualizePieChart();
+      });
+    },
+  },
+  methods: {
+    visualizePieChart() {
+      this.g.selectAll('*').remove();
+
+      const arc = this.g
+        .selectAll('.arc')
+        .data(pie(this.dataArray))
+        .enter()
+        .append('g')
+        .attr('class', 'arc');
+
+      arc
+        .append('path')
+        .attr('d', path)
+        .attr('fill', (d, i) => this.scaledColors(i))
+        .attr('stroke-width', 2)
+        .attr('stroke', '#FFFFFF')
+        .on('mouseover', function(d) {
+          d3.select(this)
+            .transition()
+            .style('cursor', 'pointer')
+            .attr('d', pathTwo);
+
+          const tooltip = d3
+            .select('.cv-pie-chart__tooltip')
+            .style('display', 'inherit');
+
+          const amount = d3.select('.cv-pie-chart__amount');
+          const item = d3.select('.cv-pie-chart__item');
+
+          amount.text(`${d.data[1]}`);
+
+          item.text(`${d.data[0]}`);
+        })
+        .on('mouseout', function(d) {
+          const tooltip = d3
+            .select('.cv-pie-chart__tooltip')
+            .style('display', 'none');
+
+          d3.select(this)
+            .transition()
+            .attr('d', path);
+        });
+    },
+  },
+  mounted() {
+    this.g = d3
+      .select('g')
+      .attr('transform', `translate(${this.width / 2}, ${this.height / 2})`);
+
+    this.scaledColors = d3.scaleOrdinal(this.colors);
+    this.visualizePieChart();
+  },
+};
+</script>
+
+<style lang="scss">
+.bx--graph-header {
+  font-weight: 300;
+  font-size: 24px;
+}
+
+.cv-pie-chart__container {
+  display: inline-block;
+  position: relative;
+}
+
+.cv-pie-chart__tooltip {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  pointer-events: none;
+  width: 100%;
+
+  p {
+    text-align: center;
+  }
+
+  .cv-pie-chart__amount {
+    font-size: 29px;
+    line-height: 1;
+    font-weight: 300;
+  }
+
+  .cv-pie-chart__item {
+    font-weight: 400;
+    font-size: 14px;
+    color: #5a6872;
+  }
+}
+</style>


### PR DESCRIPTION
Closes #52

Add pie char component. Props are dataArray, colors and header. Uses d3 library in the same way as in carbon vanilla implementation.

#### Changelog

**New**

- data-viz/cv-pie-chart/cv-pie-chart-notes.md
- data-viz/cv-pie-chart/cv-pie-chart-story.js
- data-viz/cv-pie-chart/cv-pie-chart.vue

**Changed**

- status of CvPieChart in ReadMe

**Removed**

- nothing
