### PR TITLE
fix: code snippet copy

### DIFF
--- a/packages/core/src/components/cv-code-snippet/cv-code-snippet.vue
+++ b/packages/core/src/components/cv-code-snippet/cv-code-snippet.vue
@@ -48,7 +48,7 @@ export default {
   methods: {
     onCopyCode() {
       // copy to clipboard
-      this.$refs.clippy.value = this.$refs.code.innerHTML;
+      this.$refs.clippy.value = this.$refs.code.innerText;
       this.$refs.clippy.select();
       document.execCommand('copy');
     },


### PR DESCRIPTION
Closes #522

Copies the innerText as opposed to the innerHTML of the code snippet to the clipboard.

#### Changelog
- m packages/core/src/components/cv-code-snippet/cv-code-snippet.vue 