### PR TITLE
Password button labels

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/vue",
   "description": "A collection of components for the Carbon Design System built using Vue.js",
-  "version": "2.12.7-canary.4",
+  "version": "2.12.7-canary.5",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/core/src/components/cv-text-input/cv-text-input-notes.md
+++ b/packages/core/src/components/cv-text-input/cv-text-input-notes.md
@@ -15,6 +15,8 @@ http://www.carbondesignsystem.com/components/text-input/code
 - helper-text: optional helper text
 - invalid-message: optional error message
 - label: the label text for the input
+- passwordHideLabel: aria-label for the password button if visible, default: 'Hide password',
+- passwordShowLabel: aria-label for the password button if not visible, default: 'Show password',
 - passwordVisible: Boolean makes password text visible
 - theme: optional 'light',
 - type: If 'password' adds password features

--- a/packages/core/src/components/cv-text-input/cv-text-input.vue
+++ b/packages/core/src/components/cv-text-input/cv-text-input.vue
@@ -29,7 +29,7 @@
       <button
         v-if="isPassword"
         class="bx--text-input--password__visibility"
-        :aria-label="isPasswordVisible ? 'Hide password' : 'Show password'"
+        :aria-label="passwordHideShowLabel"
         @click="togglePasswordVisibility"
         type="button"
       >
@@ -59,6 +59,8 @@ export default {
     helperText: { type: String, default: null },
     invalidMessage: { type: String, default: null },
     label: String,
+    passwordHideLabel: { type: String, default: 'Hide password' },
+    passwordShowLabel: { type: String, default: 'Show password' },
     passwordVisible: Boolean,
     theme: String,
     type: String,
@@ -101,6 +103,9 @@ export default {
     },
     isPasswordVisible() {
       return this.isPassword && this.dataPasswordVisible;
+    },
+    passwordHideShowLabel() {
+      return this.isPasswordVisible ? this.passwordHideLabel : this.passwordShowLabel;
     },
   },
   methods: {

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook",
-  "version": "2.12.7-canary.4",
+  "version": "2.12.7-canary.5",
   "private": true,
   "description": "> TODO: description",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
-    "@carbon/vue": "^2.12.7-canary.4",
+    "@carbon/vue": "^2.12.7-canary.5",
     "@storybook/addon-actions": "^5.1.8",
     "@storybook/addon-knobs": "^5.1.8",
     "@storybook/addon-notes": "^5.1.8",

--- a/storybook/stories/cv-text-input-story.js
+++ b/storybook/stories/cv-text-input-story.js
@@ -70,9 +70,32 @@ const preKnobs = {
       name: 'password-visible',
     },
   },
+  passwordHideLabel: {
+    group: 'attr',
+    type: text,
+    config: ['password hide label', 'Hide password'], // consts.CONTENT], // fails when used with number in storybook 4.1.4
+    prop: {
+      type: String,
+      name: 'password-hide-label',
+    },
+  },
+  passwordShowLabel: {
+    group: 'attr',
+    type: text,
+    config: ['password-show-label', 'Show password'], // consts.CONTENT], // fails when used with number in storybook 4.1.4
+    prop: {
+      type: String,
+      name: 'password-show-label',
+    },
+  },
   placeholder: {
     group: 'attr',
-    value: 'placeholder="sample placeholder"',
+    type: text,
+    config: ['placeholder', 'Sample placeholder'], // consts.CONTENT], // fails when used with number in storybook 4.1.4
+    prop: {
+      type: String,
+      name: 'placeholder',
+    },
   },
   vModel: {
     group: 'attr',


### PR DESCRIPTION
Closes  #541 

Add passwordHideLabel and passwordShowLabel to the text input box for use on the hide/show password icon

#### Changelog

M       packages/core/src/components/cv-text-input/cv-text-input-notes.md
M       packages/core/src/components/cv-text-input/cv-text-input.vue
M       storybook/stories/cv-text-input-story.js