### PR TITLE
fix(number input): add type=button to number input controls)

### DIFF
--- a/src/components/cv-number-input/cv-number-input.vue
+++ b/src/components/cv-number-input/cv-number-input.vue
@@ -10,12 +10,20 @@
       :data-invalid="isInvalid"
     >
       <div class="bx--number__controls">
-        <button class="bx--number__control-btn up-icon" @click="doUp">
+        <button
+          class="bx--number__control-btn up-icon"
+          @click="doUp"
+          type="button"
+        >
           <svg width="10" height="5" viewBox="0 0 10 5">
             <path d="M0 5L5 .002 10 5z" fill-rule="evenodd"></path>
           </svg>
         </button>
-        <button class="bx--number__control-btn down-icon" @click="doDown">
+        <button
+          class="bx--number__control-btn down-icon"
+          @click="doDown"
+          type="button"
+        >
           <svg width="10" height="5" viewBox="0 0 10 5">
             <path d="M0 0l5 4.998L10 0z" fill-rule="evenodd"></path>
           </svg>


### PR DESCRIPTION
Prevent number inputs within forms from prematurely submitting the form

Closes #

Same issue as [#1747](https://github.com/IBM/carbon-components/issues/1747) in IBM/carbon-components

#### Changelog
**Changed**
- src/components/cv-number-input/cv-number-input.vue