### PR TITLE
Removing an unnecessary and a ternary check

### DIFF
--- a/packages/core/src/mixins/check-mixin.js
+++ b/packages/core/src/mixins/check-mixin.js
@@ -42,25 +42,15 @@ export default {
         if (this.$props.modelValue !== undefined) {
           // model value always comes first
           if (this.isArrayModel) {
-            if (this.modelValue.includes(this.value)) {
-              return true;
-            } else {
-              return false;
-            }
+            return this.modelValue.includes(this.value);
           } else {
             return this.modelValue;
           }
         } else {
           if (this.dataChecked !== undefined) {
             return this.dataChecked;
-          } else {
-            // if checked defined
-            if (this.dataChecked !== undefined) {
-              return this.dataChecked;
-            }
-            if (this.dataMixed) {
-              return 'mixed';
-            }
+          } else if(this.dataMixed) {
+            return 'mixed';
           }
 
           return false;
@@ -77,7 +67,7 @@ export default {
           }
           this.dataChecked = Array.from(modelSet);
         } else {
-          this.dataChecked = checked ? true : undefined; //
+          this.dataChecked = checked || undefined; //
           if (this.dataChecked !== undefined) {
             this.dataMixed = false;
           }


### PR DESCRIPTION
Closes #

There was a double check in getter for the computed property `isChecked` and I also removed the ternary operator (but this might be a code style choice).

#### Changelog

M packages/core/src/mixins/check-mixin.js
