### PR TITLE
fix: multiline code snippet and inline story

### DIFF
--- a/packages/core/src/components/cv-code-snippet/_cv-code-snippet-multiline.vue
+++ b/packages/core/src/components/cv-code-snippet/_cv-code-snippet-multiline.vue
@@ -39,6 +39,7 @@
 
 <script>
 import CvFeedbackButton from './_cv-feedback-button';
+import CvButton from '../cv-button/cv-button';
 import { componentsX } from '../../internal/feature-flags';
 import Copy16 from '@carbon/icons-vue/lib/copy/16';
 import ChevronDown16 from '@carbon/icons-vue/lib/chevron--down/16';
@@ -46,6 +47,7 @@ import ChevronDown16 from '@carbon/icons-vue/lib/chevron--down/16';
 export default {
   name: 'CvCodeSnippetMultiline',
   components: {
+    CvButton,
     CvFeedbackButton,
     Copy16,
     ChevronDown16,

--- a/storybook/stories/cv-code-snippet-story.js
+++ b/storybook/stories/cv-code-snippet-story.js
@@ -34,6 +34,13 @@ let preKnobs = {
       type: String,
     },
   },
+  inlineContent: {
+    group: 'content',
+    slot: {
+      name: '',
+      value: 'printf("A short bit of code.");',
+    },
+  },
   content: {
     group: 'content',
     slot: {
@@ -70,7 +77,7 @@ let variants = [
   },
   {
     name: 'inline',
-    includes: ['content'],
+    includes: ['inlineContent'],
     extra: { kind: { group: 'attr', value: 'kind="inline"', inline: true } },
   },
   {


### PR DESCRIPTION
Part of #314

Refine inline code snippet story.
Fix multiline code snippet

#### Changelog

M       packages/core/src/components/cv-code-snippet/_cv-code-snippet-multiline.vue
M       storybook/stories/cv-code-snippet-story.js