### PR TITLE
fix: test update for cv-tabs

### DIFF
--- a/packages/core/src/components/cv-dropdown/cv-dropdown.vue
+++ b/packages/core/src/components/cv-dropdown/cv-dropdown.vue
@@ -18,9 +18,9 @@
 <template>
   <div :class="{ 'bx--form-item': formItem }">
     <div class="bx--dropdown__wrapper" :class="{ 'bx--dropdown__wrapper--inline': inline, 'cv-dropdown': !formItem }">
-      <span v-if="label" :id="`${uid}-label`" class="bx--label" :class="{ 'bx--label--disabled': $attrs.disabled }">{{
-        label
-      }}</span>
+      <span v-if="label" :id="`${uid}-label`" class="bx--label" :class="{ 'bx--label--disabled': $attrs.disabled }">
+        {{ label }}
+      </span>
 
       <div
         v-if="!inline && isHelper"
@@ -192,7 +192,7 @@ export default {
     },
     onCvBeforeDestroy(srcComponent) {
       if (srcComponent.value === this.internalValue) {
-        this.internalValue = null;
+        this.dataValue = null;
       }
     },
     dropdownItems() {

--- a/packages/core/src/components/cv-tabs/cv-tabs.vue
+++ b/packages/core/src/components/cv-tabs/cv-tabs.vue
@@ -56,6 +56,7 @@ export default {
     return {
       tabs: [],
       selectedIndex: -1,
+      selectedId: undefined,
       disabledTabs: [],
     };
   },
@@ -73,25 +74,34 @@ export default {
     },
     onCvMount(srcComponent) {
       this.tabs.push(srcComponent);
-      this.checkSelected();
+
       this.checkDisabled(srcComponent);
+      if (this.selectedIndex < 0) {
+        this.checkSelected();
+      }
     },
     onCvBeforeDestroy(srcComponent) {
       const tabIndex = this.tabs.findIndex(item => item.uid === srcComponent.uid);
       if (tabIndex > -1) {
         this.tabs.splice(tabIndex, 1);
+
+        this.checkDisabled(srcComponent);
+        if (tabIndex <= this.selectedIndex) {
+          this.checkSelected();
+        }
       }
-      this.checkSelected();
-      this.checkDisabled(srcComponent);
     },
     onTabClick(index) {
       if (this.disabledTabs.indexOf(index) === -1) {
-        this.selectedIndex = index;
-        // console.log(this.selectedIndex);
-        for (let i = 0; i < this.tabs.length; i++) {
-          this.tabs[i].internalSelected = i === index;
+        if (this.selectedId !== this.tabs[index].uid) {
+          this.selectedIndex = index;
+          this.selectedId = this.tabs[index].uid;
+
+          for (let i = 0; i < this.tabs.length; i++) {
+            this.tabs[i].internalSelected = i === index;
+          }
+          this.$emit('tab-selected', index);
         }
-        this.$emit('tab-selected', index);
       }
     },
     onCvSelected(srcComponent) {


### PR DESCRIPTION
An experiment for #671

- Change so that events are not raised if the same tab is selected again. 
- Change behaviour on tab mount to only check tab selection if none selected.
- Change behaviour on tab destroy to only check tab selection if selected or left of removed.

#### Changelog

M       packages/core/src/components/cv-dropdown/cv-dropdown.vue
M       packages/core/src/components/cv-tabs/cv-tabs.vue
