### PR TITLE
Overflow focus issue

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/vue",
   "description": "A collection of components for the Carbon Design System built using Vue.js",
-  "version": "2.13.0-canary.1",
+  "version": "2.13.0-canary.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
+++ b/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
@@ -156,12 +156,10 @@ export default {
         );
         for (let tryOn of focusOnList) {
           if (
-            !// don't focus on before after or something that can't be tabbed to
-            (
-              tryOn.classList.contains('cv-overflow-menu__before-content') ||
-              tryOn.classList.contains('cv-overflow-menu__after-content') ||
-              tryOn.tabindex < 0
-            )
+            // don't focus on before after or something that can't be tabbed to
+            tryOn.classList.contains('cv-overflow-menu__before-content') ||
+            tryOn.classList.contains('cv-overflow-menu__after-content') ||
+            tryOn.tabindex < 0
           ) {
             focusOn = tryOn;
             break;
@@ -182,9 +180,13 @@ export default {
       // On initial open the menu is positioned 0,0 causing a jump
       await this.positionMenu();
       this.positionListen(this.open);
-      this.$nextTick(() => {
-        this.doFocus();
-      });
+
+      if (this.open) {
+        // only focus on open
+        this.$nextTick(() => {
+          this.doFocus();
+        });
+      }
     },
     onOverflowMenuTab(ev) {
       if (!ev.shiftKey) {

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook",
-  "version": "2.13.0-canary.1",
+  "version": "2.13.0-canary.2",
   "private": true,
   "description": "> TODO: description",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
-    "@carbon/vue": "^2.13.0-canary.1",
+    "@carbon/vue": "^2.13.0-canary.2",
     "@storybook/addon-actions": "^5.1.8",
     "@storybook/addon-knobs": "^5.1.8",
     "@storybook/addon-notes": "^5.1.8",


### PR DESCRIPTION
Perhaps fix #542

When an overflow menu closes stop it grabbing focus

#### Changelog

M       packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
