### PR TITLE
Button press twice fix

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-button.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-button.test.js.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[` 1`] = `
+<button role="button" class="cv-button bx--btn bx--btn--secondary bx--btn--field" tab-index="2" disabled="disabled">default slot content <addfilled16-stub class="bx--btn__icon"></addfilled16-stub>
+  <!----></button>
+`;
+
+exports[` 2`] = `
+<button role="button" class="cv-button bx--btn bx--btn--primary bx--btn--sm">default slot content
+  <!---->
+  <!----></button>
+`;
+
+exports[` 3`] = `
+<button role="button" class="cv-button bx--btn bx--btn--primary">default slot content
+  <!---->
+  <!----></button>
+`;
+
+exports[` 4`] = `
+<button type="button" class="cv-button bx--btn bx--btn--icon-only bx--btn--secondary bx--btn--field" tab-index="2" disabled="disabled"><span class="bx--assistive-text"></span>
+  <addfilled16-stub class="bx--btn__icon"></addfilled16-stub>
+  <!----></button>
+`;
+
+exports[` 5`] = `
+<button type="button" class="cv-button bx--btn bx--btn--icon-only bx--btn--primary bx--btn--sm"><span class="bx--assistive-text"></span>
+  <!---->
+  <!----></button>
+`;
+
+exports[` 6`] = `
+<button type="button" class="cv-button bx--btn bx--btn--icon-only bx--btn--primary"><span class="bx--assistive-text"></span>
+  <!---->
+  <!----></button>
+`;
+
+exports[` 7`] = `<button disabled="disabled" type="button" class="bx--btn bx--skeleton bx--btn--field"></button>`;
+
+exports[` 8`] = `<button disabled="disabled" type="button" class="bx--btn bx--skeleton bx--btn--sm"></button>`;
+
+exports[` 9`] = `<button disabled="disabled" type="button" class="bx--btn bx--skeleton"></button>`;

--- a/packages/core/__tests__/cv-button.test.js
+++ b/packages/core/__tests__/cv-button.test.js
@@ -1,75 +1,147 @@
 import { shallowMount as shallow, mount } from '@vue/test-utils';
 import { testComponent, testInstance } from './_helpers';
-import { CvButton } from '@/components/cv-button';
+import { CvButton, CvIconButton, CvButtonSkeleton } from '@/components/cv-button';
 import { settings } from 'carbon-components';
 import AddFilled16 from '@carbon/icons-vue/es/add--filled/16';
 
 const { prefix } = settings;
 
 describe('CvButton', () => {
+  // ***************
+  // PROP CHECKS
+  // ***************
   describe('Has expected properties', () => {
+    // Deprecated props not tested
     testComponent.propsHaveDefault(CvButton, ['kind']);
-    testComponent.propsAreType(CvButton, ['iconHref', 'kind'], String);
+    testComponent.propsAreType(CvButton, ['iconHref', 'kind', 'size'], String);
     testComponent.propsAreType(CvButton, ['icon'], [String, Object]);
+    testComponent.propsHaveDefault(CvButton, ['kind']);
+    testComponent.prosHaveDefaultOfUndefined(CvButton, ['size', 'icon']);
   });
 
-  describe('Renders as expected', () => {
-    const propsData = { kind: 'secondary', icon: AddFilled16, href: '/home', 'tab-index': 2 };
+  // ***************
+  // SNAPSHOT TESTS
+  // ***************
+
+  describe('Renders as expected field secondary with icon disabled', () => {
+    const propsData = { kind: 'secondary', icon: AddFilled16, 'tab-index': 2, disabled: true, size: 'field' };
     const wrapper = shallow(CvButton, { propsData, slots: { default: 'default slot content' } });
 
-    it('should render with the appropriate kind', () => {
-      expect(wrapper.classes(`${prefix}--btn`)).toEqual(true);
-      expect(wrapper.classes(`${prefix}--btn--secondary`)).toEqual(true);
-    });
-
-    it('should render href and tab-index', () => {
-      expect(wrapper.attributes('href')).toBe('/home');
-      expect(wrapper.attributes('tab-index')).toBe('2');
-    });
-
-    it('should render icon', () => {
-      const icon = wrapper.find('AddFilled16-stub');
-      expect(icon.is('AddFilled16-stub')).toBe(true);
-    });
-
-    it('should render default slot content', () => {
-      expect(wrapper.html().indexOf('default slot content')).toBeGreaterThan(-1);
-    });
+    expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it('Renders a default button as primary', () => {
-    const wrapper = shallow(CvButton);
-    expect(wrapper.classes(`${prefix}--btn--primary`)).toEqual(true);
+  describe('Renders as expected small primary', () => {
+    const propsData = { kind: 'primary', size: 'small' };
+    const wrapper = shallow(CvButton, { propsData, slots: { default: 'default slot content' } });
+
+    expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it('Renders a secondary kind button as secondary', () => {
-    const wrapper = shallow(CvButton, { propsData: { kind: 'secondary' } });
-    expect(wrapper.classes(`${prefix}--btn--secondary`)).toEqual(true);
+  describe('Renders as expected default', () => {
+    const propsData = {};
+    const wrapper = shallow(CvButton, { propsData, slots: { default: 'default slot content' } });
+
+    expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it('Renders a tertiary kind button as tertiary', () => {
-    const wrapper = shallow(CvButton, { propsData: { kind: 'tertiary' } });
-    expect(wrapper.classes(`${prefix}--btn--tertiary`)).toEqual(true);
-  });
-
-  it('Renders a ghost kind button as ghost', () => {
-    const wrapper = shallow(CvButton, { propsData: { kind: 'ghost' } });
-    expect(wrapper.classes(`${prefix}--btn--ghost`)).toEqual(true);
-  });
-
-  it('Renders a danger kind button as danger', () => {
-    const wrapper = shallow(CvButton, { propsData: { kind: 'danger' } });
-    expect(wrapper.classes(`${prefix}--btn--danger`)).toEqual(true);
-  });
-
-  it('Renders a danger--primary kind button as danger--primary', () => {
-    const wrapper = shallow(CvButton, { propsData: { kind: 'danger--primary' } });
-    expect(wrapper.classes(`${prefix}--btn--danger--primary`)).toEqual(true);
-  });
-
+  // ***************
+  // FUNCTIONAL TESTS
+  // ***************
   it('Raises click event when clicked', () => {
     const wrapper = shallow(CvButton);
     wrapper.find('button').trigger('click');
     expect(wrapper.emitted().click).toBeTruthy();
   });
+});
+
+describe('CvIconButton', () => {
+  // ***************
+  // PROP CHECKS
+  // ***************
+  describe('Has expected properties', () => {
+    // Deprecated props not tested
+    testComponent.propsHaveDefault(CvIconButton, ['kind']);
+    testComponent.propsAreType(
+      CvIconButton,
+      ['iconHref', 'kind', 'size', 'label', 'tipPosition', 'tipAlignment'],
+      String
+    );
+    testComponent.propsAreType(CvIconButton, ['icon'], [String, Object]);
+    testComponent.propsHaveDefault(CvIconButton, ['kind']);
+    testComponent.prosHaveDefaultOfUndefined(CvIconButton, ['size', 'icon']);
+  });
+
+  // ***************
+  // SNAPSHOT TESTS
+  // ***************
+
+  describe('Renders as expected field secondary with icon disabled', () => {
+    const propsData = { kind: 'secondary', icon: AddFilled16, 'tab-index': 2, disabled: true, size: 'field' };
+    const wrapper = shallow(CvIconButton, { propsData, slots: { default: 'default slot content' } });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  describe('Renders as expected small primary', () => {
+    const propsData = { kind: 'primary', size: 'small' };
+    const wrapper = shallow(CvIconButton, { propsData, slots: { default: 'default slot content' } });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  describe('Renders as expected default', () => {
+    const propsData = {};
+    const wrapper = shallow(CvIconButton, { propsData, slots: { default: 'default slot content' } });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  // ***************
+  // FUNCTIONAL TESTS
+  // ***************
+  it('Raises click event when clicked', () => {
+    const wrapper = shallow(CvIconButton);
+    wrapper.find('button').trigger('click');
+    expect(wrapper.emitted().click).toBeTruthy();
+  });
+});
+
+describe('CvButtonSkeleton', () => {
+  // ***************
+  // PROP CHECKS
+  // ***************
+  describe('Has expected properties', () => {
+    // Deprecated props not tested
+    testComponent.propsAreType(CvButtonSkeleton, ['size'], String);
+    testComponent.prosHaveDefaultOfUndefined(CvButtonSkeleton, ['size']);
+  });
+
+  // ***************
+  // SNAPSHOT TESTS
+  // ***************
+
+  describe('Renders as expected small primary', () => {
+    const propsData = { size: 'field' };
+    const wrapper = shallow(CvButtonSkeleton, { propsData, slots: { default: 'default slot content' } });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  describe('Renders as expected small primary', () => {
+    const propsData = { size: 'small' };
+    const wrapper = shallow(CvButtonSkeleton, { propsData, slots: { default: 'default slot content' } });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  describe('Renders as expected default', () => {
+    const propsData = {};
+    const wrapper = shallow(CvButtonSkeleton, { propsData, slots: { default: 'default slot content' } });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  // ***************
+  // FUNCTIONAL TESTS
+  // ***************
 });

--- a/packages/core/src/components/cv-button/button-mixin.js
+++ b/packages/core/src/components/cv-button/button-mixin.js
@@ -37,4 +37,14 @@ export default {
     },
     size: { type: String, default: undefined, validator: val => ['', 'field', 'small'].includes(val) },
   },
+  computed: {
+    // Bind listeners at the component level to the embedded input element and
+    // add our own input listener to service the v-model. See:
+    // https://vuejs.org/v2/guide/components-custom-events.html#Customizing-Component-v-model
+    inputListeners() {
+      return Object.assign({}, this.$listeners, {
+        click: event => this.$emit('click', event),
+      });
+    },
+  },
 };

--- a/packages/core/src/components/cv-button/cv-button-skeleton.vue
+++ b/packages/core/src/components/cv-button/cv-button-skeleton.vue
@@ -24,7 +24,7 @@ export default {
         return true;
       },
     },
-    size: { type: String, default: undefined, validator: val => ['', 'field', 'small'] },
+    size: { type: String, default: undefined, validator: val => ['', 'field', 'small'].includes(val) },
   },
 };
 </script>

--- a/packages/core/src/components/cv-button/cv-button.vue
+++ b/packages/core/src/components/cv-button/cv-button.vue
@@ -9,8 +9,7 @@
         'bx--btn--field': size === 'field',
       },
     ]"
-    v-on="$listeners"
-    @click="$emit('click', $event)"
+    v-on="inputListeners"
     role="button"
   >
     <slot></slot>

--- a/packages/core/src/components/cv-button/cv-icon-button.vue
+++ b/packages/core/src/components/cv-button/cv-icon-button.vue
@@ -9,7 +9,7 @@
         'bx--btn--field': size === 'field',
       },
     ]"
-    v-on="$listeners"
+    v-on="inputListeners"
     type="button"
   >
     <span class="bx--assistive-text">{{ tipText }}</span>


### PR DESCRIPTION
Closes #644 

In adding tests to CvButton the use of @click alongside $listeners caused two events in the button. This had consequences wherever a button is used. Switched to using a computed listeners value as per https://vuejs.org/v2/guide/components-custom-events.html#Customizing-Component-v-model

#### Changelog

A       packages/core/__tests__/__snapshots__/cv-button.test.js.snap
M       packages/core/__tests__/cv-button.test.js
M       packages/core/src/components/cv-button/button-mixin.js
M       packages/core/src/components/cv-button/cv-button-skeleton.vue
M       packages/core/src/components/cv-button/cv-button.vue
M       packages/core/src/components/cv-button/cv-icon-button.vue