### PR TITLE
fix: use es carbon icon vue imports

### DIFF
--- a/packages/core/src/components/cv-accordion/_cv-accordion-item-skeleton.vue
+++ b/packages/core/src/components/cv-accordion/_cv-accordion-item-skeleton.vue
@@ -16,7 +16,7 @@
 <script>
 import CvSkeletonText from '../cv-skeleton-text/cv-skeleton-text';
 import { componentsX } from '../../internal/feature-flags';
-import ChevronRight16 from '@carbon/icons-vue/lib/chevron--right/16';
+import ChevronRight16 from '@carbon/icons-vue/es/chevron--right/16';
 
 export default {
   name: 'CvAccordionItemSkeleton',

--- a/packages/core/src/components/cv-accordion/cv-accordion-item.vue
+++ b/packages/core/src/components/cv-accordion/cv-accordion-item.vue
@@ -34,7 +34,7 @@
 
 <script>
 import { componentsX } from '../../internal/feature-flags';
-import ChevronRight16 from '@carbon/icons-vue/lib/chevron--right/16';
+import ChevronRight16 from '@carbon/icons-vue/es/chevron--right/16';
 import uidMixin from '../../mixins/uid-mixin';
 
 export default {

--- a/packages/core/src/components/cv-code-snippet/_cv-code-snippet-multiline.vue
+++ b/packages/core/src/components/cv-code-snippet/_cv-code-snippet-multiline.vue
@@ -41,8 +41,8 @@
 import CvFeedbackButton from './_cv-feedback-button';
 import CvButton from '../cv-button/cv-button';
 import { componentsX } from '../../internal/feature-flags';
-import Copy16 from '@carbon/icons-vue/lib/copy/16';
-import ChevronDown16 from '@carbon/icons-vue/lib/chevron--down/16';
+import Copy16 from '@carbon/icons-vue/es/copy/16';
+import ChevronDown16 from '@carbon/icons-vue/es/chevron--down/16';
 
 export default {
   name: 'CvCodeSnippetMultiline',

--- a/packages/core/src/components/cv-code-snippet/_cv-code-snippet-oneline.vue
+++ b/packages/core/src/components/cv-code-snippet/_cv-code-snippet-oneline.vue
@@ -27,7 +27,7 @@
 <script>
 import CvFeedbackButton from './_cv-feedback-button';
 import { componentsX } from '../../internal/feature-flags';
-import Copy16 from '@carbon/icons-vue/lib/copy/16';
+import Copy16 from '@carbon/icons-vue/es/copy/16';
 
 export default {
   name: 'CvCodeSnippetOneline',

--- a/packages/core/src/components/cv-data-table/_cv-data-table-heading.vue
+++ b/packages/core/src/components/cv-data-table/_cv-data-table-heading.vue
@@ -28,8 +28,8 @@
 
 <script>
 import { componentsX } from '../../internal/feature-flags';
-import ArrowDown16 from '@carbon/icons-vue/lib/arrow--down/16';
-import Arrows16 from '@carbon/icons-vue/lib/arrows/16';
+import ArrowDown16 from '@carbon/icons-vue/es/arrow--down/16';
+import Arrows16 from '@carbon/icons-vue/es/arrows/16';
 
 const nextSortOrder = {
   ascending: 'descending',

--- a/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
+++ b/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
@@ -37,7 +37,7 @@ import CvCheckbox from '../cv-checkbox/cv-checkbox';
 import CvOverflowMenu from '../cv-overflow-menu/cv-overflow-menu';
 import CvOverflowMenuItem from '../cv-overflow-menu/cv-overflow-menu-item';
 import uidMixin from '../../mixins/uid-mixin';
-import ChevronRight16 from '@carbon/icons-vue/lib/chevron--right/16';
+import ChevronRight16 from '@carbon/icons-vue/es/chevron--right/16';
 
 export default {
   name: 'CvDataTableRowInner',

--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -156,8 +156,8 @@ import CvPagination from '../cv-pagination/cv-pagination';
 import { componentsX } from '../../internal/feature-flags';
 import CvWrapper from '../cv-wrapper/_cv-wrapper';
 import uidMixin from '../../mixins/uid-mixin';
-import Search16 from '@carbon/icons-vue/lib/search/16';
-import Close16 from '@carbon/icons-vue/lib/close/16';
+import Search16 from '@carbon/icons-vue/es/search/16';
+import Close16 from '@carbon/icons-vue/es/close/16';
 
 const rows = children => children.filter(child => child.isCvDataTableRow);
 

--- a/packages/core/src/components/cv-date-picker/cv-date-picker.vue
+++ b/packages/core/src/components/cv-date-picker/cv-date-picker.vue
@@ -91,7 +91,7 @@ import l10n from 'flatpickr/dist/l10n/index';
 import RangePlugin from 'flatpickr/dist/plugins/rangePlugin';
 import uidMixin from '../../mixins/uid-mixin';
 import themeMixin from '../../mixins/theme-mixin';
-import Calendar16 from '@carbon/icons-vue/lib/calendar/16';
+import Calendar16 from '@carbon/icons-vue/es/calendar/16';
 import { componentsX } from '../../internal/feature-flags';
 import CvWrapper from '../cv-wrapper/_cv-wrapper';
 

--- a/packages/core/src/components/cv-dropdown/_cv-dropdown-inner-c10.vue
+++ b/packages/core/src/components/cv-dropdown/_cv-dropdown-inner-c10.vue
@@ -18,9 +18,9 @@
 <template>
   <div :class="{ 'bx--form-item': formItem }">
     <div class="bx--dropdown__wrapper" :class="{ 'bx--dropdown__wrapper--inline': inline, 'cv-dropdown': !formItem }">
-      <label v-if="label" :for="uid" class="bx--label" :class="{ 'bx--label--disabled': $attrs.disabled }">{{
-        label
-      }}</label>
+      <label v-if="label" :for="uid" class="bx--label" :class="{ 'bx--label--disabled': $attrs.disabled }">
+        {{ label }}
+      </label>
 
       <div
         v-if="!inline && isHelper"
@@ -82,8 +82,8 @@
 <script>
 import uidMixin from '../../mixins/uid-mixin';
 import themeMixin from '../../mixins/theme-mixin';
-import WarningFilled16 from '@carbon/icons-vue/lib/warning--filled/16';
-import ChevronDown16 from '@carbon/icons-vue/lib/chevron--down/16';
+import WarningFilled16 from '@carbon/icons-vue/es/warning--filled/16';
+import ChevronDown16 from '@carbon/icons-vue/es/chevron--down/16';
 
 export default {
   name: 'CvDropdownInner',

--- a/packages/core/src/components/cv-file-uploader/cv-file-uploader.vue
+++ b/packages/core/src/components/cv-file-uploader/cv-file-uploader.vue
@@ -115,9 +115,9 @@ import uidMixin from '../../mixins/uid-mixin';
 import CvFormItem from '../cv-form/cv-form-item';
 import { componentsX } from '../../internal/feature-flags';
 import CvInlineLoading from '../cv-inline-loading/cv-inline-loading';
-import CheckmarkFilled16 from '@carbon/icons-vue/lib/checkmark--filled/16';
-import WarningFilled16 from '@carbon/icons-vue/lib/warning--filled/16';
-import Close16 from '@carbon/icons-vue/lib/close/16';
+import CheckmarkFilled16 from '@carbon/icons-vue/es/checkmark--filled/16';
+import WarningFilled16 from '@carbon/icons-vue/es/warning--filled/16';
+import Close16 from '@carbon/icons-vue/es/close/16';
 import CvWrapper from '../cv-wrapper/_cv-wrapper';
 
 const CONSTS = {

--- a/packages/core/src/components/cv-inline-notification/cv-inline-notification.vue
+++ b/packages/core/src/components/cv-inline-notification/cv-inline-notification.vue
@@ -39,10 +39,10 @@
 import notificationMixin from '../../mixins/notification-mixin';
 import CvIcon from '../cv-icon/_cv-icon';
 import { componentsX } from '../../internal/feature-flags';
-import ErrorFilled16 from '@carbon/icons-vue/lib/error--filled/16';
-import CheckmarkFilled16 from '@carbon/icons-vue/lib/checkmark--filled/16';
-import WarningAltFilled16 from '@carbon/icons-vue/lib/warning--filled/16';
-import Close16 from '@carbon/icons-vue/lib/close/16';
+import ErrorFilled16 from '@carbon/icons-vue/es/error--filled/16';
+import CheckmarkFilled16 from '@carbon/icons-vue/es/checkmark--filled/16';
+import WarningAltFilled16 from '@carbon/icons-vue/es/warning--filled/16';
+import Close16 from '@carbon/icons-vue/es/close/16';
 
 export default {
   name: 'CvInlineNotification',

--- a/packages/core/src/components/cv-modal/cv-modal.vue
+++ b/packages/core/src/components/cv-modal/cv-modal.vue
@@ -76,7 +76,7 @@
 import CvButton from '../cv-button/cv-button';
 import CvIcon from '../cv-icon/_cv-icon';
 import uidMixin from '../../mixins/uid-mixin';
-import Close16 from '@carbon/icons-vue/lib/close/16';
+import Close16 from '@carbon/icons-vue/es/close/16';
 import { componentsX } from '../../internal/feature-flags';
 
 export default {

--- a/packages/core/src/components/cv-number-input/cv-number-input.vue
+++ b/packages/core/src/components/cv-number-input/cv-number-input.vue
@@ -46,9 +46,9 @@
 import uidMixin from '../../mixins/uid-mixin';
 import themeMixin from '../../mixins/theme-mixin';
 import { componentsX } from '../../internal/feature-flags';
-import CaretDownGlyph from '@carbon/icons-vue/lib/caret--down/index';
-import CaretUpGlyph from '@carbon/icons-vue/lib/caret--up/index';
-import WarningFilled16 from '@carbon/icons-vue/lib/warning--filled/16';
+import CaretDownGlyph from '@carbon/icons-vue/es/caret--down/index';
+import CaretUpGlyph from '@carbon/icons-vue/es/caret--up/index';
+import WarningFilled16 from '@carbon/icons-vue/es/warning--filled/16';
 import CvWrapper from '../cv-wrapper/_cv-wrapper';
 
 export default {

--- a/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
+++ b/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
@@ -56,7 +56,7 @@
 
 <script>
 import { componentsX } from '../../internal/feature-flags';
-import OverflowMenuVertical16 from '@carbon/icons-vue/lib/overflow-menu--vertical/16';
+import OverflowMenuVertical16 from '@carbon/icons-vue/es/overflow-menu--vertical/16';
 import uidMixin from '../../mixins/uid-mixin';
 
 export default {

--- a/packages/core/src/components/cv-pagination/cv-pagination.vue
+++ b/packages/core/src/components/cv-pagination/cv-pagination.vue
@@ -96,8 +96,8 @@
 import CvSelect from '../cv-select/cv-select';
 import CvSelectOption from '../cv-select/cv-select-option';
 import { componentsX } from '../../internal/feature-flags';
-import CaretLeft16 from '@carbon/icons-vue/lib/caret--left/16';
-import CaretRight16 from '@carbon/icons-vue/lib/caret--right/16';
+import CaretLeft16 from '@carbon/icons-vue/es/caret--left/16';
+import CaretRight16 from '@carbon/icons-vue/es/caret--right/16';
 
 const newPageValue = (page, lastPage) => {
   let result = 1;

--- a/packages/core/src/components/cv-progress/cv-progress-step.vue
+++ b/packages/core/src/components/cv-progress/cv-progress-step.vue
@@ -32,8 +32,8 @@ import CvProgressStepIncomplete from './_cv-progress-step-incomplete';
 import { componentsX } from '../../internal/feature-flags';
 import CvTooltip from '../cv-tooltip/cv-tooltip';
 import CvWrapper from '../cv-wrapper/_cv-wrapper';
-import CheckmarkOutline16 from '@carbon/icons-vue/lib/checkmark--outline/16';
-import Warning16 from '@carbon/icons-vue/lib/warning/16';
+import CheckmarkOutline16 from '@carbon/icons-vue/es/checkmark--outline/16';
+import Warning16 from '@carbon/icons-vue/es/warning/16';
 
 const states = ['incomplete', 'current', 'complete'];
 

--- a/packages/core/src/components/cv-search/cv-search.vue
+++ b/packages/core/src/components/cv-search/cv-search.vue
@@ -70,8 +70,8 @@
 import uidMixin from '../../mixins/uid-mixin';
 import themeMixin from '../../mixins/theme-mixin';
 import { componentsX } from '../../internal/feature-flags';
-import Search16 from '@carbon/icons-vue/lib/search/16';
-import Close16 from '@carbon/icons-vue/lib/close/16';
+import Search16 from '@carbon/icons-vue/es/search/16';
+import Close16 from '@carbon/icons-vue/es/close/16';
 import CvWrapper from '../cv-wrapper/_cv-wrapper';
 
 export default {

--- a/packages/core/src/components/cv-select/cv-select.vue
+++ b/packages/core/src/components/cv-select/cv-select.vue
@@ -78,8 +78,8 @@ import uidMixin from '../../mixins/uid-mixin';
 import themeMixin from '../../mixins/theme-mixin';
 import { componentsX } from '../../internal/feature-flags';
 import CvWrapper from '../cv-wrapper/_cv-wrapper';
-import ChevronDownGlyph from '@carbon/icons-vue/lib/chevron--down/index';
-import WarningFilled16 from '@carbon/icons-vue/lib/warning--filled/16';
+import ChevronDownGlyph from '@carbon/icons-vue/es/chevron--down/index';
+import WarningFilled16 from '@carbon/icons-vue/es/warning--filled/16';
 
 export default {
   name: 'CvSelect',

--- a/packages/core/src/components/cv-structured-list/_cv-structured-list-item-selectable.vue
+++ b/packages/core/src/components/cv-structured-list/_cv-structured-list-item-selectable.vue
@@ -34,7 +34,7 @@
 import uidMixin from '../../mixins/uid-mixin';
 import radioMixin from '../../mixins/radio-mixin';
 import { componentsX } from '../../internal/feature-flags';
-import CheckmarkFilled16 from '@carbon/icons-vue/lib/checkmark--filled/16';
+import CheckmarkFilled16 from '@carbon/icons-vue/es/checkmark--filled/16';
 
 export default {
   name: 'CvStructuredListItemSelectable',

--- a/packages/core/src/components/cv-tag/cv-tag.vue
+++ b/packages/core/src/components/cv-tag/cv-tag.vue
@@ -15,7 +15,7 @@
 
 <script>
 import { componentsX } from '../../internal/feature-flags';
-import Close16 from '@carbon/icons-vue/lib/close/16';
+import Close16 from '@carbon/icons-vue/es/close/16';
 
 const components9Tags = [
   'ibm',

--- a/packages/core/src/components/cv-text-area/cv-text-area.vue
+++ b/packages/core/src/components/cv-text-area/cv-text-area.vue
@@ -44,7 +44,7 @@
 import uidMixin from '../../mixins/uid-mixin';
 import themeMixin from '../../mixins/theme-mixin';
 import { componentsX } from '../../internal/feature-flags';
-import WarningFilled16 from '@carbon/icons-vue/lib/warning--filled/16';
+import WarningFilled16 from '@carbon/icons-vue/es/warning--filled/16';
 
 export default {
   name: 'CvTextArea',

--- a/packages/core/src/components/cv-text-input/cv-text-input.vue
+++ b/packages/core/src/components/cv-text-input/cv-text-input.vue
@@ -70,7 +70,7 @@
 import uidMixin from '../../mixins/uid-mixin';
 import themeMixin from '../../mixins/theme-mixin';
 import { componentsX } from '../../internal/feature-flags';
-import WarningFilled16 from '@carbon/icons-vue/lib/warning--filled/16';
+import WarningFilled16 from '@carbon/icons-vue/es/warning--filled/16';
 
 export default {
   name: 'CvTextInput',

--- a/packages/core/src/components/cv-tile/_cv-tile-expandable.vue
+++ b/packages/core/src/components/cv-tile/_cv-tile-expandable.vue
@@ -33,7 +33,7 @@
 
 <script>
 import { componentsX } from '../../internal/feature-flags';
-import ChevronDown16 from '@carbon/icons-vue/lib/chevron--down/16';
+import ChevronDown16 from '@carbon/icons-vue/es/chevron--down/16';
 
 export default {
   name: 'CvTileExpandable',

--- a/packages/core/src/components/cv-tile/_cv-tile-selectable.vue
+++ b/packages/core/src/components/cv-tile/_cv-tile-selectable.vue
@@ -39,7 +39,7 @@
 import uidMixin from '../../mixins/uid-mixin';
 import checkMixin from '../../mixins/check-mixin';
 import { componentsX } from '../../internal/feature-flags';
-import CheckmarkFilled16 from '@carbon/icons-vue/lib/checkmark--filled/16';
+import CheckmarkFilled16 from '@carbon/icons-vue/es/checkmark--filled/16';
 
 export default {
   name: 'CvTileSelectable',

--- a/packages/core/src/components/cv-toast-notification/cv-toast-notification.vue
+++ b/packages/core/src/components/cv-toast-notification/cv-toast-notification.vue
@@ -36,10 +36,10 @@
 <script>
 import notificationMixin from '../../mixins/notification-mixin';
 import { componentsX } from '../../internal/feature-flags';
-import ErrorFilled16 from '@carbon/icons-vue/lib/error--filled/16';
-import CheckmarkFilled16 from '@carbon/icons-vue/lib/checkmark--filled/16';
-import WarningAltFilled16 from '@carbon/icons-vue/lib/warning--alt--filled/16';
-import Close16 from '@carbon/icons-vue/lib/close/16';
+import ErrorFilled16 from '@carbon/icons-vue/es/error--filled/16';
+import CheckmarkFilled16 from '@carbon/icons-vue/es/checkmark--filled/16';
+import WarningAltFilled16 from '@carbon/icons-vue/es/warning--alt--filled/16';
+import Close16 from '@carbon/icons-vue/es/close/16';
 
 export default {
   name: 'CvToastNotification',

--- a/packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
@@ -66,7 +66,7 @@
 <script>
 import uidMixin from '../../mixins/uid-mixin';
 import { componentsX } from '../../internal/feature-flags';
-import Information16 from '@carbon/icons-vue/lib/information/16';
+import Information16 from '@carbon/icons-vue/es/information/16';
 
 export default {
   name: 'CvInteractiveTooltip',

--- a/packages/core/src/components/cv-tooltip/cv-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-tooltip.vue
@@ -20,7 +20,7 @@
 
 <script>
 import { componentsX } from '../../internal/feature-flags';
-import Information16 from '@carbon/icons-vue/lib/information/16';
+import Information16 from '@carbon/icons-vue/es/information/16';
 
 export default {
   name: 'CvTooltip',

--- a/storybook/stories/cv-button-story.js
+++ b/storybook/stories/cv-button-story.js
@@ -15,7 +15,7 @@ const storiesExperimental = storiesOf('Experimental/CvButton', module);
 import { componentsX, versions, setVersion } from '@carbon/vue/src/internal/feature-flags';
 
 const exampleIconPath = require('@carbon/vue/src/assets/images/example-icons.svg');
-import AddFilled16 from '@carbon/icons-vue/lib/add--filled/16';
+import AddFilled16 from '@carbon/icons-vue/es/add--filled/16';
 
 let preKnobs = {
   small: {

--- a/storybook/stories/cv-content-switcher-story.js
+++ b/storybook/stories/cv-content-switcher-story.js
@@ -16,7 +16,7 @@ const storiesExperimental = storiesOf('Experimental/CvContentSwitcher', module);
 import { versions, setVersion } from '@carbon/vue/src/internal/feature-flags';
 
 const exampleIconPath = require('@carbon/vue/src/assets/images/example-icons.svg');
-import AddFilled16 from '@carbon/icons-vue/lib/add--filled/16';
+import AddFilled16 from '@carbon/icons-vue/es/add--filled/16';
 
 const preKnobs = {
   initialSelected: {

--- a/storybook/stories/cv-data-table-story.js
+++ b/storybook/stories/cv-data-table-story.js
@@ -14,9 +14,9 @@ import CvDataTableCell from '@carbon/vue/src/components/cv-data-table/cv-data-ta
 import CvButton from '@carbon/vue/src/components/cv-button/cv-button';
 import CvOverflowMenu from '@carbon/vue/src/components/cv-overflow-menu/cv-overflow-menu';
 import CvOverflowMenuItem from '@carbon/vue/src/components/cv-overflow-menu/cv-overflow-menu-item';
-import TrashCan16 from '@carbon/icons-vue/lib/trash-can/16';
-import Save16 from '@carbon/icons-vue/lib/save/16';
-import Download16 from '@carbon/icons-vue/lib/download/16';
+import TrashCan16 from '@carbon/icons-vue/es/trash-can/16';
+import Save16 from '@carbon/icons-vue/es/save/16';
+import Download16 from '@carbon/icons-vue/es/download/16';
 import CvTag from '@carbon/vue/src/components/cv-tag/cv-tag';
 
 const storiesDefault = storiesOf('Components/CvDataTable', module);

--- a/storybook/stories/cv-toolbar-story.js
+++ b/storybook/stories/cv-toolbar-story.js
@@ -19,7 +19,7 @@ import CvButton from '@carbon/vue/src/components/cv-button/cv-button';
 const storiesDefault = storiesOf('Components/CvToolbar', module);
 const storiesExperimental = storiesOf('Experimental/CvToolbar', module);
 import { componentsX, versions, setVersion } from '@carbon/vue/src/internal/feature-flags';
-import Filter16 from '@carbon/icons-vue/lib/filter/16';
+import Filter16 from '@carbon/icons-vue/es/filter/16';
 
 const preKnobs = {};
 

--- a/storybook/stories/cv-tooltip-story.js
+++ b/storybook/stories/cv-tooltip-story.js
@@ -13,7 +13,7 @@ import CvDefinitionTooltip from '@carbon/vue/src/components/cv-tooltip/cv-defini
 const storiesDefault = storiesOf('Components/CvTooltip', module);
 const storiesExperimental = storiesOf('Experimental/CvTooltip', module);
 import { componentsX, versions, setVersion } from '@carbon/vue/src/internal/feature-flags';
-import Filter16 from '@carbon/icons-vue/lib/filter/16';
+import Filter16 from '@carbon/icons-vue/es/filter/16';
 
 let preKnobs = {
   direction: {


### PR DESCRIPTION
Addresses #402 

Changes all icon imports from using @carbon/icons-vue/lib/... to @carbon/icons-vue/es/...

as this prevents babel transpile.

It a test app which made use of cv-tile the following was also done to get IE and Edge working

## Change package.json to
  "browserslist": [
    "> 1%",
    "last 2 versions",
    "ie >= 11"
  ]

## add a vue.config.js
module.exports = {
  transpileDependencies: ["@carbon/vue", "@carbon/icons-vue", "@carbon/icon-helpers"]
};
