### PR TITLE
fix: replace trimright with trim for wider support

### DIFF
--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -306,7 +306,7 @@ export default {
       const zebraClass = this.zebra ? `${prefix}zebra ` : '';
       const borderlessClass = this.borderless ? `${prefix}no-border ` : '';
       const skeletonClass = this.skeleton ? `bx--skeleton` : '';
-      return `${sizeClass}${zebraClass}${borderlessClass}${skeletonClass}`.trimRight();
+      return `${sizeClass}${zebraClass}${borderlessClass}${skeletonClass}`.trim();
     },
     headingStyle() {
       return index => this.dataColumns[index].headingStyle;


### PR DESCRIPTION
Closes #615 

Remove use of trimRight for IE11  support.

#### Changelog

m  packages/core/src/components/cv-data-table/cv-data-table.vue 
