### PR TITLE
Add helper text and invalid

### DIFF
--- a/src/_storybook/views/sv-template-view/sv-template-view.vue
+++ b/src/_storybook/views/sv-template-view/sv-template-view.vue
@@ -66,7 +66,9 @@ export default {
     style() {
       return {
         alignItems:
-          this.svPosition && this.svPosition.length ? svPosition : 'flex-start',
+          this.svPosition && this.svPosition.length
+            ? this.svPosition
+            : 'flex-start',
       };
     },
   },

--- a/src/components/cv-text-area/cv-text-area-notes.md
+++ b/src/components/cv-text-area/cv-text-area-notes.md
@@ -12,8 +12,15 @@ http://www.carbondesignsystem.com/components/text-input/code
 
 ## Attributes
 
-- label: the label text for the textarea label
+- helper-text: optional helper text
+- invalid-message: optional error message
+- label: the label text for the text area
+- theme: optional 'light',
+- value: optional initial value of the text area,
+
+Other standard props e.g. disabled and placeholder
 
 ## slots
 
-none
+- helper-text: optional and overrides the helper-text attribute
+- invalid-message: optional and overrides the invalid-message attribute

--- a/src/components/cv-text-area/cv-text-area-story.js
+++ b/src/components/cv-text-area/cv-text-area-story.js
@@ -28,10 +28,20 @@ const preKnobs = {
   label: {
     group: 'attr',
     type: text,
-    config: ['label', 'Text input label'], // consts.CONTENT], // fails when used with number in storybook 4.1.4
+    config: ['label', 'Text area label'], // consts.CONTENT], // fails when used with number in storybook 4.1.4
     prop: {
       type: String,
       name: 'label',
+    },
+  },
+  value: {
+    group: 'attr',
+    type: text,
+    config: ['value', ''], // consts.CONTENT], // fails when used with number in storybook 4.1.4
+    prop: {
+      type: String,
+      name: 'value',
+      value: val => (val.length ? val : null),
     },
   },
   disabled: {
@@ -51,10 +61,48 @@ const preKnobs = {
     group: 'attr',
     value: `@input="onInput"`,
   },
+  placeholder: {
+    group: 'attr',
+    value: 'placeholder="sample placeholder"',
+  },
+  helperText: {
+    group: 'attr',
+    type: text,
+    config: ['helper text', ''],
+    prop: {
+      name: 'helper-text',
+      type: String,
+      value: val => (val.length ? val : null),
+    },
+  },
+  helperTextSlot: {
+    group: 'slots',
+    value:
+      '<template slot="helper-text">This is a helpful slot overrides the property helper-text</template>',
+  },
+  invalidMessage: {
+    group: 'attr',
+    type: text,
+    config: ['invalid message', ''],
+    prop: {
+      name: 'invalid-message',
+      type: String,
+      value: val => (val.length ? val : null),
+    },
+  },
+  invalidMessageSlot: {
+    group: 'slots',
+    value:
+      '<template slot="invalid-message">Invalid message slot overrides the invalid-message property</template>',
+  },
 };
 
 const variants = [
-  { name: 'default', excludes: ['vModel', 'events'] },
+  {
+    name: 'default',
+    excludes: ['vModel', 'events', 'helperTextSlot', 'invalidMessageSlot'],
+  },
+  { name: 'helper and error slots', excludes: ['vModel', 'events'] },
   { name: 'minimal', includes: ['label'] },
   { name: 'events', includes: ['label', 'events'] },
   { name: 'vModel', includes: ['label', 'vModel'] },
@@ -71,7 +119,7 @@ for (const story of storySet) {
       // ----------------------------------------------------------------
 
       const templateString = `
-<cv-text-area${settings.group.attr}>
+<cv-text-area${settings.group.attr}>${settings.group.slots}
 </cv-text-area>
   `;
 

--- a/src/components/cv-text-area/cv-text-area-story.js
+++ b/src/components/cv-text-area/cv-text-area-story.js
@@ -77,8 +77,10 @@ const preKnobs = {
   },
   helperTextSlot: {
     group: 'slots',
-    value:
-      '<template slot="helper-text">This is a helpful slot overrides the property helper-text</template>',
+    slot: {
+      name: 'helper-text',
+      value: 'This is a helpful slot overrides the property helper-text',
+    },
   },
   invalidMessage: {
     group: 'attr',
@@ -92,8 +94,10 @@ const preKnobs = {
   },
   invalidMessageSlot: {
     group: 'slots',
-    value:
-      '<template slot="invalid-message">Invalid message slot overrides the invalid-message property</template>',
+    slot: {
+      name: 'invalid-message',
+      value: 'Invalid message slot overrides the invalid-message property',
+    },
   },
 };
 

--- a/src/components/cv-text-area/cv-text-area.vue
+++ b/src/components/cv-text-area/cv-text-area.vue
@@ -11,6 +11,9 @@
       ]"
       >{{ label }}</label
     >
+    <div class="bx--form__helper-text" v-if="isHelper">
+      <slot name="helper-text">{{ helperText }}</slot>
+    </div>
     <textarea
       :id="uid"
       class="bx--text-area"
@@ -18,7 +21,11 @@
       v-bind="$attrs"
       :value="value"
       v-on="inputListeners"
+      :data-invalid="isInvalid"
     ></textarea>
+    <div class="bx--form-requirement" v-if="isInvalid">
+      <slot name="invalid-message">{{ invalidMessage }}</slot>
+    </div>
   </div>
 </template>
 
@@ -31,6 +38,8 @@ export default {
   mixins: [uidMixin, themeMixin],
   inheritAttrs: false,
   props: {
+    helperText: { type: String, default: null },
+    invalidMessage: { type: String, default: null },
     label: String,
     value: String,
   },
@@ -43,6 +52,18 @@ export default {
         ...this.$listeners,
         input: event => this.$emit('input', event.target.value),
       };
+    },
+    isInvalid() {
+      return (
+        this.$slots['invalid-message'] ||
+        (this.invalidMessage && this.invalidMessage.length)
+      );
+    },
+    isHelper() {
+      return (
+        this.$slots['helper-text'] ||
+        (this.helperText && this.helperText.length)
+      );
     },
   },
 };

--- a/src/components/cv-text-input/cv-text-input-notes.md
+++ b/src/components/cv-text-input/cv-text-input-notes.md
@@ -12,8 +12,15 @@ http://www.carbondesignsystem.com/components/text-input/code
 
 ## Attributes
 
-- label: the label text for the input label
+- helper-text: optional helper text
+- invalid-message: optional error message
+- label: the label text for the input
+- theme: optional 'light',
+- value: optional initial value of the text input,
+
+Other standard props e.g. disabled and placeholder
 
 ## slots
 
-none
+- helper-text: optional and overrides the helper-text attribute
+- invalid-message: optional and overrides the invalid-message attribute

--- a/src/components/cv-text-input/cv-text-input-story.js
+++ b/src/components/cv-text-input/cv-text-input-story.js
@@ -34,6 +34,16 @@ const preKnobs = {
       name: 'label',
     },
   },
+  value: {
+    group: 'attr',
+    type: text,
+    config: ['value', ''], // consts.CONTENT], // fails when used with number in storybook 4.1.4
+    prop: {
+      type: String,
+      name: 'value',
+      value: val => (val.length ? val : null),
+    },
+  },
   disabled: {
     group: 'attr',
     type: boolean,
@@ -43,6 +53,10 @@ const preKnobs = {
       name: 'disabled',
     },
   },
+  placeholder: {
+    group: 'attr',
+    value: 'placeholder="sample placeholder"',
+  },
   vModel: {
     group: 'attr',
     value: `v-model="modelValue"`,
@@ -51,10 +65,44 @@ const preKnobs = {
     group: 'attr',
     value: `@input="onInput"`,
   },
+  helperText: {
+    group: 'attr',
+    type: text,
+    config: ['helper text', ''],
+    prop: {
+      name: 'helper-text',
+      type: String,
+      value: val => (val.length ? val : null),
+    },
+  },
+  helperTextSlot: {
+    group: 'slots',
+    value:
+      '<template slot="helper-text">This is a helpful slot overrides the property helper-text</template>',
+  },
+  invalidMessage: {
+    group: 'attr',
+    type: text,
+    config: ['invalid message', ''],
+    prop: {
+      name: 'invalid-message',
+      type: String,
+      value: val => (val.length ? val : null),
+    },
+  },
+  invalidMessageSlot: {
+    group: 'slots',
+    value:
+      '<template slot="invalid-message">Invalid message slot overrides the invalid-message property</template>',
+  },
 };
 
 const variants = [
-  { name: 'default', excludes: ['vModel', 'events'] },
+  {
+    name: 'default',
+    excludes: ['vModel', 'events', 'helperTextSlot', 'invalidMessageSlot'],
+  },
+  { name: 'helper and error slots', excludes: ['vModel', 'events'] },
   { name: 'minimal', includes: ['label'] },
   { name: 'events', includes: ['label', 'events'] },
   { name: 'vModel', includes: ['label', 'vModel'] },
@@ -71,7 +119,7 @@ for (const story of storySet) {
       // ----------------------------------------------------------------
 
       const templateString = `
-<cv-text-input${settings.group.attr}>
+<cv-text-input${settings.group.attr}>${settings.group.slots}
 </cv-text-input>
   `;
       // ----------------------------------------------------------------

--- a/src/components/cv-text-input/cv-text-input-story.js
+++ b/src/components/cv-text-input/cv-text-input-story.js
@@ -77,8 +77,10 @@ const preKnobs = {
   },
   helperTextSlot: {
     group: 'slots',
-    value:
-      '<template slot="helper-text">This is a helpful slot overrides the property helper-text</template>',
+    slot: {
+      name: 'helper-text',
+      value: 'This is a helpful slot overrides the property helper-text',
+    },
   },
   invalidMessage: {
     group: 'attr',
@@ -92,8 +94,10 @@ const preKnobs = {
   },
   invalidMessageSlot: {
     group: 'slots',
-    value:
-      '<template slot="invalid-message">Invalid message slot overrides the invalid-message property</template>',
+    slot: {
+      name: 'invalid-message',
+      value: 'Invalid message slot overrides the invalid-message property',
+    },
   },
 };
 

--- a/src/components/cv-text-input/cv-text-input.vue
+++ b/src/components/cv-text-input/cv-text-input.vue
@@ -11,6 +11,9 @@
       ]"
       >{{ label }}</label
     >
+    <div class="bx--form__helper-text" v-if="isHelper">
+      <slot name="helper-text">{{ helperText }}</slot>
+    </div>
     <input
       :id="uid"
       class="bx--text-input"
@@ -18,7 +21,11 @@
       v-bind="$attrs"
       :value="value"
       v-on="inputListeners"
+      :data-invalid="isInvalid"
     />
+    <div class="bx--form-requirement" v-if="isInvalid">
+      <slot name="invalid-message">{{ invalidMessage }}</slot>
+    </div>
   </div>
 </template>
 
@@ -31,6 +38,8 @@ export default {
   mixins: [uidMixin, themeMixin],
   inheritAttrs: false,
   props: {
+    helperText: { type: String, default: null },
+    invalidMessage: { type: String, default: null },
     label: String,
     theme: String,
     value: String,
@@ -44,6 +53,18 @@ export default {
         ...this.$listeners,
         input: event => this.$emit('input', event.target.value),
       };
+    },
+    isInvalid() {
+      return (
+        this.$slots['invalid-message'] ||
+        (this.invalidMessage && this.invalidMessage.length)
+      );
+    },
+    isHelper() {
+      return (
+        this.$slots['helper-text'] ||
+        (this.helperText && this.helperText.length)
+      );
     },
   },
 };


### PR DESCRIPTION
Closes #181 

Added using slops, a slot-prop hybrid in which the slot overrides the prop.

#### Changelog

**Changed**

- CvTextArea
- CvTextInput
