### PR TITLE
Flip modifier prefix for componentsX

### DIFF
--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -223,7 +223,7 @@ export default {
       }
     },
     modifierClasses() {
-      const prefix = this.componentsX ? 'bx--data-table-v2--' : 'bx--data-table--';
+      const prefix = this.componentsX ? 'bx--data-table--' : 'bx--data-table-v2--';
       const sizeClass = this.rowSize.length === 0 || this.rowSize === 'standard' ? '' : `${prefix}${this.rowSize} `;
       const zebraClass = this.zebra ? `${prefix}zebra ` : '';
       const borderlessClass = this.borderless ? `${prefix}no-border ` : '';


### PR DESCRIPTION
This fixes size, zebra, and borderless props.

#### Changelog

**Changed**

- Fixes modifier class prefixes in cv-data-table
