### PR TITLE
fix: overflow menu gap style

### DIFF
--- a/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
+++ b/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
@@ -144,11 +144,10 @@ export default {
               this.offsetLeft -
               this.$refs.popup.offsetWidth +
               this.$el.offsetWidth;
-            this.top = menuPosition.bottom + 2 + this.offsetTop + window.scrollY;
           } else {
             this.left = menuPosition.left - (this.componentsX ? 0 : 20) + this.offsetLeft + window.scrollX;
-            this.top = menuPosition.bottom + 2 + this.offsetTop + window.scrollY;
           }
+          this.top = menuPosition.bottom + (this.componentsX ? 0 : 2) + this.offsetTop + window.scrollY;
         });
       }
     },


### PR DESCRIPTION
Closes #316 

Remove gap in v 2

#### Changelog

m .   packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue