### PR TITLE
feat: add side nav

### DIFF
--- a/packages/core/src/components/cv-ui-shell/_cv-side-nav-footer.vue
+++ b/packages/core/src/components/cv-ui-shell/_cv-side-nav-footer.vue
@@ -1,0 +1,28 @@
+<template>
+  <footer class="cv-side-nav-footer bx--side-nav__footer">
+    <button class="bx--side-nav__toggle" type="button" v-bind="$attrs" v-on="$listeners" :title="assistiveText">
+      <div class="bx--side-nav__icon">
+        <Close20 v-if="expanded" class="bx--side-nav__icon--collapse bx--side-nave-collapse-icon" />
+        <ChevronRight20 v-if="!expanded" class="bx--side-nav__icon--expand bx--side-nave-expand-icon" />
+      </div>
+      <span class="bx--assistive-text">{{ assistiveText }}</span>
+    </button>
+  </footer>
+</template>
+
+<script>
+import Close20 from '@carbon/icons-vue/es/close/20';
+import ChevronRight20 from '@carbon/icons-vue/es/chevron--right/20';
+
+export default {
+  name: 'CvSideNavFooter',
+  inheritAttrs: false,
+  components: { ChevronRight20, Close20 },
+  props: {
+    assistiveText: { type: String, default: 'Open / close side nav' },
+    expanded: Boolean,
+  },
+};
+</script>
+
+<style lang="scss"></style>

--- a/packages/core/src/components/cv-ui-shell/_cv-side-nav-link-text.vue
+++ b/packages/core/src/components/cv-ui-shell/_cv-side-nav-link-text.vue
@@ -1,0 +1,13 @@
+<template>
+  <span class="bx--side-nav__link-text">
+    <slot />
+  </span>
+</template>
+
+<script>
+export default {
+  name: 'CvSideNavLinkText',
+};
+</script>
+
+<style lang="scss"></style>

--- a/packages/core/src/components/cv-ui-shell/cv-header-menu-button.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-header-menu-button.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     v-on="$listeners"
-    class="cv-button-menu bx--header__action"
+    class="cv-header-menu-button bx--header__action bx--header__menu-trigger bx--header__menu-toggle"
     :class="dataActive ? 'bx--header__action--active' : ''"
     type="button"
     aria-haspopup="true"
@@ -10,16 +10,20 @@
     @click="gaToggle"
     @focusout="gaFocusout"
   >
-    <slot />
+    <Close20 v-if="active" />
+    <Menu20 v-if="!active" />
   </button>
 </template>
 
 <script>
 import uidMixin from '../../mixins/uid-mixin';
+import Close20 from '@carbon/icons-vue/es/close/20';
+import Menu20 from '@carbon/icons-vue/es/menu/20';
 
 export default {
-  name: 'CvButtonMenu',
+  name: 'CvHeaderMenuButton',
   mixins: [uidMixin],
+  components: { Close20, Menu20 },
   props: {
     active: Boolean,
     ariaControls: { type: String, required: true },
@@ -34,6 +38,9 @@ export default {
     return {
       dataActive: this.active,
     };
+  },
+  mounted() {
+    // watch width transition and
   },
   watch: {
     expanded() {

--- a/packages/core/src/components/cv-ui-shell/cv-header-menu.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-header-menu.vue
@@ -1,7 +1,7 @@
 <template>
   <li class="cv-header-menu bx--header__submenu">
     <a
-      aria-haspopup="menu"
+      aria-haspopup="true"
       :aria-expanded="expanded ? 'true' : 'false'"
       class="bx--header__menu-item bx--header__menu-title"
       href="javascript:void(0)"

--- a/packages/core/src/components/cv-ui-shell/cv-header.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-header.vue
@@ -4,6 +4,7 @@
     <div v-if="$slots['header-global']" class="bx--header__global">
       <slot name="header-global" />
     </div>
+    <slot name="left-panels" />
     <slot name="right-panels" />
   </header>
 </template>
@@ -31,6 +32,11 @@ export default {
       panelControllers: [],
       panels: [],
     };
+  },
+  computed: {
+    isCvHeader() {
+      return true;
+    },
   },
   methods: {
     onCvPanelControlMounted(srcComponent) {

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav-icon.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav-icon.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="bx--side-nav__icon" :class="{ 'bx--side-nav__icon--small': small }">
+    <slot />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'CvSideNavIcon',
+  props: {
+    small: Boolean,
+  },
+};
+</script>
+
+<style lang="scss"></style>

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav-items.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav-items.vue
@@ -1,0 +1,13 @@
+<template>
+  <ul class="cv-side-nav-items bx--side-nav__items">
+    <slot />
+  </ul>
+</template>
+
+<script>
+export default {
+  name: 'CvSideNavItems',
+};
+</script>
+
+<style lang="scss"></style>

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
@@ -1,0 +1,37 @@
+<template>
+  <li class="bx--side-nav__item">
+    <component
+      :is="tagType"
+      class="cv-side-nav-item-link bx--side-nav__link"
+      v-on="$listeners"
+      v-bind="$attrs"
+      :class="{ 'bx--side-nav__link--current': active }"
+    >
+      <cv-side-nav-icon v-if="$slots['nav-icon'] !== undefined" small>
+        <slot name="nav-icon" />
+      </cv-side-nav-icon>
+      <cv-side-nav-link-text>
+        <slot />
+      </cv-side-nav-link-text>
+    </component>
+  </li>
+</template>
+
+<script>
+import linkMixin from '../../mixins/link-mixin';
+import CvSideNavIcon from './cv-side-nav-icon';
+import CvSideNavLinkText from './_cv-side-nav-link-text';
+
+export default {
+  name: 'CvSideNavLink',
+  inheritAttrs: false,
+  mixins: [linkMixin],
+  components: { CvSideNavIcon, CvSideNavLinkText },
+  props: {
+    active: Boolean,
+    icon: Object,
+  },
+};
+</script>
+
+<style lang="scss"></style>

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav-menu-item.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav-menu-item.vue
@@ -1,0 +1,33 @@
+<template>
+  <li class="bx--side-nav__menu-item">
+    <component
+      :is="tagType"
+      class="bx--side-nav__link"
+      v-on="$listeners"
+      v-bind="$attrs"
+      :class="{ 'bx--side-nav__link--current': active }"
+      role="menuitem"
+    >
+      <cv-side-nav-link-text>
+        <slot />
+      </cv-side-nav-link-text>
+    </component>
+  </li>
+</template>
+
+<script>
+import linkMixin from '../../mixins/link-mixin';
+import CvSideNavLinkText from './_cv-side-nav-link-text';
+
+export default {
+  name: 'CvSideNavMenuItem',
+  inheritAttrs: false,
+  mixins: [linkMixin],
+  components: { CvSideNavLinkText },
+  props: {
+    active: Boolean,
+  },
+};
+</script>
+
+<style lang="scss"></style>

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav-menu.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav-menu.vue
@@ -1,0 +1,73 @@
+<template>
+  <li
+    class="cv-side-nav-menu bx--side-nav__item"
+    :class="{ 'bx--side-nav__item--active': active, 'bx--side-nav__item--icon': hasIcon }"
+  >
+    <button
+      aria-haspopup="true"
+      :aria-expanded="expanded ? 'true' : 'false'"
+      class="bx--side-nav__submenu"
+      role="menuitem"
+      type="button"
+      @click="doToggle"
+      @keydown.space.prevent
+      @keyup.space.prevent="doToggle"
+      @keydown.enter.prevent="doToggle"
+      @focusout="onFocusout"
+    >
+      <cv-side-nav-icon v-if="hasIcon">
+        <slot name="nav-icon" />
+      </cv-side-nav-icon>
+      <span class="bx--side-nav__submenu-title">{{ title }}</span>
+      <cv-side-nav-icon
+        class="bx--side-nav__submenu-chevron"
+        small
+        :aria-label="expanded ? 'collapse nav menu' : 'expand nav menu'"
+      >
+        <ChevronDown20 />
+      </cv-side-nav-icon>
+    </button>
+    <ul class="bx--side-nav__menu" role="menu" @focusout="onFocusout">
+      <slot></slot>
+    </ul>
+  </li>
+</template>
+
+<script>
+import ChevronDown20 from '@carbon/icons-vue/es/chevron--down/20';
+import CvSideNavIcon from './cv-side-nav-icon';
+
+export default {
+  name: 'CvSideNavMenu',
+  components: { CvSideNavIcon, ChevronDown20 },
+  props: {
+    active: Boolean,
+    title: { type: String, required: true },
+  },
+  data() {
+    return {
+      expanded: false,
+    };
+  },
+  mounted() {
+    console.dir(this.$slots);
+  },
+  computed: {
+    hasIcon() {
+      return this.$slots['nav-icon'] !== undefined;
+    },
+  },
+  methods: {
+    doToggle() {
+      this.expanded = !this.expanded;
+    },
+    onFocusout(ev) {
+      if (!(this.$el.contains(ev.relatedTarget) || this.$refs.menu.contains(ev.relatedTarget))) {
+        this.expanded = false;
+      }
+    },
+  },
+};
+</script>
+
+<style lang="scss"></style>

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav.vue
@@ -1,21 +1,31 @@
 <template>
-  <div
-    class="cv-header-panel bx--header-panel"
-    :class="{ 'bx--header-panel--expanded': internalExpanded }"
-    :aria-hidden="!internalExpanded"
+  <nav
+    class="cv-side-nav bx--side-nav bx--side-nav__navigation"
+    :class="{
+      'bx--side-nav--expanded': internalExpanded,
+      'bx--side-nav--collapsed': !internalExpanded && fixed,
+      'bx--side-nav--ux': isChildOfHeader,
+    }"
+    :aria-hidden="!internalExpanded && !fixed"
     @focusout="onFocusout"
     @mousedown="onMouseDown"
   >
     <slot></slot>
-  </div>
+    <cv-side-nav-footer v-if="!fixed" :expanded="internalExpanded" :assistiveText="assistiveToggleText" />
+  </nav>
 </template>
 
 <script>
+import CvSideNavFooter from './_cv-side-nav-footer';
+
 export default {
-  name: 'CvHeaderPanel',
+  name: 'CvSideNav',
+  components: { CvSideNavFooter },
   props: {
     expanded: Boolean,
+    fixed: Boolean,
     id: { type: String, required: true },
+    assistiveToggleText: String,
   },
   mounted() {
     this.$parent.$emit('cv:panel-mounted', this);
@@ -35,6 +45,9 @@ export default {
     },
   },
   computed: {
+    isChildOfHeader() {
+      return this.$parent.isCvHeader;
+    },
     internalExpanded: {
       get() {
         return this.dataExpanded;

--- a/packages/core/src/components/cv-ui-shell/cv-switcher-item-link.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-switcher-item-link.vue
@@ -1,12 +1,22 @@
 <template>
-  <a class="cv-switcher-item-link bx--switcher__item-link" :class="{ 'bx--switcher__item-link--selected': selected }">
+  <component
+    :is="tagType"
+    class="cv-switcher-item-link bx--switcher__item-link"
+    v-on="$listeners"
+    v-bind="$attrs"
+    :class="{ 'bx--switcher__item-link--selected': selected }"
+  >
     <slot />
-  </a>
+  </component>
 </template>
 
 <script>
+import linkMixin from '../../mixins/link-mixin';
+
 export default {
   name: 'CvSwitcherItemLink',
+  inheritAttrs: false,
+  mixins: [linkMixin],
   props: {
     selected: Boolean,
   },

--- a/storybook/_storybook/views/sv-template-view/sv-template-view.vue
+++ b/storybook/_storybook/views/sv-template-view/sv-template-view.vue
@@ -22,11 +22,11 @@
       />
       <slot name="component"></slot>
     </section>
-    <section class="sv-template-view__other">
+    <section class="sv-template-view__other" :style="otherStyle">
       <h2 class="sv-template-view__label">Sample interaction</h2>
       <slot name="other"></slot>
     </section>
-    <section class="sv-template-view__code">
+    <section class="sv-template-view__code" :style="otherStyle">
       <h2 class="sv-template-view__label">Sample code</h2>
       <pre v-highlightjs="svSource">
         <code class="html"></code>
@@ -62,6 +62,7 @@ export default {
     svSource: String,
     svAltBack: { type: Boolean, default: true },
     svPosition: String, // flex position
+    svExtraMargin: { type: String, default: '20px' },
     svPadding: String,
     underConstruction: { type: [Boolean, String], default: false },
   },
@@ -71,10 +72,16 @@ export default {
     };
   },
   computed: {
+    otherStyle() {
+      return {
+        marginLeft: this.svExtraMargin,
+      };
+    },
     style() {
       return {
         padding: this.svPadding,
         alignItems: this.svPosition && this.svPosition.length ? this.svPosition : 'flex-start',
+        marginLeft: this.svExtraMargin,
       };
     },
   },

--- a/storybook/stories/cv-ui-shell-story.js
+++ b/storybook/stories/cv-ui-shell-story.js
@@ -15,10 +15,17 @@ import CvHeaderName from '@carbon/vue/src/components/cv-ui-shell/cv-header-name'
 import CvHeaderMenu from '@carbon/vue/src/components/cv-ui-shell/cv-header-menu';
 import CvHeaderMenuItem from '@carbon/vue/src/components/cv-ui-shell/cv-header-menu-item';
 import CvHeaderGlobalAction from '@carbon/vue/src/components/cv-ui-shell/cv-header-global-action';
+import CvHeaderMenuButton from '@carbon/vue/src/components/cv-ui-shell/cv-header-menu-button';
+import CvSideNav from '@carbon/vue/src/components/cv-ui-shell/cv-side-nav';
+import CvSideNavLink from '@carbon/vue/src/components/cv-ui-shell/cv-side-nav-link';
+import CvSideNavMenu from '@carbon/vue/src/components/cv-ui-shell/cv-side-nav-menu';
+import CvSideNavItems from '@carbon/vue/src/components/cv-ui-shell/cv-side-nav-items';
+import CvSideNavMenuItem from '@carbon/vue/src/components/cv-ui-shell/cv-side-nav-menu-item';
 import CvSkipToContent from '@carbon/vue/src/components/cv-ui-shell/cv-skip-to-content';
 import CvSwitcher from '@carbon/vue/src/components/cv-ui-shell/cv-switcher';
 import CvSwitcherItem from '@carbon/vue/src/components/cv-ui-shell/cv-switcher-item';
 import CvSwitcherItemLink from '@carbon/vue/src/components/cv-ui-shell/cv-switcher-item-link';
+import Fade16 from '@carbon/icons-vue/es/fade/16';
 import Notification20 from '@carbon/icons-vue/es/notification/20';
 import UserAvatar20 from '@carbon/icons-vue/es/user--avatar/20';
 import AppSwitcher20 from '@carbon/icons-vue/es/app-switcher/20';
@@ -142,6 +149,158 @@ const preKnobs = {
       </cv-switcher>
     </cv-header-panel>`,
   },
+  headerMenuButton: {
+    group: 'headerMenuButton',
+    value: `<cv-header-menu-button aria-label="Header menu" aria-controls="side-nav" />`,
+  },
+  sideNavFixed: {
+    group: 'leftPanels2',
+    value: `<cv-side-nav id="side-nav" fixed expanded>
+      <cv-side-nav-items>
+        <cv-side-nav-menu title="L1 menu">
+          <cv-side-nav-menu-item href="javascript:void(0)" active>
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+        </cv-side-nav-menu>
+        <cv-side-nav-menu title="L1 menu">
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)" aria-current="page">
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+        </cv-side-nav-menu>
+        <cv-side-nav-link href="javascript:void(0)">
+          L1 link
+        </cv-side-nav-link>
+        <cv-side-nav-link href="javascript:void(0)">
+          L1 link
+        </cv-side-nav-link>
+      </cv-side-nav-items>
+    </cv-side-nav>`,
+  },
+  sideNavFixedWithIcons: {
+    group: 'leftPanels2',
+    value: `<cv-side-nav id="side-nav" fixed expanded>
+      <cv-side-nav-items>
+        <cv-side-nav-menu title="L1 menu">
+          <template slot="nav-icon"><Fade16 /></template>
+          <cv-side-nav-menu-item href="javascript:void(0)" active>
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+        </cv-side-nav-menu>
+        <cv-side-nav-menu title="L1 menu">
+          <template slot="nav-icon"><Fade16 /></template>
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)" aria-current="page">
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+        </cv-side-nav-menu>
+        <cv-side-nav-link href="javascript:void(0)">
+          <template slot="nav-icon"><Fade16 /></template>
+          L1 link
+        </cv-side-nav-link>
+        <cv-side-nav-link href="javascript:void(0)">
+          <template slot="nav-icon"><Fade16 /></template>
+          L1 link
+        </cv-side-nav-link>
+      </cv-side-nav-items>
+    </cv-side-nav>`,
+  },
+  sideNav: {
+    group: 'leftPanels',
+    value: `<cv-side-nav id="side-nav">
+      <cv-side-nav-items>
+        <cv-side-nav-menu title="L1 menu">
+          <cv-side-nav-menu-item href="javascript:void(0)" active>
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+        </cv-side-nav-menu>
+        <cv-side-nav-menu title="L1 menu">
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)" aria-current="page">
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+        </cv-side-nav-menu>
+        <cv-side-nav-link href="javascript:void(0)">
+          L1 link
+        </cv-side-nav-link>
+        <cv-side-nav-link href="javascript:void(0)">
+          L1 link
+        </cv-side-nav-link>
+      </cv-side-nav-items>
+    </cv-side-nav>`,
+  },
+  sideNavWithIcons: {
+    group: 'leftPanels',
+    value: `<cv-side-nav id="side-nav">
+      <cv-side-nav-items>
+        <cv-side-nav-menu title="L1 menu">
+          <template slot="nav-icon"><Fade16 /></template>
+          <cv-side-nav-menu-item href="javascript:void(0)" active>
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+        </cv-side-nav-menu>
+        <cv-side-nav-menu title="L1 menu">
+          <template slot="nav-icon"><Fade16 /></template>
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)" aria-current="page">
+            L2 menu item
+          </cv-side-nav-menu-item>
+          <cv-side-nav-menu-item href="javascript:void(0)">
+            L2 menu item
+          </cv-side-nav-menu-item>
+        </cv-side-nav-menu>
+        <cv-side-nav-link href="javascript:void(0)">
+          <template slot="nav-icon"><Fade16 /></template>
+          L1 link
+        </cv-side-nav-link>
+        <cv-side-nav-link href="javascript:void(0)">
+          <template slot="nav-icon"><Fade16 /></template>
+          L1 link
+        </cv-side-nav-link>
+      </cv-side-nav-items>
+    </cv-side-nav>`,
+  },
 };
 
 const variants = [
@@ -156,6 +315,22 @@ const variants = [
     name: 'Header Base with Actions and right panels',
     includes: ['headerName', 'headerActions', 'notificationsPanel', 'switcherPanel'],
   },
+  {
+    name: 'Fixed Side Nav',
+    includes: ['headerName', 'sideNavFixed'],
+  },
+  {
+    name: 'Fixed Side Nav and icons',
+    includes: ['headerName', 'sideNavFixedWithIcons'],
+  },
+  {
+    name: 'Header Base with Side Nav',
+    includes: ['headerName', 'headerMenuButton', 'sideNav'],
+  },
+  {
+    name: 'Header Base with Side Nav and icons',
+    includes: ['headerName', 'headerMenuButton', 'sideNavWithIcons'],
+  },
 ];
 
 const storySet = knobsHelper.getStorySet(variants, preKnobs);
@@ -167,11 +342,15 @@ for (const story of storySet) {
       const settings = story.knobs();
 
       // ----------------------------------------------------------------
-      const templateString = `<cv-header aria-label="Carbon header">${settings.group.headerName}${settings.group.headerNav}${settings.group.headerActions}
-  <template slot="right-panels" v-if="areRightPanels">
+      const templateString = `<cv-header aria-label="Carbon header">${settings.group.headerMenuButton}${settings.group.headerName}${settings.group.headerNav}${settings.group.headerActions}
+    <template slot="left-panels" v-if="areLeftPanels">
+      ${settings.group.leftPanels}
+    </template>
+    <template slot="right-panels" v-if="areRightPanels">
     ${settings.group.rightPanels}
   </template>
 </cv-header>
+${settings.group.leftPanels2}
           `;
 
       // ----------------------------------------------------------------
@@ -183,6 +362,7 @@ for (const story of storySet) {
       sv-source='${templateString.trim()}'
       sv-position="center"
       sv-padding="150px 0 50px 0"
+      :sv-extra-margin="areLeftPanels ? '300px' : ''"
       >
       <template slot="component">${templateString}</template>
     </sv-template-view>
@@ -198,6 +378,12 @@ for (const story of storySet) {
           CvHeaderGlobalAction,
           CvHeaderMenu,
           CvHeaderMenuItem,
+          CvHeaderMenuButton,
+          CvSideNav,
+          CvSideNavLink,
+          CvSideNavMenu,
+          CvSideNavItems,
+          CvSideNavMenuItem,
           CvSkipToContent,
           CvSwitcher,
           CvSwitcherItem,
@@ -205,6 +391,7 @@ for (const story of storySet) {
           Notification20,
           UserAvatar20,
           AppSwitcher20,
+          Fade16,
         },
         template: templateViewString,
         props: settings.props,
@@ -213,6 +400,9 @@ for (const story of storySet) {
           this.doActionSwitcher = () => action('Notifications - click');
         },
         computed: {
+          areLeftPanels() {
+            return settings.group.leftPanels.length > 0 || settings.group.leftPanels2.length > 0;
+          },
           areRightPanels() {
             return settings.group.rightPanels.length > 0;
           },


### PR DESCRIPTION
Part of #353 

A first pass at the left panel leaving the UI Shell in a similar position to Carbon React 10.3.0

A       packages/core/src/components/cv-ui-shell/_cv-side-nav-footer.vue
A       packages/core/src/components/cv-ui-shell/_cv-side-nav-link-text.vue
R076    packages/core/src/components/cv-ui-shell/cv-button-menu.vue     packages/core/src/components/cv-ui-shell/cv-header-menu-button.vue
M       packages/core/src/components/cv-ui-shell/cv-header-menu.vue
M       packages/core/src/components/cv-ui-shell/cv-header-panel.vue
M       packages/core/src/components/cv-ui-shell/cv-header.vue
A       packages/core/src/components/cv-ui-shell/cv-side-nav-icon.vue
A       packages/core/src/components/cv-ui-shell/cv-side-nav-items.vue
A       packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
A       packages/core/src/components/cv-ui-shell/cv-side-nav-menu-item.vue
A       packages/core/src/components/cv-ui-shell/cv-side-nav-menu.vue
A       packages/core/src/components/cv-ui-shell/cv-side-nav.vue
M       packages/core/src/components/cv-ui-shell/cv-switcher-item-link.vue
M       storybook/_storybook/views/sv-template-view/sv-template-view.vue
R052    storybook/stories/cv-header-story.js    storybook/stories/cv-ui-shell-story.js
