### PR TITLE
fix: popup proliferation on render

### DIFF
--- a/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
+++ b/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
@@ -215,10 +215,14 @@ export default {
     this.$el.addEventListener('focusout', this.checkFocusOut);
 
     // move popup out to body to ensure it appears above other elements
-    document.body.appendChild(this.$refs.popup);
+    this.popupEl = document.body.appendChild(this.$refs.popup);
   },
   beforeDestroy() {
     this.positionListen(false);
+    if (this.popupEl) {
+      // move back to where it came from
+      this.$el.appendChild(this.popupEl);
+    }
   },
 };
 </script>

--- a/packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
@@ -201,7 +201,7 @@ export default {
   },
   mounted() {
     // move popup out to body to ensure it appears above other elements
-    document.body.appendChild(this.$refs.popup);
+    this.popupEl = document.body.appendChild(this.$refs.popup);
 
     if (this.visible) {
       this.show();
@@ -211,6 +211,10 @@ export default {
   },
   beforeDestroy() {
     this.positionListen(false);
+    if (this.popupEl) {
+      // move back to where it came from
+      this.$el.appendChild(this.popupEl);
+    }
   },
 };
 </script>


### PR DESCRIPTION
Closes #557

Overflow and interactive tooltip popups are moved out to the body so they appear above other content. This fix puts them back before the component is destroyed.

#### Changelog

M       packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
M       packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
