### PR TITLE
feat: add expand all to data table

### DIFF
--- a/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
+++ b/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
@@ -36,13 +36,11 @@
 import CvCheckbox from '../cv-checkbox/cv-checkbox';
 import CvOverflowMenu from '../cv-overflow-menu/cv-overflow-menu';
 import CvOverflowMenuItem from '../cv-overflow-menu/cv-overflow-menu-item';
-import uidMixin from '../../mixins/uid-mixin';
 import ChevronRight16 from '@carbon/icons-vue/es/chevron--right/16';
 
 export default {
   name: 'CvDataTableRowInner',
   components: { CvCheckbox, CvOverflowMenu, CvOverflowMenuItem, ChevronRight16 },
-  mixins: [uidMixin],
   props: {
     checked: Boolean,
     expanded: Boolean,
@@ -73,12 +71,6 @@ export default {
       this.dataSomeExpandingRows = this.someExpandingRows;
     },
   },
-  mounted() {
-    this.$parent.$emit('cv:mounted', this);
-  },
-  beforeDestroy() {
-    this.$parent.$emit('cv:beforeDestroy', this);
-  },
   computed: {
     isCvDataTableRow() {
       return true;
@@ -102,6 +94,7 @@ export default {
     },
     toggleExpand() {
       this.dataExpanded = !this.dataExpanded;
+      this.$emit('expanded-change', this.dataExpanded);
     },
   },
 };

--- a/packages/core/src/components/cv-data-table/cv-data-table-row.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table-row.vue
@@ -6,6 +6,8 @@
       v-on="$listeners"
       :expanding-row="dataExpandable"
       some-expanding-rows
+      @expanded-change="onExpandedChange"
+      :expanded="dataExpanded"
     >
       <slot />
     </cv-data-table-row-inner>
@@ -24,15 +26,28 @@
 
 <script>
 import CvDataTableRowInner from './_cv-data-table-row-inner';
+import uidMixin from '../../mixins/uid-mixin';
 
 export default {
   name: 'CvDataTableRow',
+  mixins: [uidMixin],
   components: { CvDataTableRowInner },
+  props: {
+    expanded: Boolean,
+  },
   data() {
     return {
       dataExpandable: this.$slots.expandedContent !== undefined,
       dataSomeExpandingRows: false,
+      dataExpanded: this.expanded,
     };
+  },
+  watch: {
+    expanded() {
+      if (this.dataExpanded !== this.expaned) {
+        this.dataExpanded = this.expanded;
+      }
+    },
   },
   mounted() {
     this.$parent.$emit('cv:mounted', this);
@@ -58,6 +73,14 @@ export default {
         this.$refs.row.dataChecked = val;
       },
     },
+    isExpanded: {
+      get() {
+        return this.dataExpanded;
+      },
+      set(val) {
+        this.dataExpanded = val;
+      },
+    },
     someExpandingRows: {
       get() {
         return this.dataSomeExpandingRows;
@@ -72,6 +95,12 @@ export default {
     },
     value() {
       return this.$refs.row.value;
+    },
+  },
+  methods: {
+    onExpandedChange(val) {
+      this.dataExpanded = val;
+      this.$emit('cv:expanded-change', this);
     },
   },
 };

--- a/storybook/stories/cv-combo-box-story.js
+++ b/storybook/stories/cv-combo-box-story.js
@@ -183,7 +183,7 @@ let variants = [
 let storySet = knobsHelper.getStorySet(variants, preKnobs);
 
 for (const story of storySet) {
-  storiesExperimental.add(
+  storiesDefault.add(
     story.name,
     () => {
       const settings = story.knobs();

--- a/storybook/stories/cv-data-table-story.js
+++ b/storybook/stories/cv-data-table-story.js
@@ -274,6 +274,12 @@ let preKnobs = {
     value: `<template v-slot:items-selected="{scope}">You picked {{scope.count}} rows.</template>
   `,
   },
+  hasExpandAll: {
+    group: 'attr',
+    type: boolean,
+    config: ['has-expand-all', false], // consts.CONFIG], // fails when used with number in storybook 4.1.4
+    prop: 'has-expand-all',
+  },
 };
 
 let variants = [
@@ -289,6 +295,7 @@ let variants = [
       'hasExpandingRows',
       'expandingSlottedData',
       'scopedSlots',
+      'hasExpandAll',
     ],
   },
   {
@@ -303,6 +310,7 @@ let variants = [
       'hasExpandingRows',
       'expandingSlottedData',
       'scopedSlots',
+      'hasExpandAll',
     ],
   },
   {
@@ -315,12 +323,16 @@ let variants = [
       'basicPagination',
       'hasExpandingRows',
       'expandingSlottedData',
+      'hasExpandAll',
     ],
   },
   { name: 'slottedHelper', includes: ['columns', 'data', 'title', 'helperTextSlot'] },
   { name: 'minimal', includes: ['columns', 'data'] },
   { name: 'slotted data', includes: ['columns', 'slottedData', 'data', 'basicPagination', 'hasExpandingRows'] },
-  { name: 'slotted expanding data', includes: ['columns', 'expandingSlottedData', 'data', 'basicPagination'] },
+  {
+    name: 'slotted expanding data',
+    includes: ['columns', 'expandingSlottedData', 'data', 'basicPagination', 'hasExpandAll'],
+  },
   { name: 'slotted HTML', includes: ['columns', 'htmlData', 'basicPagination'] },
   { name: 'styled columns', includes: ['columns2', 'data'] },
 ];


### PR DESCRIPTION
Ref: #581 

Adds expand all option to data table as part of 10.6 catchup.

#### Changelog

M       packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
M       packages/core/src/components/cv-data-table/cv-data-table-row.vue
M       packages/core/src/components/cv-data-table/cv-data-table.vue
M       storybook/stories/cv-combo-box-story.js
M       storybook/stories/cv-data-table-story.js
