### PR TITLE
fix: nextTick instead of setTimeout

### DIFF
--- a/src/components/cv-overflow-menu/cv-overflow-menu.vue
+++ b/src/components/cv-overflow-menu/cv-overflow-menu.vue
@@ -110,18 +110,18 @@ export default {
         ) {
           this.open = false;
           this.positionListen(false);
-          setTimeout(() => {
+          this.$nextTick(() => {
             this.doFocus();
-          }, 1);
+          });
         }
       }
     },
     menuItemclick() {
       this.open = false;
       this.positionListen(false);
-      setTimeout(() => {
+      this.$nextTick(() => {
         this.doFocus();
-      }, 1);
+      });
     },
     doClose() {
       this.open = false;
@@ -139,7 +139,7 @@ export default {
     positionMenu() {
       if (this.open) {
         const menuPosition = this.$el.getBoundingClientRect();
-        setTimeout(() => {
+        this.$nextTick(() => {
           if (this.flipMenu) {
             this.left =
               menuPosition.left +
@@ -155,7 +155,7 @@ export default {
             this.top =
               menuPosition.bottom + 2 + this.offsetTop + window.scrollY;
           }
-        }, 1);
+        });
       }
     },
     doFocus() {
@@ -184,16 +184,16 @@ export default {
       } else {
         focusOn = this.$el;
       }
-      setTimeout(() => {
-        focusOn.focus();
-      }, 1);
+      focusOn.focus();
     },
     doToggle() {
       this.open = !this.open;
 
       this.positionMenu();
       this.positionListen(this.open);
-      this.doFocus();
+      this.$nextTick(() => {
+        this.doFocus();
+      });
     },
     onOverflowMenuTab(ev) {
       if (!ev.shiftKey) {

--- a/src/components/cv-pagination/cv-pagination.vue
+++ b/src/components/cv-pagination/cv-pagination.vue
@@ -217,13 +217,13 @@ export default {
       this.pageCount = newPageCount(this.numberOfItems, this.pageSizeValue);
       this.pages = newPagesArray(this.pageCount);
       // what page is firstItem on
-      setTimeout(() => {
+      this.$nextTick(() => {
         // setting pageValue immediately seems to cause a problem - test set pageSize to 40, page to 3, set pageSize to 10
         // this previously resulted in 1 being set on Chrome (other browsers untested)
         this.pageValue = Math.ceil(this.firstItem / this.pageSizeValue);
         this.firstItem = newFirstItem(this.pageValue, this.pageSizeValue);
         this.$emit('change', this.internalValue);
-      }, 1);
+      });
     },
     onPrevPage() {
       if (this.pageValue > 1) {

--- a/src/components/cv-slider/cv-slider.vue
+++ b/src/components/cv-slider/cv-slider.vue
@@ -123,20 +123,20 @@ export default {
       this.setValue(val);
     },
     min() {
-      setTimeout(() => {
+      this.$nextTick(() => {
         this.setValue(this.internalValue);
-      }, 1);
+      });
       //      this.internalMin = val && val.length ? val : '0';
     },
     max() {
-      setTimeout(() => {
+      this.$nextTick(() => {
         this.setValue(this.internalValue);
-      }, 1);
+      });
     },
     step() {
-      setTimeout(() => {
+      this.$nextTick(() => {
         this.setValue(this.internalValue);
-      }, 1);
+      });
     },
   },
   methods: {

--- a/src/components/cv-tooltip/cv-interactive-tooltip.vue
+++ b/src/components/cv-tooltip/cv-interactive-tooltip.vue
@@ -168,10 +168,10 @@ export default {
       this.dataVisible = true;
       this.positionListen(true);
 
-      setTimeout(() => {
+      this.$nextTick(() => {
         this.position();
         this.$refs.trigger.focus();
-      }, 1);
+      });
     },
     hide() {
       this.dataVisible = false;


### PR DESCRIPTION
Closes #169 

Replace setTimeout with nextTick

#### Changelog

**New**

-

**Changed**

- interactive-tooltip, slider, pagination and overflow-menu

**Removed**

-

**Comments**

Could you please check overflow-menu component? I am not 100% sure in the correctness of using nextTick for `focus` parts.
