### PR TITLE
fix: linter warnings in structures list

### DIFF
--- a/packages/core/src/components/cv-structured-list/_cv-structured-list-item-selectable.vue
+++ b/packages/core/src/components/cv-structured-list/_cv-structured-list-item-selectable.vue
@@ -44,11 +44,12 @@
 <script>
 import uidMixin from '../../mixins/uid-mixin';
 import radioMixin from '../../mixins/radio-mixin';
-import componentsX from '../../internal/feature-flags';
+import { componentsX } from '../../internal/feature-flags';
 import CheckmarkFilled16 from '@carbon/icons-vue/lib/checkmark--filled/16';
 
 export default {
   name: 'CvStructuredListItemSelectable',
+  components: { CheckmarkFilled16 },
   inheritAttrs: false,
   mixins: [uidMixin, radioMixin],
   data: () => ({ componentsX }),

--- a/packages/core/src/components/cv-structured-list/cv-structured-list.vue
+++ b/packages/core/src/components/cv-structured-list/cv-structured-list.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script>
-import componentsX from '../../internal/feature-flags';
+import { componentsX } from '../../internal/feature-flags';
 
 export default {
   name: 'CvStructuredList',


### PR DESCRIPTION
Fix linter warnings in structured list

#### Changelog

M       packages/core/src/components/cv-structured-list/_cv-structured-list-item-selectable.vue
M       packages/core/src/components/cv-structured-list/cv-structured-list.vue