### PR TITLE
fix(header-name): add space after prefix

### DIFF
--- a/packages/core/src/components/cv-ui-shell/cv-header-name.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-header-name.vue
@@ -1,6 +1,6 @@
 <template>
   <cv-link-inner v-on="$listeners" class="cv-header-name bx--header__name">
-    <span v-if="prefix" class="bx--header__name--prefix">{{ prefix }}</span>
+    <span v-if="prefix" class="bx--header__name--prefix">{{ prefix }}&nbsp;</span>
     <slot />
   </cv-link-inner>
 </template>


### PR DESCRIPTION
Add non-breaking space after prefix similar to the React components project.

#### Changelog

**New**

- Non-breaking space after prefix in Header Name component.