### PR TITLE
fix(cv dropdown): inline dropdown arrow icon missing

### DIFF
--- a/packages/core/src/components/cv-dropdown/cv-dropdown.vue
+++ b/packages/core/src/components/cv-dropdown/cv-dropdown.vue
@@ -50,8 +50,8 @@
         @click="onClick"
       >
         <WarningFilled16 v-if="isInvalid" class="bx--dropdown__invalid-icon" />
-        <li v-if="inline" class="bx--dropdown-text" ref="valueContent">
-          <span class="bx--dropdown-text__inner">{{ placeholder }}</span>
+        <li v-if="inline" class="bx--dropdown-text">
+          <span class="bx--dropdown-text__inner" ref="valueContent">{{ placeholder }}</span>
           <chevron-down-16 class="cv-dropdown__arrow bx--dropdown__arrow" />
         </li>
         <template v-else>


### PR DESCRIPTION
Closes #584 

Fixes the arrow icon being replaced by the `internalValue` when set (`this.$refs.valueContent.innerHTML = child.internalContent;`) by changing the `valueContent` to the span where the text should be rather than the parent of the span and the icon.

#### Changelog

`M       packages/core/src/components/cv-dropdown/cv-dropdown.vue`
