### PR TITLE
Search fix

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/vue",
   "description": "A collection of components for the Carbon Design System built using Vue.js",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/core/src/components/cv-search/cv-search-notes.md
+++ b/packages/core/src/components/cv-search/cv-search-notes.md
@@ -7,13 +7,13 @@ http://www.carbondesignsystem.com/components/text-input/code
 ## Usage
 
 ```html
-<cv-search large v-model="modelValue" label="Search label"> </cv-search>
+<cv-search small v-model="modelValue" label="Search label"> </cv-search>
 ```
 
 ## Attributes
 
 - label: the label text for the search box
-- large: is the search the large version
+- small: makes hte search box smaller
 - value: initial value
 
 ## slots

--- a/packages/core/src/components/cv-search/cv-search.vue
+++ b/packages/core/src/components/cv-search/cv-search.vue
@@ -84,7 +84,19 @@ export default {
     formItem: { type: Boolean, default: true },
     kind: { type: String, default: null },
     label: String,
-    large: Boolean,
+    small: Boolean,
+    large: {
+      type: Boolean,
+      default: null,
+      validator(val) {
+        if (process.env.NODE_ENV === 'development') {
+          if (val !== null) {
+            console.warn('The larger search input is now the default.');
+          }
+        }
+        return true;
+      },
+    },
     value: String,
     placeholder: { type: String, default: 'Search' },
   },
@@ -114,7 +126,9 @@ export default {
     },
     searchClasses() {
       const themeClass = this.theme.length ? `bx--search--${this.theme}` : '';
-      const sizeClass = `bx--search--${this.large ? 'lg' : 'sm'}`;
+      const sizeClass = componentsX
+        ? `bx--search--${this.small ? 'sm' : 'xl'}`
+        : `bx--search--${this.large ? 'lg' : 'sm'}`;
       let toolbarClasses = '';
       if (this.isToolbarKind) {
         toolbarClasses = this.toolbarActive ? 'bx--toolbar-search bx--toolbar-search--active' : 'bx--toolbar-search';

--- a/packages/data-viz/package.json
+++ b/packages/data-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/data-viz-vue",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "> TODO: description",
   "author": "Dave Clark <dave.clark@uk.ibm.com>",
   "homepage": "https://github.com/carbon-design-system/carbon-components-vue/tree/master/packages/dataviz#readme",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "private": true,
   "description": "> TODO: description",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",
-    "@carbon/vue": "^2.0.0-alpha.1",
+    "@carbon/vue": "^2.0.0-alpha.2",
     "@storybook/addon-actions": "^5.0.3",
     "@storybook/addon-knobs": "^5.0.3",
     "@storybook/addon-notes": "^5.0.3",

--- a/storybook/stories/cv-search-story.js
+++ b/storybook/stories/cv-search-story.js
@@ -11,7 +11,7 @@ import CvSearch from '@carbon/vue/src/components/cv-search/cv-search';
 
 const storiesDefault = storiesOf('Components/CvSearch', module);
 const storiesExperimental = storiesOf('Experimental/CvSearch', module);
-import { versions, setVersion } from '@carbon/vue/src/internal/feature-flags';
+import { versions, setVersion, componentsX } from '@carbon/vue/src/internal/feature-flags';
 
 const preKnobs = {
   theme: {
@@ -54,6 +54,12 @@ const preKnobs = {
     config: ['large', false], // consts.CONFIG],
     prop: { name: 'large', type: Boolean },
   },
+  small: {
+    group: 'attr',
+    type: boolean,
+    config: ['small', false], // consts.CONFIG],
+    prop: { name: 'small', type: Boolean },
+  },
   vModel: {
     group: 'attr',
     value: `v-model="modelValue"`,
@@ -65,7 +71,7 @@ const preKnobs = {
 };
 
 const variants = [
-  { name: 'default', excludes: ['vModel', 'events'] },
+  { name: 'default', excludes: ['vModel', 'events', componentsX ? 'large' : 'small'] },
   { name: 'minimal', includes: ['label'] },
   { name: 'events', includes: ['label', 'events'] },
   { name: 'vModel', includes: ['label', 'vModel'] },


### PR DESCRIPTION
Closes #314

Change search sizing to use a small property in line with the design language page.

#### Changelog

M       packages/core/src/components/cv-search/cv-search-notes.md
M       packages/core/src/components/cv-search/cv-search.vue
M       storybook/stories/cv-search-story.js