### PR TITLE
feat: make y-axis gridlines optional

### DIFF
--- a/src/data-viz/cv-bar-graph/cv-bar-graph-notes.md
+++ b/src/data-viz/cv-bar-graph/cv-bar-graph-notes.md
@@ -18,6 +18,7 @@ https://www.carbondesignsystem.com/data-visualization/bar-graph/code
   :bar-colors="['#00a78f', '#3b1a40', '#473793', '#3c6df0', '#56d2bb']"
   :x-axis-label-offset="50"
   :y-axis-label-offset="50"
+  :y-axis-grid-lines="false"
   :key-labels="['Data set #1', 'Data set #2', 'Data set #3', 'Data set #4', 'Data set #5']"
   :empty-text="There is no data"
   :data="[
@@ -67,6 +68,7 @@ https://www.carbondesignsystem.com/data-visualization/bar-graph/code
 - bar-colors: An array of CSS fill color strings for the bars, one color per data set. Optional (default `['#00a78f', '#3b1a40', '#473793', '#3c6df0', '#56d2bb']`)
 - x-axis-label-offset: The offset, in pixels, of the x-axis label from the x-axis. Optional (default 50).
 - y-axis-label-offset: The offset, in pixels, of the y-axis label from the y-axis. Optional (default 50).
+- y-axis-grid-lines: Whether or not to display grid lines on the graph for the y-axis. Optional (default true).
 - key-labels: An array of label strings to be used in the optional key that describes the data sets. Optional (default none).
 - empty-text: A text message to be displayed when there is no data. This is overridden by the emptyContent slot if one is provided. Optional (default none).
 - data: An array of objects containing the data to be plotted. Each object contains an 'x'

--- a/src/data-viz/cv-bar-graph/cv-bar-graph-story.js
+++ b/src/data-viz/cv-bar-graph/cv-bar-graph-story.js
@@ -1,5 +1,11 @@
 import { storiesOf } from '@storybook/vue';
-import { withKnobs, text, object, number } from '@storybook/addon-knobs';
+import {
+  withKnobs,
+  text,
+  object,
+  number,
+  boolean,
+} from '@storybook/addon-knobs';
 // import { action } from '@storybook/addon-actions';
 import { withNotes } from '@storybook/addon-notes';
 
@@ -92,6 +98,12 @@ const preKnobs = {
       type: Number,
       value: val => (val === null ? undefined : val),
     },
+  },
+  yAxisGridLines: {
+    group: 'attr',
+    type: boolean,
+    config: ['y-axis-grid-lines', true],
+    prop: { name: 'y-axis-grid-lines', type: Boolean },
   },
   keyLabels: {
     group: 'attr',

--- a/src/data-viz/cv-bar-graph/cv-bar-graph.vue
+++ b/src/data-viz/cv-bar-graph/cv-bar-graph.vue
@@ -64,6 +64,7 @@ export default {
     yAxisLabel: String,
     xAxisLabelOffset: { type: Number, default: 50 },
     yAxisLabelOffset: { type: Number, default: 50 },
+    yAxisGridLines: { type: Boolean, default: true },
   },
   data() {
     return {
@@ -208,7 +209,9 @@ export default {
         .indexOf(0);
       yAxis
         .selectAll('.tick line')
+        .attr('visibility', this.yAxisGridLines ? 'visible' : 'hidden')
         .filter((d, i) => i === yScaleZeroTickIndex)
+        .attr('visibility', 'visible')
         .attr('stroke-dasharray', 'none');
 
       // Set up the axis labels.
@@ -356,6 +359,9 @@ export default {
       this.updateGraph();
     },
     yAxisLabelOffset() {
+      this.updateGraph();
+    },
+    yAxisGridLines() {
       this.updateGraph();
     },
   },


### PR DESCRIPTION
Closes #

Makes gridlines on the y-axis (dashed lines across the graph) optional via a property setting

#### Changelog

**New**

- Makes gridlines on the y-axis optional via a property setting

