### PR TITLE
chore: update tooltip to 10-7 form

### DIFF
--- a/packages/core/src/components/cv-tooltip/cv-definition-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-definition-tooltip.vue
@@ -1,17 +1,25 @@
 <template>
-  <div class="cv-definition-tooltip bx--tooltip--definition">
-    <p class="bx--tooltip__trigger" tabindex="0">{{ term }}</p>
-    <div :class="`bx--tooltip--definition__${direction}`">
-      <span class="bx--tooltip__caret"></span>
-      <p>{{ definition }}</p>
-    </div>
+  <div class="cv-definition-tooltip bx--tooltip--definition bx--tooltip--a11y">
+    <button
+      :aria-describedby="`${uid}-label`"
+      class="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition"
+      :class="`bx--tooltip--${direction} bx--tooltip--align-${alignment}`"
+      role="button"
+    >
+      {{ term }}
+    </button>
+    <div class="bx--assistive-text" :id="`${uid}-label`" role="tooltip">{{ definition }}</div>
   </div>
 </template>
 
 <script>
+import uidMixin from '../../mixins/uid-mixin';
+
 export default {
   name: 'CvDefinitionTooltip',
+  mixins: [uidMixin],
   props: {
+    alignment: { type: String, default: 'center', validator: val => ['start', 'center', 'end'].includes(val) },
     definition: { type: String, required: true },
     direction: {
       type: String,

--- a/packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
@@ -1,33 +1,36 @@
 <template>
   <div class="cv-interactive-tooltip">
-    <div class="bx--tooltip__label" :aria-describedby="uid">
+    <div :id="`${uid}-label`" class="bx--tooltip__label">
       <slot name="label"></slot>
 
-      <div
-        tabindex="0"
-        data-tooltip-trigger
-        :data-tooltip-target="`#${uid}`"
-        role="tooltip"
+      <button
+        :aria-expanded="dataVisible"
+        :aria-labelledby="`${uid}-label`"
         class="bx--tooltip__trigger"
+        :aria-controls="`${uid}`"
+        aria-haspopup="true"
         ref="trigger"
+        role="button"
         @click="toggle"
-        @keydown.space.prevent
-        @keyup.space.prevent="toggle"
-        @keydown.enter.prevent="toggle"
         @keydown.tab="onTriggerTab"
         @focusout="checkFocusOut"
       >
         <slot name="trigger">
-          <Information16 class="banana" />
+          <Information16 />
         </slot>
-      </div>
+      </button>
     </div>
+
     <div
-      :id="uid"
+      :id="`${uid}`"
+      aria-hidden="true"
       :data-floating-menu-direction="direction"
       class="bx--tooltip"
       :class="{ 'bx--tooltip--shown': dataVisible }"
       ref="popup"
+      role="dialog"
+      :aria-describedby="`${uid}-body`"
+      :aria-labelledby="`${uid}-label`"
       @focusout="checkFocusOut"
       :style="{ left: left + 'px', top: top + 'px' }"
       tabindex="-1"
@@ -41,7 +44,9 @@
         @focus="focusBeforeContent"
       />
       <span class="bx--tooltip__caret"></span>
-      <slot name="content"></slot>
+      <div class="bx--tooltip__content">
+        <slot name="content"></slot>
+      </div>
       <div
         class="cv-interactive-tooltip__after-content"
         ref="afterContent"

--- a/packages/core/src/components/cv-tooltip/cv-tooltip-notes.md
+++ b/packages/core/src/components/cv-tooltip/cv-tooltip-notes.md
@@ -28,6 +28,7 @@ http://www.carbondesignsystem.com/components/tooltip/code
 
 ## Attributes
 
+- alignment: start, center or end.
 - direction: 'top', 'left', 'right', 'bottom'
 
 ## slots
@@ -40,3 +41,45 @@ http://www.carbondesignsystem.com/components/tooltip/code
   - default: SVG i in a circle
 - content
   - Content of the tooltip can be interactive content.
+
+# cv-definition-tooltip
+
+A Vue implementation of a Carbon Components tooltip
+
+http://www.carbondesignsystem.com/components/tooltip/code
+
+## Usage
+
+```html
+<cv-definition-tooltip
+  alignment="center"
+  direction="bottom"
+  term="thing to be defined"
+  definition="definition of term"
+/>
+```
+
+## Attributes
+
+- alignment: start, center or end.
+- direction: 'top', 'left', 'right', 'bottom'
+- term: to be defined
+- definition: of the term
+
+# cv-tooltip
+
+A Vue implementation of a Carbon Components tooltip
+
+http://www.carbondesignsystem.com/components/tooltip/code
+
+## Usage
+
+```html
+<cv-definition-tooltip alignment="center" direction="bottom" tip="tip text" />
+```
+
+## Attributes
+
+- alignment: start, center or end.
+- direction: 'top', 'left', 'right', 'bottom'
+- tip: text displayed on tip

--- a/packages/core/src/components/cv-tooltip/cv-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-tooltip.vue
@@ -1,11 +1,13 @@
 <template>
-  <div class="cv-tooltip bx--tooltip--icon">
-    <div tabindex="0" class="bx--tooltip__trigger" :class="`bx--tooltip--icon__${direction}`" :aria-label="tip">
-      <slot>
-        <Information16 />
-      </slot>
-    </div>
-  </div>
+  <button
+    class="cv-tooltip bx--tooltip__trigger bx--tooltip--a11y"
+    :class="`bx--tooltip--${direction} bx--tooltip--align-${alignment}`"
+  >
+    <span class="bx--assistive-text">{{ tip }}</span>
+    <slot>
+      <Information16 />
+    </slot>
+  </button>
 </template>
 
 <script>
@@ -15,6 +17,7 @@ export default {
   name: 'CvTooltip',
   components: { Information16 },
   props: {
+    alignment: { type: String, default: 'center', validator: val => ['start', 'center', 'end'].includes(val) },
     direction: {
       type: String,
       default: 'top',

--- a/packages/core/src/components/cv-tooltip/cv-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-tooltip.vue
@@ -2,6 +2,7 @@
   <button
     class="cv-tooltip bx--tooltip__trigger bx--tooltip--a11y"
     :class="`bx--tooltip--${direction} bx--tooltip--align-${alignment}`"
+    role="button"
   >
     <span class="bx--assistive-text">{{ tip }}</span>
     <slot>

--- a/storybook/stories/cv-tooltip-story.js
+++ b/storybook/stories/cv-tooltip-story.js
@@ -14,6 +14,22 @@ const storiesExperimental = storiesOf('Experimental/CvTooltip', module);
 import Filter16 from '@carbon/icons-vue/es/filter/16';
 
 let preKnobs = {
+  alignment: {
+    group: 'attr',
+    type: select,
+    config: [
+      'alignment',
+      {
+        Start: 'start',
+        Center: 'center',
+        End: 'end',
+      },
+      'center',
+      // consts.CONFIG,// fails when used with number in storybook 4.1.4
+    ],
+    inline: true,
+    prop: 'alignment',
+  },
   direction: {
     group: 'attr',
     type: select,
@@ -114,6 +130,22 @@ for (const story of storySet) {
 // /* ----------------------------------------------------- */
 
 preKnobs = {
+  alignment: {
+    group: 'attr',
+    type: select,
+    config: [
+      'alignment',
+      {
+        Start: 'start',
+        Center: 'center',
+        End: 'end',
+      },
+      'center',
+      // consts.CONFIG,// fails when used with number in storybook 4.1.4
+    ],
+    inline: true,
+    prop: 'alignment',
+  },
   direction: {
     group: 'attr',
     type: select,
@@ -121,7 +153,9 @@ preKnobs = {
       'direction',
       {
         Top: 'top',
+        Right: 'right',
         Bottom: 'bottom',
+        Left: 'left',
       },
       'bottom',
       // consts.CONFIG,// fails when used with number in storybook 4.1.4
@@ -185,6 +219,22 @@ for (const story of storySet) {
 // /* ----------------------------------------------------- */
 
 preKnobs = {
+  alignment: {
+    group: 'attr',
+    type: select,
+    config: [
+      'alignment',
+      {
+        Start: 'start',
+        Center: 'center',
+        End: 'end',
+      },
+      'center',
+      // consts.CONFIG,// fails when used with number in storybook 4.1.4
+    ],
+    inline: true,
+    prop: 'alignment',
+  },
   direction: {
     group: 'attr',
     type: select,


### PR DESCRIPTION
Part of #581

Update CvTooltip and variants formats to 10-7 button version

#### Changelog

M       packages/core/src/components/cv-tooltip/cv-definition-tooltip.vue
M       packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
M       packages/core/src/components/cv-tooltip/cv-tooltip-notes.md
M       packages/core/src/components/cv-tooltip/cv-tooltip.vue
M       storybook/stories/cv-tooltip-story.js