### PR TITLE
fix: add missing menu title

### DIFF
--- a/packages/core/src/components/cv-ui-shell/cv-header-menu.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-header-menu.vue
@@ -14,6 +14,7 @@
       @keydown.enter.prevent="doToggle"
       @focusout="onFocusout"
     >
+      {{ title }}
       <chevron-down-glyph class="bx--header__menu-arrow" :aria-label="$attrs.ariaLabel" />
     </a>
     <ul
@@ -35,6 +36,9 @@ import ChevronDownGlyph from '@carbon/icons-vue/es/chevron--down';
 export default {
   name: 'CvHeaderMenu',
   components: { ChevronDownGlyph },
+  props: {
+    title: String,
+  },
   data() {
     return {
       expanded: false,

--- a/storybook/stories/cv-ui-shell-story.js
+++ b/storybook/stories/cv-ui-shell-story.js
@@ -76,7 +76,7 @@ const preKnobs = {
   <cv-header-menu-item href="javascript:void(0)">
     Link 3
   </cv-header-menu-item>
-  <cv-header-menu aria-label="Link 4">
+  <cv-header-menu aria-label="Link 4" title="Link 4">
     <cv-header-menu-item href="javascript:void(0)">
       Submenu Link 1
     </cv-header-menu-item>


### PR DESCRIPTION
Closes #510 

Add title to header menu.

m packages/core/src/components/cv-ui-shell/cv-header-menu.vue
m storybook/stories/cv-ui-shell-story.js