### PR TITLE
fix: toggle tests broken by 10-7 update

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-tag.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-tag.test.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CvTag matches tag filter snapshot 1`] = `
-<span tabindex="0" title="Clear filter" class="cv-tag bx--tag bx--tag--filter bx--tag--filter">
+<span tabindex="0" role="listitem" title="Clear filter" class="cv-tag bx--tag bx--tag--filter bx--tag--filter">
   I am a filter tag
   <close16-stub aria-label="Clear filter" role="button"></close16-stub></span>
 `;
 
 exports[`CvTag matches tag snapshot 1`] = `
-<span tabindex="0" class="cv-tag bx--tag bx--tag--red">
+<span tabindex="0" role="listitem" class="cv-tag bx--tag bx--tag--red">
   I am a tag
   <!----></span>
 `;

--- a/packages/core/__tests__/cv-toggle.test.js
+++ b/packages/core/__tests__/cv-toggle.test.js
@@ -9,40 +9,38 @@ describe('CvToggle', () => {
   it('should render with the appropriate kind', () => {
     const propsData = { label: 'test', value: 'check-1' };
     const wrapper = shallow(CvToggle, { propsData });
-    expect(wrapper.find('input').classes(`${prefix}--toggle`)).toEqual(true);
-    expect(wrapper.find('label').classes(`${prefix}--toggle__label`)).toEqual(true);
+    expect(wrapper.find('input').classes(`${prefix}--toggle-input`)).toEqual(true);
+    expect(wrapper.find('label').classes(`${prefix}--toggle-input__label`)).toEqual(true);
     expect(
       wrapper
         .findAll('div')
         .at(0)
         .classes(`${prefix}--form-item`)
     ).toEqual(true);
-    expect(
-      wrapper
-        .findAll('div')
-        .at(1)
-        .classes(`${prefix}--toggle__text--left`)
-    ).toEqual(true);
-    expect(
-      wrapper
-        .findAll('div')
-        .at(2)
-        .classes(`${prefix}--toggle__text--right`)
-    ).toEqual(true);
-    expect(wrapper.find('span').classes(`${prefix}--toggle__appearance`)).toEqual(true);
+    expect(wrapper.find(`${prefix}--toggle__text--off`)).toBeDefined();
+    expect(wrapper.find(`${prefix}--toggle__text--on`)).toBeDefined();
   });
 
-  it('should render with the appropriate kind when label is set', () => {
+  it('should render with the appropriate label when label is set', () => {
     const propsData = { label: 'test', value: 'check-1' };
     const wrapper = shallow(CvToggle, { propsData });
-    expect(wrapper.classes(`${prefix}--fieldset`)).toEqual(true);
-    expect(wrapper.find('legend').classes(`${prefix}--label`)).toEqual(true);
+    const label = wrapper.find('label');
+    expect(label.classes(`${prefix}--toggle-input__label`)).toEqual(true);
+    expect(label.html()).toContain('test');
+  });
+
+  it('should render aria-label when label is set and hideLabel is true', () => {
+    const propsData = { label: 'test', value: 'check-1', hideLabel: true };
+    const wrapper = shallow(CvToggle, { propsData });
+    const label = wrapper.find('label');
+    expect(label.classes(`${prefix}--toggle-input__label`)).toEqual(true);
+    expect(label.attributes('aria-label')).toBe('test');
   });
 
   it('should render with the appropriate kind when small is true', () => {
     const propsData = { label: 'test', small: true, value: 'check-1' };
     const wrapper = shallow(CvToggle, { propsData });
-    expect(wrapper.find('input').classes(`${prefix}--toggle--small`)).toEqual(true);
+    expect(wrapper.find('input').classes(`${prefix}--toggle-input--small`)).toEqual(true);
     expect(wrapper.find('svg').classes(`${prefix}--toggle__check`)).toEqual(true);
   });
 


### PR DESCRIPTION
Corrects CvToggle tests broken by 10-7 update

#### Changelog

M       packages/core/__tests__/__snapshots__/cv-tag.test.js.snap
M       packages/core/__tests__/cv-toggle.test.js