### PR TITLE
fix: selectable tile state

### DIFF
--- a/src/components/cv-tile/_cv-tile-selectable.vue
+++ b/src/components/cv-tile/_cv-tile-selectable.vue
@@ -16,6 +16,7 @@
       :checked="isChecked"
       class="bx--tile-input"
       v-bind="$attrs"
+      v-on="inputListeners"
     />
     <div class="bx--tile__checkmark">
       <svg width="16" height="16" viewBox="0 0 16 16" fill-rule="evenodd">
@@ -25,7 +26,9 @@
       </svg>
     </div>
     <div class="bx--tile-content">
-      <slot> <!-- Tile content here --> </slot>
+      <slot>
+        <!-- Tile content here -->
+      </slot>
     </div>
   </label>
 </template>


### PR DESCRIPTION
The selectable tile was not correctly setting classes and other state attributes.

#### Changelog

**Changed**

m  src/components/cv-tile/_cv-tile-selectable.vue
