### PR TITLE
Enable searching without providing an actions slot

### DIFF
--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -34,7 +34,7 @@
           </div>
         </div>
 
-        <div v-if="$slots.actions && !batchActive" class="bx--toolbar-content">
+        <div v-if="($slots.actions && !batchActive) || $listeners.search" class="bx--toolbar-content">
           <div
             v-if="$listeners.search"
             :class="{

--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -34,7 +34,7 @@
           </div>
         </div>
 
-        <div v-if="($slots.actions && !batchActive) || $listeners.search" class="bx--toolbar-content">
+        <div v-if="($slots.actions || $listeners.search) && !batchActive" class="bx--toolbar-content">
           <div
             v-if="$listeners.search"
             :class="{


### PR DESCRIPTION
This enables searching when `@search` is present but no `actions` slot is provided.

#### Changelog

**Changed**

- Enables searching when no `actions` slot is provided