### PR TITLE
Allow the number input to work with number and string values

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.15.0-canary.x (Oct 18th 2019)
+## 2.15.0 (Oct 24th 2019)
 
 ### Feat
 
@@ -19,6 +19,9 @@
   - CvNumberInput
   - CvOverflowMenu
   - CvToastNotification
+  - CvTextInput
+  - CvToggle
+  - CvTags
 - Add expand all to data table
 - Add inline link
 - Add nested list ordering
@@ -26,11 +29,14 @@
 - Tests for CvCheckbox, CvToggle, CvBreadcrumb added
 - Rework tabs component to behave better when dynamically adding/removing tabs.
 - Added CvTabs property no-default-to-first option to revent auto default to first tab.
+- Add hover expand for header menu items
+- Add keyboard scroll to modal dialog, suppressing background scroll.
 
 ### Fix
 
 - Uploader skeleton typo
 - CvTabs behaviour when switching tab set (beforeDestory event name typo)
+- Remove trimRight usage for wider support
 
 ### Chore
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.16.0-canary.0 (Oct 24th 2019)
+
+### Feat
+
+Allow number input to work with string or number for value, v-model and events.
+
+### Fix
+
 ## 2.15.0 (Oct 24th 2019)
 
 ### Feat

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/vue",
   "description": "A collection of components for the Carbon Design System built using Vue.js",
-  "version": "2.15.0-canary.9",
+  "version": "2.15.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/core/src/components/cv-number-input/cv-number-input-notes.md
+++ b/packages/core/src/components/cv-number-input/cv-number-input-notes.md
@@ -28,11 +28,15 @@ http://www.carbondesignsystem.com/components/number-input/code
 - invalid-message: optional error message
 - label: the label text for the input
 - theme: optional 'light',
-- value: optional initial value of the input,
+- value: optional initial value of the input (string or number)
 - ariaLabelForDownButton: optional defaults to 'Decrease number input'
 - ariaLabelForUpButton: optional defaults to 'Increase number input'
 
 Other standard props e.g. disabled
+
+## v-model
+
+The value and/or v-model attributes can be integers represented by string or number types. The same type will be raised in events as is supplied to value or v-model attributes.
 
 ## slots
 

--- a/packages/core/src/components/cv-number-input/cv-number-input.vue
+++ b/packages/core/src/components/cv-number-input/cv-number-input.vue
@@ -61,7 +61,7 @@ export default {
     helperText: { type: String, default: undefined },
     invalidMessage: { type: String, default: undefined },
     label: String,
-    value: String,
+    value: { type: [String, Number], default: '' },
     invalid: /* deprecate */ {
       type: Boolean,
       default: undefined,
@@ -77,12 +77,12 @@ export default {
   },
   data() {
     return {
-      internalValue: this.value,
+      internalValue: this.valueAsString(this.value),
     };
   },
   watch: {
     value() {
-      this.internalValue = this.value;
+      this.internalValue = this.valueAsString(this.value);
     },
   },
   computed: {
@@ -91,7 +91,7 @@ export default {
     // https://vuejs.org/v2/guide/components-custom-events.html#Customizing-Component-v-model
     inputListeners() {
       return Object.assign({}, this.$listeners, {
-        input: () => this.$emit('input', this.internalValue),
+        input: () => this.emitValue(),
       });
     },
     internalIntValue() {
@@ -112,11 +112,24 @@ export default {
   methods: {
     doUp() {
       this.internalValue = `${this.internalIntValue + 1}`;
-      this.$emit('input', this.internalValue);
+      this.emitValue();
     },
     doDown() {
       this.internalValue = `${this.internalIntValue - 1}`;
-      this.$emit('input', this.internalValue);
+      this.emitValue();
+    },
+    emitValue() {
+      if (typeof this.value === 'number') {
+        this.$emit('input', this.internalIntValue);
+      } else {
+        this.$emit('input', this.internalValue);
+      }
+    },
+    valueAsString(val) {
+      if (typeof val === 'number') {
+        return '' + val;
+      }
+      return val;
     },
   },
 };

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook",
-  "version": "2.15.0-canary.9",
+  "version": "2.15.0",
   "private": true,
   "description": "> TODO: description",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",
-    "@carbon/vue": "^2.15.0-canary.9",
+    "@carbon/vue": "^2.15.0",
     "@storybook/addon-actions": "^5.2.1",
     "@storybook/addon-knobs": "^5.2.1",
     "@storybook/addon-notes": "^5.2.1",

--- a/storybook/stories/cv-number-input-story.js
+++ b/storybook/stories/cv-number-input-story.js
@@ -63,9 +63,19 @@ let preKnobs = {
     prop: 'value',
     value: val => `${val}`,
   },
+  intValue: {
+    group: 'attr',
+    type: number,
+    config: ['value', 0], // consts.CONFIG], // fails when used with number in storybook 4.1.4
+    prop: 'value',
+  },
   vModel: {
     group: 'attr',
     value: `v-model="modelValue"`,
+  },
+  vModelInt: {
+    group: 'attr',
+    value: `v-model="modelValueInt"`,
   },
   events: {
     group: 'attr',
@@ -76,15 +86,19 @@ let preKnobs = {
 let variants = [
   {
     name: 'default',
-    excludes: ['vModel', 'events', 'invalidMessageSlot', 'helperTextSlot'],
+    excludes: ['vModel', 'invalidMessageSlot', 'helperTextSlot', 'intValue', 'vModelInt'],
+  },
+  {
+    name: 'integer value',
+    excludes: ['vModel', 'invalidMessageSlot', 'helperTextSlot', 'value', 'vModelInt'],
   },
   {
     name: 'helper and invalid slots',
-    excludes: ['vModel', 'events'],
+    excludes: ['vModel', 'events', 'intValue', 'vModelInt'],
   },
   { name: 'minimal', includes: ['label'] },
-  { name: 'events', includes: ['label', 'events'] },
-  { name: 'vModel', includes: ['label', 'vModel'] },
+  { name: 'vModel', includes: ['label', 'vModel', 'events'] },
+  { name: 'vModelInt', includes: ['label', 'vModelInt', 'events'] },
 ];
 
 let storySet = knobsHelper.getStorySet(variants, preKnobs);
@@ -113,7 +127,7 @@ for (const story of storySet) {
       <template slot="other">
         <div v-if="${templateString.indexOf('v-model') > 0}">
           <label>Model value:
-            <input type="number" v-model="modelValue" />
+            <input type="number" v-model="modelValue"/>
           </label>
         </div>
       </template>
@@ -127,7 +141,27 @@ for (const story of storySet) {
         data() {
           return {
             modelValue: '100',
+            modelValueInt: 100,
+            storyName: story.name,
           };
+        },
+        watch: {
+          modelValue() {
+            let intVal = parseInt(this.modelValue, 10);
+
+            if (isNaN(intVal)) {
+              intVal = 0;
+            }
+            if (intVal !== this.modelValueInt) {
+              this.modelValueInt = intVal;
+            }
+          },
+          modelValueInt() {
+            let val = '' + this.modelValueInt;
+            if (this.modelValue !== val) {
+              this.modelValue = '' + this.modelValueInt;
+            }
+          },
         },
         methods: {
           onInput: action('cv-number-input - input event'),


### PR DESCRIPTION
Closes #630

Allow the number input to work with number and string values.

#### Changelog

M       packages/core/CHANGELOG.md
M       packages/core/src/components/cv-number-input/cv-number-input-notes.md
M       packages/core/src/components/cv-number-input/cv-number-input.vue
M       storybook/stories/cv-number-input-story.js
