### PR TITLE
fix: expand tile updates

### DIFF
--- a/packages/core/src/components/cv-tile/_cv-tile-expandable.vue
+++ b/packages/core/src/components/cv-tile/_cv-tile-expandable.vue
@@ -5,8 +5,12 @@
     tabindex="0"
     :class="[{ 'bx--tile--is-expanded': internalExpanded }]"
     :style="styleObject"
+    @click="toggle"
+    @keydown.enter.prevent="toggle"
+    @keydown.space.prevent
+    @keyup.space.prevent="toggle"
   >
-    <button type="button" class="bx--tile__chevron" @click="toggle">
+    <button type="button" class="bx--tile__chevron">
       <ChevronDown16 v-if="componentsX" />
       <svg v-else width="12" height="8" viewBox="0 0 12 8" fill-rule="evenodd">
         <path d="M10.6 0L6 4.7 1.4 0 0 1.4l6 6.1 6-6.1z"></path>


### PR DESCRIPTION
Closes #369 

Make expandable tile expand on tile click instead of just chevron.

#### Changelog

M       packages/core/src/components/cv-tile/_cv-tile-expandable.vue