### PR TITLE
fix: combobox behaviour

### DIFF
--- a/packages/core/src/components/cv-combo-box/cv-combo-box.vue
+++ b/packages/core/src/components/cv-combo-box/cv-combo-box.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="cv-combo-box bx--list-box__wrapper" @focusout="onFocusOut">
-    <label v-if="title" :for="uid" class="bx--label" :class="{ 'bx--label--disabled': $attrs.disabled }">{{
-      title
-    }}</label>
+    <label v-if="title" :for="uid" class="bx--label" :class="{ 'bx--label--disabled': $attrs.disabled }">
+      {{ title }}
+    </label>
 
     <div v-if="isHelper" class="bx--form__helper-text" :class="{ 'bx--form__helper-text--disabled': $attrs.disabled }">
       <slot name="helper-text">{{ helperText }}</slot>
@@ -22,7 +22,6 @@
       @keydown.down.prevent="onDown"
       @keydown.up.prevent="onUp"
       @keydown.enter.prevent="onEnter"
-      @keydown.space.prevent="onSpace"
       @keydown.esc.prevent="onEsc"
       @click="onClick"
     >
@@ -189,7 +188,10 @@ export default {
           this.dataHighlighted = val;
         }
         if (firstMatchIndex >= 0) {
-          this.checkHighlightPosition(firstMatchIndex);
+          this.$nextTick(() => {
+            // $nextTick to prevent highlight check ahead of list update on filter
+            this.checkHighlightPosition(firstMatchIndex);
+          });
         }
       },
     },
@@ -250,7 +252,8 @@ export default {
     },
     updateOptions() {
       if (this.autoFilter) {
-        const pat = new RegExp(this.filter, 'iu');
+        const escFilter = this.filter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const pat = new RegExp(escFilter, 'iu');
         this.dataOptions = this.options.filter(opt => pat.test(opt.label)).slice(0);
       } else {
         this.dataOptions = this.options.slice(0);
@@ -275,7 +278,6 @@ export default {
     onInput(ev) {
       this.doOpen(true);
 
-      // this.$emit('filter', this.filter);
       this.updateOptions();
       this.updateHighlight();
     },
@@ -297,9 +299,6 @@ export default {
     onEsc() {
       this.doOpen(false);
       this.$el.focus();
-    },
-    onSpace() {
-      this.onItemClick(this.highlighted);
     },
     onEnter() {
       this.doOpen(!this.open);

--- a/packages/core/src/components/cv-multi-select/cv-multi-select.vue
+++ b/packages/core/src/components/cv-multi-select/cv-multi-select.vue
@@ -8,9 +8,9 @@
     }"
     @focusout="onFocusOut"
   >
-    <label v-if="title" :for="uid" class="bx--label" :class="{ 'bx--label--disabled': $attrs.disabled }">
-      {{ title }}
-    </label>
+    <label v-if="title" :for="uid" class="bx--label" :class="{ 'bx--label--disabled': $attrs.disabled }">{{
+      title
+    }}</label>
 
     <div
       v-if="!inline && isHelper"
@@ -37,8 +37,7 @@
       v-bind="$attrs"
       @keydown.down.prevent="onDown"
       @keydown.up.prevent="onUp"
-      @keydown.enter.prevent="onClick"
-      @keydown.space.prevent="onSpace"
+      @keydown.enter.prevent="onEnter"
       @keydown.esc.prevent="onEsc"
       @click="onClick"
     >
@@ -249,7 +248,10 @@ export default {
           this.dataHighlighted = val;
         }
         if (firstMatchIndex >= 0) {
-          this.checkHighlightPosition(firstMatchIndex);
+          this.$nextTick(() => {
+            // $nextTick to prevent highlight check ahead of list update on filter
+            this.checkHighlightPosition(firstMatchIndex);
+          });
         }
       },
     },
@@ -310,7 +312,8 @@ export default {
     },
     updateOptions() {
       if (this.autoFilter) {
-        const pat = new RegExp(this.filter, 'iu');
+        const escFilter = this.filter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const pat = new RegExp(escFilter, 'iu');
         this.dataOptions = this.options.filter(opt => pat.test(opt.label)).slice(0);
       } else {
         this.dataOptions = this.options.slice(0);
@@ -343,7 +346,6 @@ export default {
     onInput(ev) {
       this.doOpen(true);
 
-      // this.$emit('filter', this.filter);
       this.updateOptions();
       this.updateHighlight();
     },
@@ -376,8 +378,17 @@ export default {
       this.doOpen(false);
       this.inputOrButtonFocus();
     },
-    onSpace() {
-      this.onItemClick(this.highlighted);
+    onEnter() {
+      if (this.open) {
+        this.onItemClick(this.highlighted);
+        this.$refs.input.focus();
+        this.filter = '';
+
+        this.doOpen(false);
+        this.updateOptions();
+      } else {
+        this.doOpen(true);
+      }
     },
     onClick(ev) {
       this.doOpen(!this.open);

--- a/storybook/stories/cv-multi-select-story.js
+++ b/storybook/stories/cv-multi-select-story.js
@@ -198,7 +198,7 @@ let preKnobs = {
   initialValue: {
     group: 'attr',
     type: array,
-    config: ['initial-value', ['20s', '40s'], ','],
+    config: ['initial-value', ['banana', 'ugli_fruit'], ','],
     prop: {
       type: Array,
       name: 'value',


### PR DESCRIPTION
Closes #501

The following is true for combobox and multi-select
- Removes space auto-completion to allow spaces in filter.
- Enter now used for auto-completion
- Escapes regex special characters

#### Changelog
M       packages/core/src/components/cv-combo-box/cv-combo-box.vue
M       packages/core/src/components/cv-multi-select/cv-multi-select.vue
M       storybook/stories/cv-multi-select-story.js
