### PR TITLE
fix: focus not showing on panel links

### DIFF
--- a/packages/core/src/components/cv-ui-shell/cv-header-panel.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-header-panel.vue
@@ -50,7 +50,8 @@ export default {
       this.$parent.$emit('cv:panel-focusout', this, ev);
     },
     onMouseDown(ev) {
-      if (this.$el.contains(ev.target)) {
+      if (this.$el === ev.target) {
+        // ignore mousedown on panel can cause focus event
         ev.preventDefault();
       }
     },

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav-menu.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav-menu.vue
@@ -27,7 +27,7 @@
         <ChevronDown20 />
       </cv-side-nav-icon>
     </button>
-    <ul class="bx--side-nav__menu" role="menu" @focusout="onFocusout">
+    <ul class="bx--side-nav__menu" role="menu" ref="menu" @focusout="onFocusout">
       <slot></slot>
     </ul>
   </li>
@@ -48,9 +48,6 @@ export default {
     return {
       expanded: false,
     };
-  },
-  mounted() {
-    console.dir(this.$slots);
   },
   computed: {
     hasIcon() {

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav.vue
@@ -68,7 +68,8 @@ export default {
       this.$parent.$emit('cv:panel-focusout', this, ev);
     },
     onMouseDown(ev) {
-      if (this.$el.contains(ev.target)) {
+      if (this.$el === ev.target) {
+        // ignore mousedown on panel can cause focus event
         ev.preventDefault();
       }
     },


### PR DESCRIPTION
Fixes side panel and header panel issue where focus was not getting to interactive content on the panel.

Changed:
M       packages/core/src/components/cv-ui-shell/cv-header-panel.vue
M       packages/core/src/components/cv-ui-shell/cv-side-nav-menu.vue
M       packages/core/src/components/cv-ui-shell/cv-side-nav.vue