### PR TITLE
feat: update overflow to 10 7

### DIFF
--- a/packages/core/src/components/cv-button/cv-icon-button.vue
+++ b/packages/core/src/components/cv-button/cv-icon-button.vue
@@ -28,19 +28,19 @@ export default {
   name: 'CvIconButton',
   mixins: [buttonMixin],
   props: {
-    tipText: { type: String, default: undefined },
+    label: { type: String, default: undefined },
     tipPosition: {
       type: String,
       default: 'bottom',
       validator: val => ['top', 'left', 'bottom', 'right'.includes(val)],
     },
-    tipAlignment: { type: String, default: 'center' },
+    tipAlignment: { type: String, default: 'center', validator: val => ['start', 'center', 'end'].includes(val) },
   },
   computed: {
     tipClasses() {
       const tipPosition = this.tipPosition || 'bottom';
       const tipAlignment = this.tipAlignment || 'center';
-      if (this.tipText) {
+      if (this.label) {
         return `bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--${tipPosition} bx--tooltip--align-${tipAlignment}`;
       } else {
         return '';

--- a/packages/core/src/components/cv-overflow-menu/cv-overflow-menu-notes.md
+++ b/packages/core/src/components/cv-overflow-menu/cv-overflow-menu-notes.md
@@ -23,6 +23,9 @@ CvOverflowMenu contains slotted CvOverflowMenuItem's which have slotted contents
 - flip-menu: Boolean, optionally moves caret from right to left of popup menu
 - offset: Object, optional offset setting for left and top position.
   - e.g. { left: 0, top: 200 }
+- label: assistive text shown as a tooltip
+- tipPosition: top, left, right(default) or bottom
+- tipAlignment: start, center(default) or end.
 
 NOTE: Default behaviour (no offset) automatically positions the popup menu.
 

--- a/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
+++ b/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
@@ -1,21 +1,27 @@
 <template>
-  <div
-    data-overflow-menu
-    tabindex="0"
-    @click="doToggle"
-    @keydown.space.prevent
-    @keyup.space.prevent="doToggle"
-    @keydown.enter.prevent="doToggle"
-    @keydown.tab="onOverflowMenuTab"
-    :aria-label="label"
-    role="button"
-    class="cv-overflow-menu bx--overflow-menu"
-    :class="{ 'bx--overflow-menu--open': open }"
-  >
-    <slot name="trigger">
-      <OverflowMenuVertical16 class="bx--overflow-menu__icon" />
-    </slot>
-    <ul
+  <div data-overflow-menu class="cv-overflow-menu bx--overflow-menu">
+    <button
+      class="bx--overflow-menu__trigger bx--tooltip__trigger bx--tooltip--a11y"
+      :class="[tipClasses, { 'bx--overflow-menu--open': open }]"
+      aria-haspopup
+      role="button"
+      :aria-expanded="open"
+      :aria-controls="`${uid}-menu`"
+      :id="`${uid}-trigger`"
+      ref="trigger"
+      @click="doToggle"
+      @keydown.space.prevent
+      @keyup.space.prevent="doToggle"
+      @keydown.enter.prevent="doToggle"
+      @keydown.tab="onOverflowMenuTab"
+    >
+      <span class="bx--assistive-text">{{ label }}</span>
+
+      <slot name="trigger">
+        <OverflowMenuVertical16 class="bx--overflow-menu__icon" />
+      </slot>
+    </button>
+    <div
       class="bx--overflow-menu-options"
       :class="{
         'bx--overflow-menu--flip': flipMenu,
@@ -23,7 +29,8 @@
       }"
       tabindex="-1"
       ref="popup"
-      :id="uid"
+      :aria-labelledby="`${uid}-trigger`"
+      :id="`${uid}-menu`"
       :style="{ left: left + 'px', top: top + 'px' }"
       @focusout="checkFocusOut"
       @mousedown.prevent="preventFocusOut"
@@ -35,7 +42,9 @@
         style="position: absolute; height: 1px; width: 1px; left: -9999px;"
         @focus="focusBeforeContent"
       />
-      <slot></slot>
+      <ul class="bx--overflow-menu-options__content">
+        <slot></slot>
+      </ul>
       <div
         class="cv-overflow-menu__after-content"
         ref="afterContent"
@@ -43,7 +52,7 @@
         style="position: absolute; height: 1px; width: 1px; left: -9999px;"
         @focus="focusAfterContent"
       />
-    </ul>
+    </div>
   </div>
 </template>
 
@@ -65,6 +74,12 @@ export default {
         return value.hasOwnProperty('left') && value.hasOwnProperty('top');
       },
     },
+    tipPosition: {
+      type: String,
+      default: 'right',
+      validator: val => ['top', 'left', 'bottom', 'right'.includes(val)],
+    },
+    tipAlignment: { type: String, default: 'center', validator: val => ['start', 'center', 'end'].includes(val) },
   },
   watch: {
     flipMenu(val) {
@@ -84,6 +99,15 @@ export default {
     },
     offsetTop() {
       return this.offset ? this.offset.top : 0;
+    },
+    tipClasses() {
+      const tipPosition = this.tipPosition || 'right';
+      const tipAlignment = this.tipAlignment || 'center';
+      if (this.label) {
+        return `bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--${tipPosition} bx--tooltip--align-${tipAlignment}`;
+      } else {
+        return '';
+      }
     },
   },
   created() {
@@ -198,12 +222,12 @@ export default {
     },
     focusBeforeContent(ev) {
       if (this.$refs.popup.contains(ev.relatedTarget)) {
-        this.$el.focus();
+        this.$refs.trigger.focus();
         this.open = false;
       }
     },
     focusAfterContent() {
-      this.$el.focus();
+      this.$refs.trigger.focus();
       this.open = false;
     },
     preventFocusOut() {

--- a/storybook/stories/cv-button-story.js
+++ b/storybook/stories/cv-button-story.js
@@ -73,11 +73,11 @@ let preKnobs = {
     prop: 'icon',
     value: () => AddFilled16,
   },
-  tipText: {
+  label: {
     group: 'attr',
     type: text,
-    config: ['Tip text', 'Tool tip'],
-    prop: 'tip-text',
+    config: ['label for assistive text', 'Icon button'],
+    prop: 'label',
   },
   tipPosition: {
     group: 'attr',
@@ -179,7 +179,7 @@ for (const story of storySet) {
 variants = [
   {
     name: 'icon-only',
-    includes: ['kind', 'size', 'disabled', 'tipText', 'tipPosition', 'tipAlignment', 'iconAlways'],
+    includes: ['kind', 'size', 'disabled', 'label', 'tipPosition', 'tipAlignment', 'iconAlways'],
   },
 ];
 

--- a/storybook/stories/cv-overflow-menu-story.js
+++ b/storybook/stories/cv-overflow-menu-story.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/vue';
-import { object, boolean } from '@storybook/addon-knobs';
+import { object, boolean, text, select } from '@storybook/addon-knobs';
 
 import SvTemplateView from '../_storybook/views/sv-template-view/sv-template-view';
 // import consts from '../_storybook/utils/consts';
@@ -30,9 +30,47 @@ const preKnobs = {
     config: ['offset example', { left: 0, top: 0 }], // consts.CONFIG], // fails when used with number in storybook 4.1.4
     prop: 'offset',
   },
+  label: {
+    group: 'attr',
+    type: text,
+    config: ['label for assistive text', 'Oveflow menu'],
+    prop: 'label',
+  },
+  tipPosition: {
+    group: 'attr',
+    type: select,
+    config: [
+      'Tip position',
+      {
+        Top: 'top',
+        Right: 'right',
+        Bottom: 'bottom',
+        Left: 'left',
+      },
+      'right',
+      // consts.CONFIG,// fails when used with number in storybook 4.1.4
+    ],
+    inline: true,
+    prop: 'tip-position',
+  },
+  tipAlignment: {
+    group: 'attr',
+    type: select,
+    config: [
+      'Tip alignment',
+      {
+        Start: 'start',
+        Center: 'center',
+        End: 'end',
+      },
+      'center',
+      // consts.CONFIG,// fails when used with number in storybook 4.1.4
+    ],
+    prop: 'tip-alignment',
+  },
 };
 
-const variants = [{ name: 'default' }];
+const variants = [{ name: 'default' }, { name: 'minimal', includes: ['label'] }];
 
 const storySet = knobsHelper.getStorySet(variants, preKnobs);
 


### PR DESCRIPTION
Updates the overflow menu to 10 7 stylings and accessibility

M       packages/core/src/components/cv-button/cv-icon-button.vue
M       packages/core/src/components/cv-overflow-menu/cv-overflow-menu-notes.md
M       packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
M       storybook/stories/cv-button-story.js
M       storybook/stories/cv-overflow-menu-story.js