### PR TITLE
fix: role button usage when type was intended

### DIFF
--- a/packages/core/src/components/cv-button/cv-icon-button.vue
+++ b/packages/core/src/components/cv-button/cv-icon-button.vue
@@ -10,7 +10,7 @@
       },
     ]"
     v-on="$listeners"
-    role="button"
+    type="button"
   >
     <span class="bx--assistive-text">{{ tipText }}</span>
 

--- a/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
+++ b/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
@@ -4,7 +4,7 @@
       class="bx--overflow-menu__trigger bx--tooltip__trigger bx--tooltip--a11y"
       :class="[tipClasses, { 'bx--overflow-menu--open': open }]"
       aria-haspopup
-      role="button"
+      type="button"
       :aria-expanded="open"
       :aria-controls="`${uid}-menu`"
       :id="`${uid}-trigger`"

--- a/packages/core/src/components/cv-tooltip/cv-definition-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-definition-tooltip.vue
@@ -4,7 +4,7 @@
       :aria-describedby="`${uid}-label`"
       class="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition"
       :class="`bx--tooltip--${direction} bx--tooltip--align-${alignment}`"
-      role="button"
+      type="button"
     >
       {{ term }}
     </button>

--- a/packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
@@ -10,7 +10,7 @@
         :aria-controls="`${uid}`"
         aria-haspopup="true"
         ref="trigger"
-        role="button"
+        type="button"
         @click="toggle"
         @keydown.tab="onTriggerTab"
         @focusout="checkFocusOut"

--- a/packages/core/src/components/cv-tooltip/cv-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-tooltip.vue
@@ -2,7 +2,7 @@
   <button
     class="cv-tooltip bx--tooltip__trigger bx--tooltip--a11y"
     :class="`bx--tooltip--${direction} bx--tooltip--align-${alignment}`"
-    role="button"
+    type="button"
   >
     <span class="bx--assistive-text">{{ tip }}</span>
     <slot>


### PR DESCRIPTION
Fixes use of role button which should have been type button.

#### Changelog

M       packages/core/src/components/cv-button/cv-icon-button.vue
M       packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
M       packages/core/src/components/cv-tooltip/cv-definition-tooltip.vue
M       packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
M       packages/core/src/components/cv-tooltip/cv-tooltip.vue