### PR TITLE
Cv tabs from data fix

### DIFF
--- a/packages/core/src/components/cv-dropdown/cv-dropdown-item.vue
+++ b/packages/core/src/components/cv-dropdown/cv-dropdown-item.vue
@@ -55,7 +55,7 @@ export default {
     this.$parent.$emit('cv:mounted', this);
   },
   beforeDestroy() {
-    this.$parent.$emit('cv:beforeDestory', this);
+    this.$parent.$emit('cv:beforeDestroy', this);
   },
   computed: {
     internalSelected: {

--- a/packages/core/src/components/cv-tabs/cv-tabs.vue
+++ b/packages/core/src/components/cv-tabs/cv-tabs.vue
@@ -10,9 +10,9 @@
       @keydown.left.prevent="moveLeft"
     >
       <cv-dropdown class="bx--tabs-trigger" :value="`${selectedIndex}`" @change="onDropChange" :form-item="false">
-        <cv-dropdown-item v-for="(tab, index) in tabs" :key="`drop-${index}`" :value="`${index}`">
-          {{ tab.label }}
-        </cv-dropdown-item>
+        <cv-dropdown-item v-for="(tab, index) in tabs" :key="`drop-${index}`" :value="`${index}`">{{
+          tab.label
+        }}</cv-dropdown-item>
       </cv-dropdown>
       <ul class="bx--tabs__nav bx--tabs__nav--hidden" role="tablist">
         <li
@@ -62,7 +62,7 @@ export default {
   created() {
     // add these on created otherwise cv:mounted is too early.
     this.$on('cv:mounted', srcComponent => this.onCvMount(srcComponent));
-    this.$on('cv:beforeDestory', srcComponent => this.onCvBeforeDestroy(srcComponent));
+    this.$on('cv:beforeDestroy', srcComponent => this.onCvBeforeDestroy(srcComponent));
     this.$on('cv:selected', srcComponent => this.onCvSelected(srcComponent));
     this.$on('cv:disabled', srcComponent => this.onCvDisabled(srcComponent));
     this.$on('cv:enabled', srcComponent => this.onCvEnabled(srcComponent));
@@ -85,13 +85,13 @@ export default {
       this.checkDisabled(srcComponent);
     },
     onTabClick(index) {
-      if (this.selectedIndex !== index && this.disabledTabs.indexOf(index) === -1) {
+      if (this.disabledTabs.indexOf(index) === -1) {
         this.selectedIndex = index;
         // console.log(this.selectedIndex);
         for (let i = 0; i < this.tabs.length; i++) {
           this.tabs[i].internalSelected = i === index;
         }
-        this.$emit('tab-selected', index); // only needed if changed.
+        this.$emit('tab-selected', index);
       }
     },
     onCvSelected(srcComponent) {

--- a/storybook/stories/cv-tabs-story.js
+++ b/storybook/stories/cv-tabs-story.js
@@ -31,9 +31,9 @@ const preKnobs = {
   },
 };
 
-const variants = [{ name: 'default' }, { name: 'minimal', excludes: ['events', 'selected', 'disabled'] }];
+let variants = [{ name: 'default' }, { name: 'minimal', excludes: ['events', 'selected', 'disabled'] }];
 
-const storySet = knobsHelper.getStorySet(variants, preKnobs);
+let storySet = knobsHelper.getStorySet(variants, preKnobs);
 
 for (const story of storySet) {
   storiesDefault.add(
@@ -87,6 +87,87 @@ for (const story of storySet) {
         },
         template: templateViewString,
         props: settings.props,
+      };
+    },
+    {
+      notes: { markdown: CvTabsNotesMD },
+    }
+  );
+}
+
+variants = [{ name: 'tabs from data', includes: [] }];
+
+storySet = knobsHelper.getStorySet(variants, preKnobs);
+
+for (const story of storySet) {
+  storiesDefault.add(
+    story.name,
+    () => {
+      const settings = story.knobs();
+
+      // ----------------------------------------------------------------
+
+      const templateString = `
+<cv-tabs${settings.group.attr} aria-label="navigation tab label">
+  <cv-tab :key="tab.name" :label="tab.label" v-for="tab in activeSet" v-html="tab.label" :data-test="tab.content">
+  </cv-tab>
+</cv-tabs>
+  `;
+
+      // ----------------------------------------------------------------
+
+      const templateViewString = `
+    <sv-template-view
+      sv-margin
+      sv-source='${templateString.trim()}'>
+      <template slot="component">${templateString}</template>
+      <template slot="other"><button @click="changeSet">Change Set</button></template>
+    </sv-template-view>
+  `;
+
+      return {
+        components: { CvTabs, CvTab, SvTemplateView },
+        data() {
+          return {
+            dataSet1: [
+              {
+                name: 'item1',
+                label: 'Item 1',
+                content: 'Content for item 1',
+              },
+              {
+                name: 'item2',
+                label: 'Item 2',
+                content: 'Content for item 2',
+              },
+            ],
+            dataSet2: [
+              {
+                name: 'item3',
+                label: 'Item 3',
+                content: 'Content for item 3',
+              },
+              {
+                name: 'item4',
+                label: 'Item 4',
+                content: 'Content for item 4',
+              },
+            ],
+            activeSet: undefined,
+          };
+        },
+        methods: {
+          actionSelected: action('Cv Tabs - tab-selected'),
+          actionBeingSelected: action('Cv Tabs - tab-beingselected'),
+          changeSet() {
+            this.activeSet = this.activeSet === this.dataSet1 ? this.dataSet2 : this.dataSet1;
+          },
+        },
+        template: templateViewString,
+        props: settings.props,
+        mounted() {
+          this.activeSet = this.dataSet1;
+        },
       };
     },
     {

--- a/storybook/stories/cv-tabs-story.js
+++ b/storybook/stories/cv-tabs-story.js
@@ -109,7 +109,7 @@ for (const story of storySet) {
 
       const templateString = `
 <cv-tabs${settings.group.attr} aria-label="navigation tab label">
-  <cv-tab :key="tab.name" :label="tab.label" v-for="tab in activeSet" v-html="tab.label" :data-test="tab.content">
+  <cv-tab :key="tab.name" :label="tab.label" v-for="tab in activeSet" v-html="tab.content" :data-test="tab.content">
   </cv-tab>
 </cv-tabs>
   `;


### PR DESCRIPTION
Closes #599

There was a couple of typos in cv:beforeDestroy event names and also in how swapping out a data set was handled to ensure an item is selected.

#### Changelog

M       packages/core/src/components/cv-dropdown/cv-dropdown-item.vue
M       packages/core/src/components/cv-tabs/cv-tabs.vue
M       storybook/stories/cv-tabs-story.js
