### PR TITLE
feat: add code snippet theme for inline

### DIFF
--- a/packages/core/src/components/cv-code-snippet/_cv-code-snippet-inline.vue
+++ b/packages/core/src/components/cv-code-snippet/_cv-code-snippet-inline.vue
@@ -1,9 +1,10 @@
 <template>
   <cv-feedback-button
     class="cv-code-snippet-inline"
-    feedback="Copied!"
+    :class="{ 'bx--snippet--light': theme === 'light' }"
+    :feedback="copyFeedback"
     inline
-    aria-label="Copy code"
+    :aria-label="feedbackAriaLabel"
     @click="$emit('copy-code')"
   >
     <slot></slot>
@@ -12,11 +13,17 @@
 
 <script>
 import CvFeedbackButton from './_cv-feedback-button';
+import themeMixin from '../../mixins/theme-mixin';
 
 export default {
   name: 'CvCodeSnippetInline',
+  mixins: [themeMixin],
   components: {
     CvFeedbackButton,
+  },
+  props: {
+    copyFeedback: String,
+    feedbackAriaLabel: String,
   },
 };
 </script>

--- a/packages/core/src/components/cv-code-snippet/_cv-code-snippet-multiline.vue
+++ b/packages/core/src/components/cv-code-snippet/_cv-code-snippet-multiline.vue
@@ -4,12 +4,12 @@
     :class="{ 'bx--snippet--expand': expanded }"
     data-code-snippet
   >
-    <div class="bx--snippet-container" aria-label="Code Snippet Text">
+    <div class="bx--snippet-container">
       <pre>
         <slot></slot>
       </pre>
     </div>
-    <cv-feedback-button feedback="Copied!" aria-label="Copy code" @click="$emit('copy-code')">
+    <cv-feedback-button :feedback="copyFeedback" :aria-label="feedbackAriaLabel" @click="$emit('copy-code')">
       <Copy16 class="bx--snippet__icon" />
     </cv-feedback-button>
 
@@ -38,6 +38,8 @@ export default {
   props: {
     lessText: { type: String, default: 'Show less' },
     moreText: { type: String, default: 'Show more' },
+    feedbackAriaLabel: String,
+    copyFeedback: String,
   },
   data() {
     return {

--- a/packages/core/src/components/cv-code-snippet/_cv-code-snippet-oneline.vue
+++ b/packages/core/src/components/cv-code-snippet/_cv-code-snippet-oneline.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="cv-code-snippet-oneline bx--snippet bx--snippet--single">
-    <div class="bx--snippet-container" aria-label="Code Snippet Text">
+    <div class="bx--snippet-container">
       <pre>
         <slot></slot>
       </pre>
     </div>
-    <cv-feedback-button feedback="Copied!" aria-label="Copy code" @click="$emit('copy-code')">
+    <cv-feedback-button :feedback="copyFeedback" :aria-label="feedbackAriaLabel" @click="$emit('copy-code')">
       <Copy16 class="bx--snippet__icon" />
     </cv-feedback-button>
   </div>
@@ -21,6 +21,10 @@ export default {
   components: {
     CvFeedbackButton,
     Copy16,
+  },
+  props: {
+    copyFeedback: String,
+    feedbackAriaLabel: String,
   },
 };
 </script>

--- a/packages/core/src/components/cv-code-snippet/cv-code-snippet-notes.md
+++ b/packages/core/src/components/cv-code-snippet/cv-code-snippet-notes.md
@@ -35,6 +35,12 @@ $z-indexes: (
 </cv-code-snippet>
 ```
 
+## attributes
+
+- feedback-aria-label: aria label for the feedback button. Default: 'Copy code'
+- copyFeedback: string of tip shown after copy performed. Default: 'Copied!'
+- thme: inline only allows 'light' version
+
 ## slots
 
 - default: slotted code content

--- a/packages/core/src/components/cv-code-snippet/cv-code-snippet.vue
+++ b/packages/core/src/components/cv-code-snippet/cv-code-snippet.vue
@@ -1,5 +1,12 @@
 <template>
-  <component class="cv-code-snippet" :is="theComponent" v-bind="$attrs" @copy-code="onCopyCode">
+  <component
+    class="cv-code-snippet"
+    :is="theComponent"
+    v-bind="$attrs"
+    @copy-code="onCopyCode"
+    :copy-feedback="copyFeedback"
+    :feedback-aria-label="feedbackAriaLabel"
+  >
     <code ref="code">
       <slot></slot>
     </code>
@@ -27,6 +34,8 @@ export default {
     CvCodeSnippetOneline,
   },
   props: {
+    feedbackAriaLabel: { type: String, default: 'Copy code' },
+    copyFeedback: { type: String, default: 'Copied!' },
     kind: {
       type: String,
       default: 'oneline',

--- a/storybook/stories/cv-code-snippet-story.js
+++ b/storybook/stories/cv-code-snippet-story.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/vue';
-import { text, select } from '@storybook/addon-knobs';
+import { text, select, boolean } from '@storybook/addon-knobs';
 
 import SvTemplateView from '../_storybook/views/sv-template-view/sv-template-view';
 // import consts from '../_storybook/utils/consts';
@@ -12,6 +12,24 @@ const storiesDefault = storiesOf('Components/CvCodeSnippet', module);
 const storiesExperimental = storiesOf('Experimental/CvCodeSnippet', module);
 
 let preKnobs = {
+  copyFeedback: {
+    group: 'attr',
+    type: text,
+    config: ['copy feedback', 'Content copied!'],
+    prop: {
+      type: String,
+      name: 'copy-feedback',
+    },
+  },
+  feedbackAriaLabel: {
+    group: 'attr',
+    type: text,
+    config: ['feedback aria label', 'feedback aria label'],
+    prop: {
+      type: String,
+      name: 'feedback-aria-label',
+    },
+  },
   lessText: {
     group: 'attr',
     type: text,
@@ -37,6 +55,16 @@ let preKnobs = {
     slot: {
       name: '',
       value: 'printf("A short bit of code.");',
+    },
+  },
+  theme: {
+    group: 'attr',
+    type: boolean,
+    config: ['light-theme', false], // consts.CONFIG], // fails when used with number in storybook 4.1.4
+    prop: {
+      type: String,
+      name: 'theme',
+      value: val => (val ? 'light' : ''),
     },
   },
   content: {
@@ -75,6 +103,11 @@ let variants = [
   },
   {
     name: 'inline',
+    includes: ['inlineContent', 'theme', 'copyFeedback', 'feedbackAriaLabel'],
+    extra: { kind: { group: 'attr', value: 'kind="inline"', inline: true } },
+  },
+  {
+    name: 'inline (minimal)',
     includes: ['inlineContent'],
     extra: { kind: { group: 'attr', value: 'kind="inline"', inline: true } },
   },
@@ -89,6 +122,11 @@ let variants = [
   },
   {
     name: 'oneline',
+    includes: ['content', 'copyFeedback', 'feedbackAriaLabel'],
+    extra: { kind: { group: 'attr', value: 'kind="oneline"', inline: true } },
+  },
+  {
+    name: 'oneline (minimal)',
     includes: ['content'],
     extra: { kind: { group: 'attr', value: 'kind="oneline"', inline: true } },
   },
@@ -115,7 +153,7 @@ for (const story of storySet) {
       const templateViewString = `
     <sv-template-view ref="view"
       sv-margin
-      :sv-alt-back="${settings.group.attr.indexOf('inline') > -1}"
+      :sv-alt-back="this.$options.propsData.theme !== 'light'"
       sv-source='${templateString.trim()}'>
       <template slot="component">${templateString}</template>
     </sv-template-view>


### PR DESCRIPTION
Closes #345

Adds theme 'light' to inline code snippet. 
Also adds options for the feedback button to change it's aria-label and the feedback message.

#### Changelog

M       packages/core/src/components/cv-code-snippet/_cv-code-snippet-inline.vue
M       packages/core/src/components/cv-code-snippet/_cv-code-snippet-multiline.vue
M       packages/core/src/components/cv-code-snippet/_cv-code-snippet-oneline.vue
M       packages/core/src/components/cv-code-snippet/cv-code-snippet-notes.md
M       packages/core/src/components/cv-code-snippet/cv-code-snippet.vue
M       storybook/stories/cv-code-snippet-story.js
