### PR TITLE
fix: remove extra dot from subtitle

### DIFF
--- a/packages/core/src/components/cv-inline-notification/cv-inline-notification.vue
+++ b/packages/core/src/components/cv-inline-notification/cv-inline-notification.vue
@@ -16,7 +16,7 @@
       <component :is="icon" class="bx--inline-notification__icon" />
       <div class="bx--inline-notification__text-wrapper">
         <p class="bx--inline-notification__title">{{ title }}</p>
-        <p class="bx--inline-notification__subtitle">{{ subTitle }}.</p>
+        <p class="bx--inline-notification__subtitle">{{ subTitle }}</p>
       </div>
     </div>
     <button


### PR DESCRIPTION
Closes #622

Remove extra dot in the sub-title of CvInlineNotification

#### Changelog

M       packages/core/src/components/cv-inline-notification/cv-inline-notification.vue
