### PR TITLE
fix: correct non-cv-button button types

### DIFF
--- a/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
+++ b/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
@@ -5,7 +5,7 @@
       class="bx--table-expand"
       :data-previous-value="dataExpanded ? 'collapsed' : 'expanded'"
     >
-      <button v-if="expandingRow" class="bx--table-expand__button" @click="toggleExpand">
+      <button v-if="expandingRow" class="bx--table-expand__button" @click="toggleExpand" type="button">
         <ChevronRight16 class="bx--table-expand__svg" />
       </button>
     </td>

--- a/packages/core/src/components/cv-data-table/cv-data-table-action.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table-action.vue
@@ -1,5 +1,5 @@
 <template>
-  <button class="bx--overflow-menu bx--toolbar-action" v-on="$listeners">
+  <button class="bx--overflow-menu bx--toolbar-action" v-on="$listeners" type="button">
     <slot></slot>
   </button>
 </template>

--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -75,6 +75,7 @@
                 title="Clear search input"
                 aria-label="Clear search input"
                 @click="onClearClick"
+                type="button"
               >
                 <Close16 />
               </button>

--- a/packages/core/src/components/cv-text-input/cv-text-input.vue
+++ b/packages/core/src/components/cv-text-input/cv-text-input.vue
@@ -31,6 +31,7 @@
         class="bx--text-input--password__visibility"
         :aria-label="isPasswordVisible ? 'Hide password' : 'Show password'"
         @click="togglePasswordVisibility"
+        type="button"
       >
         <ViewOff16 v-if="isPasswordVisible" class="bx--icon-visibility-off" />
         <View16 v-else class="bx--icon-visibility-off" />


### PR DESCRIPTION
Closes #536 

Set button type="button" for buttons that are not cv-buttons

#### Changelog

M       packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
M       packages/core/src/components/cv-data-table/cv-data-table-action.vue
M       packages/core/src/components/cv-data-table/cv-data-table.vue
M       packages/core/src/components/cv-text-input/cv-text-input.vue
