### PR TITLE
feat: vertical progress and tip enhancement

### DIFF
--- a/packages/core/src/components/cv-progress/cv-progress-notes.md
+++ b/packages/core/src/components/cv-progress/cv-progress-notes.md
@@ -24,7 +24,9 @@ NOTE: The current step is deemed to be the first incomplete step.
 
 ### Attributes - cv-progress
 
-- steps: Ignored if slotted content is provided.
+- initialStep: index of initial step defaults to 0
+- steps: Ignored if slotted content is provided
+- vertical: if true progress is displayed in a vertical orientation
 
 ### Attributes - cv-progress-step
 
@@ -32,6 +34,7 @@ NOTE: The current step is deemed to be the first incomplete step.
 - invalid: Boolean
 - disabled: Boolean
 - additional-info: optional additional info for step.
+- tip-text: Hard coded tip text always displayed
 
 ## Carbon 9
 

--- a/packages/core/src/components/cv-progress/cv-progress-step.vue
+++ b/packages/core/src/components/cv-progress/cv-progress-step.vue
@@ -1,19 +1,30 @@
 <template>
   <li class="cv-progress-step bx--progress-step" :class="stateClass" :aria-disabled="disabled">
     <svg v-if="isCurrent">
-      <path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"></path>
+      <path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0" />
     </svg>
     <Warning16 v-else-if="!isComplete && invalid" class="bx--progress__warning" />
     <svg v-else-if="!isComplete">
       <path
         d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
-      ></path>
+      />
     </svg>
     <CheckmarkOutline16 v-else-if="isComplete" />
 
-    <cv-tooltip direction="bottom" :tip="label">
-      <p class="bx--progress-label">{{ label }}</p>
-    </cv-tooltip>
+    <p
+      class="bx--progress-label"
+      :class="{ 'bx--progress-label-overflow': showOverflow }"
+      @mouseenter="onMouseEnter"
+      @mouseleave="onMouseLeave"
+      ref="label"
+    >
+      {{ label }}
+    </p>
+
+    <div role="tooltip" data-floating-menu-direction="bottom" class="bx--tooltip">
+      <span class="bx--tooltip__caret"></span>
+      <p class="bx--tooltip__text">{{ tip }}</p>
+    </div>
 
     <p class="bx--progress-optional" v-if="additionalInfo">{{ additionalInfo }}</p>
     <span class="bx--progress-line"></span>
@@ -45,11 +56,14 @@ export default {
     disabled: Boolean,
     invalid: Boolean,
     label: String,
+    tipText: String,
     complete: Boolean,
   },
   data() {
     return {
       state: -1,
+      showOverflow: false,
+      tip: '',
     };
   },
   mounted() {
@@ -83,6 +97,25 @@ export default {
       const disabledClass = this.disabled ? ' bx--progress-step--disabled' : '';
       const invalidClass = this.invalid ? ' bx--progress-step--invalid' : '';
       return `bx--progress-step--${states[this.state + 1]}${disabledClass}${invalidClass}`;
+    },
+  },
+  methods: {
+    onMouseEnter() {
+      if (this.tipText) {
+        this.tip = this.tipText;
+        this.showOverflow = true;
+      } else {
+        if (this.$refs.label.scrollWidth > this.$refs.label.clientWidth) {
+          this.tip = this.label;
+          this.showOverflow = true;
+        } else {
+          this.tip = '';
+          this.showOverflow = false;
+        }
+      }
+    },
+    onMouseLeave() {
+      this.showOverflow = false;
     },
   },
 };

--- a/packages/core/src/components/cv-progress/cv-progress.vue
+++ b/packages/core/src/components/cv-progress/cv-progress.vue
@@ -1,5 +1,10 @@
 <template>
-  <ul data-progress data-progress-current class="cv-progress bx--progress">
+  <ul
+    data-progress
+    data-progress-current
+    class="cv-progress bx--progress"
+    :class="{ 'bx--progress--vertical': vertical }"
+  >
     <slot>
       <cv-progress-step
         v-for="(step, index) in steps"
@@ -23,6 +28,7 @@ export default {
   props: {
     initialStep: { type: Number, default: 0 },
     steps: Array,
+    vertical: Boolean,
   },
   created() {
     // add these on created otherwise cv:mounted is too late.

--- a/storybook/stories/cv-progress-story.js
+++ b/storybook/stories/cv-progress-story.js
@@ -26,7 +26,7 @@ const preKnobs = {
     type: array,
     config: [
       'Steps',
-      ['Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5'],
+      ['Step 1', 'Step 2 overflows and shows a tip', 'Step 3', 'Step 4', 'Step 5'],
       ',',
       // 'consts.CONFIG', // , - does not seem to work in storybook 4
     ],
@@ -35,21 +35,27 @@ const preKnobs = {
       type: Array,
     },
   },
+  vertical: {
+    group: 'attr',
+    type: boolean,
+    config: ['vertical', false], // consts.CONFIG], // fails when used with number in storybook 4.1.4
+    prop: {
+      name: 'vertical',
+      type: Boolean,
+    },
+  },
   slotted: {
     group: 'slots',
-    value: `  <cv-progress-step label="Step 1" additional-info="Optional info" :complete="complete[0]"/>
+    value: `<cv-progress-step label="Step 1" additional-info="Optional info" :complete="complete[0]"/>
   <cv-progress-step label="Step 2 is a bit longer" :complete="complete[1]"/>
-  <cv-progress-step label="Step 3" :complete="complete[2]"/>
+  <cv-progress-step label="Step 3" :complete="complete[2]" tip-text="Step 3 has hard coded tip"/>
   <cv-progress-step label="Step 4" :complete="complete[3]" invalid />
   <cv-progress-step label="Step 4" :complete="complete[4]" disabled />
 `,
   },
 };
 
-const variants = [
-  { name: 'default', includes: ['initialStep', 'steps'] },
-  { name: 'slotted', excludes: ['steps', 'initialStep'], skip: { default: true } },
-];
+const variants = [{ name: 'default', excludes: ['slotted'] }, { name: 'slotted', excludes: ['steps', 'initialStep'] }];
 
 const storySet = knobsHelper.getStorySet(variants, preKnobs);
 


### PR DESCRIPTION
Adds a vertical progress option and enhances the tooltip so it is shown only if explicitly provided or the label is truncated.

#### Changelog

M       packages/core/src/components/cv-progress/cv-progress-notes.md
M       packages/core/src/components/cv-progress/cv-progress-step.vue
M       packages/core/src/components/cv-progress/cv-progress.vue
M       storybook/stories/cv-progress-story.js
