### PR TITLE
fix: side nave focus

### DIFF
--- a/packages/core/src/components/cv-ui-shell/cv-side-nav-items.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav-items.vue
@@ -10,4 +10,12 @@ export default {
 };
 </script>
 
-<style lang="scss"></style>
+<style lang="scss">
+.cv-side-nav-items {
+  pointer-events: none;
+
+  * {
+    pointer-events: initial;
+  }
+}
+</style>


### PR DESCRIPTION
Corrects side nav focus

1. Open http://vue.carbondesignsystem.com/?path=/story/experimental-cvuishell-header--header-base-with-side-nav
2. If hamburger not shown reduce width until visible.
3. Click on hamburger to show side nav
4. Click on background of side nav, hamburger will lose focus.
5. Move mouse out of side nav, it should not close.

Changelog
M       packages/core/src/components/cv-ui-shell/cv-side-nav-items.vue