### PR TITLE
fix: prop type test in case of plain prop

### DIFF
--- a/packages/core/__tests__/_helpers.js
+++ b/packages/core/__tests__/_helpers.js
@@ -35,10 +35,12 @@ export const testComponent = {
 
     test.each(props)(`has a prop of ${typeName} type: %s`, prop => {
       let componentProp = getComponentProp(component, prop);
+      let componentPropType = componentProp.type || componentProp;
+
       if (types.map) {
-        expect(componentProp.type).toEqual(expect.arrayContaining(types));
+        expect(componentPropType).toEqual(expect.arrayContaining(types));
       } else {
-        expect(componentProp.type).toBe(types);
+        expect(componentPropType).toBe(types);
       }
     });
   },


### PR DESCRIPTION
Fix prop type test which was failing when the property declaration was not the object form.

#### Changelog

m packages/core/__tests__/_helpers.js
