### PR TITLE
feat: add tests for cvnumberinput

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-number-input.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-number-input.test.js.snap
@@ -1,0 +1,126 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CvNumberInput should match snapshot when all props are default 1`] = `
+<cv-wrapper-stub tagtype="div" class="cv-number-input bx--form-item">
+  <div data-numberinput="" class="bx--number"><label for="1" class="bx--label"></label>
+    <!---->
+    <div class="bx--number__input-wrapper"><input id="1" type="number">
+      <!---->
+      <div class="bx--number__controls"><button type="button" aria-label="Increase number input" class="bx--number__control-btn up-icon">
+          <caretupglyph-stub></caretupglyph-stub>
+        </button> <button type="button" aria-label="Decrease number input" class="bx--number__control-btn down-icon">
+          <caretdownglyph-stub></caretdownglyph-stub>
+        </button></div>
+    </div>
+    <!---->
+  </div>
+</cv-wrapper-stub>
+`;
+
+exports[`CvNumberInput should match snapshot when all props are provided 1`] = `
+<cv-wrapper-stub tagtype="" class="cv-number-input bx--form-item">
+  <div data-numberinput="" data-invalid="14" class="bx--number bx--number--helpertext cv-number-input"><label for="1" class="bx--label">label</label>
+    <div class="bx--form__helper-text">helperText</div>
+    <div class="bx--number__input-wrapper"><input id="1" type="number">
+      <warningfilled16-stub class="bx--number__invalid"></warningfilled16-stub>
+      <div class="bx--number__controls"><button type="button" aria-label="ariaLabelForUpButton" class="bx--number__control-btn up-icon">
+          <caretupglyph-stub></caretupglyph-stub>
+        </button> <button type="button" aria-label="ariaLabelForDownButton" class="bx--number__control-btn down-icon">
+          <caretdownglyph-stub></caretdownglyph-stub>
+        </button></div>
+    </div>
+    <div class="bx--form-requirement">invalidMessage</div>
+  </div>
+</cv-wrapper-stub>
+`;
+
+exports[`CvNumberInput should match snapshot when it is not a formItem 1`] = `
+<cv-wrapper-stub tagtype="" class="cv-number-input bx--form-item">
+  <div data-numberinput="" class="bx--number cv-number-input"><label for="1" class="bx--label"></label>
+    <!---->
+    <div class="bx--number__input-wrapper"><input id="1" type="number">
+      <!---->
+      <div class="bx--number__controls"><button type="button" aria-label="Increase number input" class="bx--number__control-btn up-icon">
+          <caretupglyph-stub></caretupglyph-stub>
+        </button> <button type="button" aria-label="Decrease number input" class="bx--number__control-btn down-icon">
+          <caretdownglyph-stub></caretdownglyph-stub>
+        </button></div>
+    </div>
+    <!---->
+  </div>
+</cv-wrapper-stub>
+`;
+
+exports[`CvNumberInput should match snapshot when light theme 1`] = `
+<cv-wrapper-stub tagtype="" class="cv-number-input bx--form-item">
+  <div data-numberinput="" class="bx--number bx--number--light cv-number-input"><label for="1" class="bx--label"></label>
+    <!---->
+    <div class="bx--number__input-wrapper"><input id="1" type="number">
+      <!---->
+      <div class="bx--number__controls"><button type="button" aria-label="Increase number input" class="bx--number__control-btn up-icon">
+          <caretupglyph-stub></caretupglyph-stub>
+        </button> <button type="button" aria-label="Decrease number input" class="bx--number__control-btn down-icon">
+          <caretdownglyph-stub></caretdownglyph-stub>
+        </button></div>
+    </div>
+    <!---->
+  </div>
+</cv-wrapper-stub>
+`;
+
+exports[`CvNumberInput should match snapshot when value is Number 1`] = `
+<cv-wrapper-stub tagtype="" class="cv-number-input bx--form-item">
+  <div data-numberinput="" class="bx--number cv-number-input"><label for="1" class="bx--label"></label>
+    <!---->
+    <div class="bx--number__input-wrapper"><input id="1" type="number">
+      <!---->
+      <div class="bx--number__controls"><button type="button" aria-label="Increase number input" class="bx--number__control-btn up-icon">
+          <caretupglyph-stub></caretupglyph-stub>
+        </button> <button type="button" aria-label="Decrease number input" class="bx--number__control-btn down-icon">
+          <caretdownglyph-stub></caretdownglyph-stub>
+        </button></div>
+    </div>
+    <!---->
+  </div>
+</cv-wrapper-stub>
+`;
+
+exports[`CvNumberInput should match snapshot when value is String 1`] = `
+<cv-wrapper-stub tagtype="" class="cv-number-input bx--form-item">
+  <div data-numberinput="" class="bx--number cv-number-input"><label for="1" class="bx--label"></label>
+    <!---->
+    <div class="bx--number__input-wrapper"><input id="1" type="number">
+      <!---->
+      <div class="bx--number__controls"><button type="button" aria-label="Increase number input" class="bx--number__control-btn up-icon">
+          <caretupglyph-stub></caretupglyph-stub>
+        </button> <button type="button" aria-label="Decrease number input" class="bx--number__control-btn down-icon">
+          <caretdownglyph-stub></caretdownglyph-stub>
+        </button></div>
+    </div>
+    <!---->
+  </div>
+</cv-wrapper-stub>
+`;
+
+exports[`CvNumberInput should match snapshot when value is invalid 1`] = `
+<cv-wrapper-stub tagtype="" class="cv-number-input bx--form-item">
+  <div data-numberinput="" class="bx--number cv-number-input"><label for="1" class="bx--label"></label>
+    <!---->
+    <div class="bx--number__input-wrapper"><input id="1" type="number">
+      <!---->
+      <div class="bx--number__controls"><button type="button" aria-label="Increase number input" class="bx--number__control-btn up-icon">
+          <caretupglyph-stub></caretupglyph-stub>
+        </button> <button type="button" aria-label="Decrease number input" class="bx--number__control-btn down-icon">
+          <caretdownglyph-stub></caretdownglyph-stub>
+        </button></div>
+    </div>
+    <!---->
+  </div>
+</cv-wrapper-stub>
+`;
+
+exports[`CvNumberInputSkeleton should match snapshot 1`] = `
+<div class="cv-number-input bx--form-item"><label class="bx--label bx--skeleton"></label>
+  <div class="bx--number bx--skeleton"></div>
+</div>
+`;

--- a/packages/core/__tests__/__snapshots__/cv-number-input.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-number-input.test.js.snap
@@ -34,6 +34,40 @@ exports[`CvNumberInput should match snapshot when all props are provided 1`] = `
 </cv-wrapper-stub>
 `;
 
+exports[`CvNumberInput should match snapshot when helper-text slot is provided 1`] = `
+<cv-wrapper-stub tagtype="div" class="cv-number-input bx--form-item">
+  <div data-numberinput="" class="bx--number bx--number--helpertext"><label for="1" class="bx--label"></label>
+    <div class="bx--form__helper-text">test</div>
+    <div class="bx--number__input-wrapper"><input id="1" type="number">
+      <!---->
+      <div class="bx--number__controls"><button type="button" aria-label="Increase number input" class="bx--number__control-btn up-icon">
+          <caretupglyph-stub></caretupglyph-stub>
+        </button> <button type="button" aria-label="Decrease number input" class="bx--number__control-btn down-icon">
+          <caretdownglyph-stub></caretdownglyph-stub>
+        </button></div>
+    </div>
+    <!---->
+  </div>
+</cv-wrapper-stub>
+`;
+
+exports[`CvNumberInput should match snapshot when invalid-message slot is provided 1`] = `
+<cv-wrapper-stub tagtype="div" class="cv-number-input bx--form-item">
+  <div data-numberinput="" data-invalid="4" class="bx--number"><label for="1" class="bx--label"></label>
+    <!---->
+    <div class="bx--number__input-wrapper"><input id="1" type="number">
+      <warningfilled16-stub class="bx--number__invalid"></warningfilled16-stub>
+      <div class="bx--number__controls"><button type="button" aria-label="Increase number input" class="bx--number__control-btn up-icon">
+          <caretupglyph-stub></caretupglyph-stub>
+        </button> <button type="button" aria-label="Decrease number input" class="bx--number__control-btn down-icon">
+          <caretdownglyph-stub></caretdownglyph-stub>
+        </button></div>
+    </div>
+    <div class="bx--form-requirement">test</div>
+  </div>
+</cv-wrapper-stub>
+`;
+
 exports[`CvNumberInput should match snapshot when it is not a formItem 1`] = `
 <cv-wrapper-stub tagtype="" class="cv-number-input bx--form-item">
   <div data-numberinput="" class="bx--number cv-number-input"><label for="1" class="bx--label"></label>
@@ -86,23 +120,6 @@ exports[`CvNumberInput should match snapshot when value is Number 1`] = `
 `;
 
 exports[`CvNumberInput should match snapshot when value is String 1`] = `
-<cv-wrapper-stub tagtype="" class="cv-number-input bx--form-item">
-  <div data-numberinput="" class="bx--number cv-number-input"><label for="1" class="bx--label"></label>
-    <!---->
-    <div class="bx--number__input-wrapper"><input id="1" type="number">
-      <!---->
-      <div class="bx--number__controls"><button type="button" aria-label="Increase number input" class="bx--number__control-btn up-icon">
-          <caretupglyph-stub></caretupglyph-stub>
-        </button> <button type="button" aria-label="Decrease number input" class="bx--number__control-btn down-icon">
-          <caretdownglyph-stub></caretdownglyph-stub>
-        </button></div>
-    </div>
-    <!---->
-  </div>
-</cv-wrapper-stub>
-`;
-
-exports[`CvNumberInput should match snapshot when value is invalid 1`] = `
 <cv-wrapper-stub tagtype="" class="cv-number-input bx--form-item">
   <div data-numberinput="" class="bx--number cv-number-input"><label for="1" class="bx--label"></label>
     <!---->

--- a/packages/core/__tests__/_helpers.js
+++ b/packages/core/__tests__/_helpers.js
@@ -48,6 +48,11 @@ export const testComponent = {
       expect(getComponentProp(component, prop).default).toBeDefined();
     });
   },
+  prosHaveDefaultOfUndefined: (component, props) => {
+    test.each(props)('has a prop with a default undefined: %s', prop => {
+      expect(getComponentProp(component, prop).default).not.toBeDefined();
+    });
+  },
 };
 
 const PLACEMENT_STRING = 'Now is > the FOO &amp; of &#128169; our (discontent)';

--- a/packages/core/__tests__/cv-number-input.test.js
+++ b/packages/core/__tests__/cv-number-input.test.js
@@ -1,11 +1,12 @@
-import { shallowMount as shallow, createLocalVue } from '@vue/test-utils';
-import { testComponent, testInstance } from './_helpers';
+import { shallowMount as shallow } from '@vue/test-utils';
+import { testComponent } from './_helpers';
 import { CvNumberInput, CvNumberInputSkeleton } from '@/components/cv-number-input';
-import { settings } from 'carbon-components';
-
-const { prefix } = settings;
 
 describe('CvNumberInput', () => {
+  // ***************
+  // PROP CHECKS
+  // ***************
+
   testComponent.propsHaveDefault(CvNumberInput, [
     'formItem',
     'ariaLabelForUpButton',
@@ -23,6 +24,10 @@ describe('CvNumberInput', () => {
 
   testComponent.prosHaveDefaultOfUndefined(CvNumberInput, ['helperText', 'invalidMessage']);
 
+  // ***************
+  // SNAPSHOT TESTS
+  // ***************
+
   it('should match snapshot when all props are default', () => {
     const id = '1';
     const wrapper = shallow(CvNumberInput, { propsData: { id } });
@@ -32,7 +37,6 @@ describe('CvNumberInput', () => {
   it('should match snapshot when it is not a formItem', () => {
     const formItem = false;
     const id = '1';
-
     const wrapper = shallow(CvNumberInput, { propsData: { formItem, id } });
     expect(wrapper.html()).toMatchSnapshot();
   });
@@ -85,13 +89,41 @@ describe('CvNumberInput', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it('should match snapshot when value is invalid', () => {
-    const formItem = false;
+  it('should match snapshot when invalid-message slot is provided', () => {
     const id = '1';
-    const value = 'not a number';
-    const wrapper = shallow(CvNumberInput, { propsData: { formItem, id, value } });
+    const value = 5;
+    const invalidMessage = 'test';
+    const wrapper = shallow(
+      CvNumberInput,
+      { propsData: { id, value, invalidMessage } },
+      {
+        slots: {
+          'invalid-message': '<div class="fake-slot">my invalid message</div>',
+        },
+      }
+    );
     expect(wrapper.html()).toMatchSnapshot();
   });
+
+  it('should match snapshot when helper-text slot is provided', () => {
+    const id = '1';
+    const value = 5;
+    const helperText = 'test';
+    const wrapper = shallow(
+      CvNumberInput,
+      { propsData: { id, value, helperText } },
+      {
+        slots: {
+          'helper-text': '<div class="fake-slot">my helper text</div>',
+        },
+      }
+    );
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  // ***************
+  // FUNCTIONAL TESTS
+  // ***************
 
   it('should emit input on doDown', () => {
     const id = '1';
@@ -114,14 +146,6 @@ describe('CvNumberInput', () => {
     expect(wrapper.emitted().input).toBeTruthy();
   });
 
-  it('should emit Number when value prop is Number', () => {
-    const id = '1';
-    const value = 5;
-    const wrapper = shallow(CvNumberInput, { propsData: { id, value } });
-    wrapper.find('.up-icon').trigger('click');
-    expect(wrapper.emitted().input[0]).toEqual([value + 1]);
-  });
-
   it('should emit String when value prop is String', () => {
     const id = '1';
     const value = '5';
@@ -130,12 +154,20 @@ describe('CvNumberInput', () => {
     expect(wrapper.emitted().input[0]).toEqual([(parseInt(value) + 1).toString()]);
   });
 
-  it('should increase value by 1 when doUp', () => {
+  it('should emit value encreased by 1 on doUp', () => {
     const id = '1';
     const value = 2;
     const wrapper = shallow(CvNumberInput, { propsData: { id, value } });
     wrapper.find('.up-icon').trigger('click');
     expect(wrapper.emitted().input[0]).toEqual([value + 1]);
+  });
+
+  it('should emit value decreased by 1 on doDown', () => {
+    const id = '1';
+    const value = 10;
+    const wrapper = shallow(CvNumberInput, { propsData: { id, value } });
+    wrapper.find('.down-icon').trigger('click');
+    expect(wrapper.emitted().input[0]).toEqual([value - 1]);
   });
 
   it('should emit the correct value on input', () => {
@@ -160,8 +192,20 @@ describe('CvNumberInput', () => {
 });
 
 describe('CvNumberInputSkeleton', () => {
+  // ***************
+  // PROP CHECKS
+  // ***************
+
+  // ***************
+  // SNAPSHOT TESTS
+  // ***************
+
   it('should match snapshot', () => {
     const wrapper = shallow(CvNumberInputSkeleton);
     expect(wrapper.html()).toMatchSnapshot();
   });
+
+  // ***************
+  // FUNCTIONAL TESTS
+  // ***************
 });

--- a/packages/core/__tests__/cv-number-input.test.js
+++ b/packages/core/__tests__/cv-number-input.test.js
@@ -1,0 +1,167 @@
+import { shallowMount as shallow, createLocalVue } from '@vue/test-utils';
+import { testComponent, testInstance } from './_helpers';
+import { CvNumberInput, CvNumberInputSkeleton } from '@/components/cv-number-input';
+import { settings } from 'carbon-components';
+
+const { prefix } = settings;
+
+describe('CvNumberInput', () => {
+  testComponent.propsHaveDefault(CvNumberInput, [
+    'formItem',
+    'ariaLabelForUpButton',
+    'ariaLabelForDownButton',
+    'label',
+    'value',
+  ]);
+  testComponent.propsAreType(CvNumberInput, ['value'], [String, Number]);
+  testComponent.propsAreType(CvNumberInput, ['formItem', 'invalid'], Boolean);
+  testComponent.propsAreType(
+    CvNumberInput,
+    ['helperText', 'invalidMessage', 'label', 'ariaLabelForUpButton', 'ariaLabelForDownButton'],
+    String
+  );
+
+  testComponent.prosHaveDefaultOfUndefined(CvNumberInput, ['helperText', 'invalidMessage']);
+
+  it('should match snapshot when all props are default', () => {
+    const id = '1';
+    const wrapper = shallow(CvNumberInput, { propsData: { id } });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should match snapshot when it is not a formItem', () => {
+    const formItem = false;
+    const id = '1';
+
+    const wrapper = shallow(CvNumberInput, { propsData: { formItem, id } });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should match snapshot when all props are provided', () => {
+    const formItem = false;
+    const id = '1';
+    const helperText = 'helperText';
+    const invalidMessage = 'invalidMessage';
+    const label = 'label';
+    const value = 5;
+    const ariaLabelForDownButton = 'ariaLabelForDownButton';
+    const ariaLabelForUpButton = 'ariaLabelForUpButton';
+    const wrapper = shallow(CvNumberInput, {
+      propsData: {
+        formItem,
+        id,
+        helperText,
+        invalidMessage,
+        label,
+        value,
+        ariaLabelForDownButton,
+        ariaLabelForUpButton,
+      },
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should match snapshot when value is String', () => {
+    const formItem = false;
+    const id = '1';
+    const value = '15';
+    const wrapper = shallow(CvNumberInput, { propsData: { formItem, id, value } });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should match snapshot when value is Number', () => {
+    const formItem = false;
+    const id = '1';
+    const value = 5;
+    const wrapper = shallow(CvNumberInput, { propsData: { formItem, id, value } });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should match snapshot when light theme', () => {
+    const formItem = false;
+    const id = '1';
+    const theme = 'light';
+    const wrapper = shallow(CvNumberInput, { propsData: { formItem, id, theme } });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should match snapshot when value is invalid', () => {
+    const formItem = false;
+    const id = '1';
+    const value = 'not a number';
+    const wrapper = shallow(CvNumberInput, { propsData: { formItem, id, value } });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should emit input on doDown', () => {
+    const id = '1';
+    const wrapper = shallow(CvNumberInput, { propsData: { id } });
+    wrapper.find('.down-icon').trigger('click');
+    expect(wrapper.emitted().input).toBeTruthy();
+  });
+
+  it('should emit input on doUp', () => {
+    const id = '1';
+    const wrapper = shallow(CvNumberInput, { propsData: { id } });
+    wrapper.find('.up-icon').trigger('click');
+    expect(wrapper.emitted().input).toBeTruthy();
+  });
+
+  it('should emit input on change', () => {
+    const id = '1';
+    const wrapper = shallow(CvNumberInput, { propsData: { id } });
+    wrapper.find('input').trigger('input');
+    expect(wrapper.emitted().input).toBeTruthy();
+  });
+
+  it('should emit Number when value prop is Number', () => {
+    const id = '1';
+    const value = 5;
+    const wrapper = shallow(CvNumberInput, { propsData: { id, value } });
+    wrapper.find('.up-icon').trigger('click');
+    expect(wrapper.emitted().input[0]).toEqual([value + 1]);
+  });
+
+  it('should emit String when value prop is String', () => {
+    const id = '1';
+    const value = '5';
+    const wrapper = shallow(CvNumberInput, { propsData: { id, value } });
+    wrapper.find('.up-icon').trigger('click');
+    expect(wrapper.emitted().input[0]).toEqual([(parseInt(value) + 1).toString()]);
+  });
+
+  it('should increase value by 1 when doUp', () => {
+    const id = '1';
+    const value = 2;
+    const wrapper = shallow(CvNumberInput, { propsData: { id, value } });
+    wrapper.find('.up-icon').trigger('click');
+    expect(wrapper.emitted().input[0]).toEqual([value + 1]);
+  });
+
+  it('should emit the correct value on input', () => {
+    const id = '1';
+    const value = 2;
+    const inputValue = 100;
+    const wrapper = shallow(CvNumberInput, { propsData: { id, value } });
+    wrapper.find('input').setValue(inputValue);
+    wrapper.find('input').trigger('input');
+    expect(wrapper.emitted().input[0]).toEqual([inputValue]);
+  });
+
+  it('should watch value', () => {
+    const id = '1';
+    const value1 = 2;
+    const value2 = 80;
+    const wrapper = shallow(CvNumberInput, { propsData: { id, value: value1 } });
+    expect(wrapper.vm.value).toEqual(value1);
+    wrapper.setProps({ value: value2 });
+    expect(wrapper.vm.value).toEqual(value2);
+  });
+});
+
+describe('CvNumberInputSkeleton', () => {
+  it('should match snapshot', () => {
+    const wrapper = shallow(CvNumberInputSkeleton);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+});

--- a/packages/core/src/components/cv-number-input/cv-number-input.vue
+++ b/packages/core/src/components/cv-number-input/cv-number-input.vue
@@ -60,7 +60,7 @@ export default {
     formItem: { type: Boolean, default: true },
     helperText: { type: String, default: undefined },
     invalidMessage: { type: String, default: undefined },
-    label: String,
+    label: { type: String, default: '' },
     value: { type: [String, Number], default: '' },
     invalid: /* deprecate */ {
       type: Boolean,


### PR DESCRIPTION
#182 

Add tests for CvNumberInput. Added default value for `label` prop for CvNumberInput component.

#### Changelog

A       packages/core/__tests__/__snapshots__/cv-number-input.test.js.snap
M       packages/core/__tests__/_helpers.js
A       packages/core/__tests__/cv-number-input.test.js
M       packages/core/src/components/cv-number-input/cv-number-input.vue

#### Additional information

I am not sure I implemented the snapshot tests correctly.
 
Test Coverage:

![image](https://user-images.githubusercontent.com/5481483/67586639-64153080-f752-11e9-970e-e8b6856d4981.png)

