### PR TITLE
fix: show tip and hide tip buttons for interactive tooltip storybook

### DIFF
--- a/src/components/cv-tooltip/cv-tooltip-story.js
+++ b/src/components/cv-tooltip/cv-tooltip-story.js
@@ -116,10 +116,10 @@ for (const story of storySet) {
         props: settings.props,
         methods: {
           show() {
-            this.$children[0].$children[0].show();
+            this.$children[0].$children[0].$children[0].show();
           },
           hide() {
-            this.$children[0].$children[0].hide();
+            this.$children[0].$children[0].$children[0].hide();
           },
         },
       };


### PR DESCRIPTION
Closes #247 

Fix onclick actions for 'show tip' and 'hide tip' buttons for interactive tooltip storybook.

#### Changelog

**Changed**

- storybook for interactive tooltip
