### PR TITLE
fix: update link-mixin usage in all components

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.12.5 (August 5, 2019)
+
+### Fix
+
+- Change how cv-link and other
+
 ## 2.12.4 (August 3, 2019)
 
 ### Fix

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## 2.12.5 (August 5, 2019)
+## 2.12.5-rc.0 (August 5, 2019)
 
 ### Fix
 
-- Change how cv-link and other
+- Change how cv-link and other link-mixin usage
 
 ## 2.12.4 (August 3, 2019)
 

--- a/packages/core/src/components/cv-tile/_cv-tile-clickable.vue
+++ b/packages/core/src/components/cv-tile/_cv-tile-clickable.vue
@@ -2,8 +2,7 @@
   <component
     :is="tagType"
     v-on="$listeners"
-    :to="to"
-    :href="href"
+    v-bind="linkProps"
     data-tile="clickable"
     class="cv-tile-clickable bx--tile--clickable"
     tabindex="0"

--- a/packages/core/src/components/cv-ui-shell/cv-header-menu-item.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-header-menu-item.vue
@@ -3,9 +3,7 @@
     <component
       :is="tagType"
       v-on="$listeners"
-      :to="to"
-      :href="href"
-      v-bind="$attrs"
+      v-bind="{ ...$attrs, ...linkProps }"
       class="bx--header__menu-item"
       role="menuitem"
     >

--- a/packages/core/src/components/cv-ui-shell/cv-header-name.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-header-name.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="tagType" v-on="$listeners" :to="to" :href="href" class="cv-header-name bx--header__name">
+  <component :is="tagType" v-on="$listeners" v-bind="linkProps" class="cv-header-name bx--header__name">
     <span v-if="prefix" class="bx--header__name--prefix">{{ prefix }}&nbsp;</span>
     <slot />
   </component>

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
@@ -3,10 +3,8 @@
     <component
       :is="tagType"
       v-on="$listeners"
-      :to="to"
-      :href="href"
       class="cv-side-nav-item-link bx--side-nav__link"
-      v-bind="$attrs"
+      v-bind="{ ...$attrs, ...linkProps }"
       :class="{ 'bx--side-nav__link--current': active }"
     >
       <cv-side-nav-icon v-if="$slots['nav-icon'] !== undefined" small>

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav-menu-item.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav-menu-item.vue
@@ -3,10 +3,8 @@
     <component
       :is="tagType"
       v-on="$listeners"
-      :to="to"
-      :href="href"
       class="bx--side-nav__link"
-      v-bind="$attrs"
+      v-bind="{ ...$attrs, ...linkProps }"
       :class="{ 'bx--side-nav__link--current': active }"
       role="menuitem"
     >

--- a/packages/core/src/components/cv-ui-shell/cv-skip-to-content.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-skip-to-content.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="tagType" v-on="$listeners" :to="to" :href="href" class="cv-skip-to-content bx--skip-to-content">
+  <component :is="tagType" v-on="$listeners" v-bind="linkProps" class="cv-skip-to-content bx--skip-to-content">
     <slot>Skip to main content</slot>
   </component>
 </template>

--- a/packages/core/src/components/cv-ui-shell/cv-switcher-item-link.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-switcher-item-link.vue
@@ -2,8 +2,7 @@
   <component
     :is="tagType"
     v-on="$listeners"
-    :to="to"
-    :href="href"
+    v-bind="linkProps"
     class="cv-switcher-item-link bx--switcher__item-link"
     :class="{ 'bx--switcher__item-link--selected': selected }"
   >


### PR DESCRIPTION
part of #506

Update other link mixin usage to match cv-link

#### Changelog

M       packages/core/CHANGELOG.md
M       packages/core/src/components/cv-tile/_cv-tile-clickable.vue
M       packages/core/src/components/cv-ui-shell/cv-header-menu-item.vue
M       packages/core/src/components/cv-ui-shell/cv-header-name.vue
M       packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
M       packages/core/src/components/cv-ui-shell/cv-side-nav-menu-item.vue
M       packages/core/src/components/cv-ui-shell/cv-skip-to-content.vue
M       packages/core/src/components/cv-ui-shell/cv-switcher-item-link.vue