### PR TITLE
chore: update checkbox tests to use snapshots

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-checkbox.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-checkbox.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[` 1`] = `<div class="cv-checkbox bx--form-item bx--checkbox-wrapper"><label class="bx--checkbox-label bx--skeleton"></label></div>`;
+
+exports[`CvCheckbox should render with the appropriate kind 1`] = `
+<div class="cv-checkbox bx--checkbox-wrapper bx--form-item"><label class="bx--checkbox-label"><input type="checkbox" aria-checked="false" class="bx--checkbox" value="check-1">
+
+  </label></div>
+`;
+
+exports[`CvCheckbox should render with the appropriate kind when disabled 1`] = `
+<div class="cv-checkbox bx--checkbox-wrapper bx--form-item"><label data-contained-checkbox-disabled="true" class="bx--checkbox-label bx--label--disabled"><input type="checkbox" aria-checked="false" disabled="disabled" class="bx--checkbox" value="check-1">
+
+  </label></div>
+`;

--- a/packages/core/__tests__/_helpers.js
+++ b/packages/core/__tests__/_helpers.js
@@ -17,6 +17,11 @@ const getComponentProp = (component, prop) => {
   return componentProp;
 };
 
+const getComponentPropDefault = (component, prop) => {
+  const _default = getComponentProp(component, prop).default;
+  return typeof _default === 'function' ? _default() : _default;
+};
+
 export const testComponent = {
   propsAreRequired: (component, props) => {
     test.each(props)('has a required prop: %s', prop => {
@@ -26,6 +31,7 @@ export const testComponent = {
 
   propsAreType: (component, props, types) => {
     let typeName;
+
     if (types.map) {
       const typeNames = types.map(type => type.name);
       typeName = `(${typeNames.join('|')})`;
@@ -47,12 +53,14 @@ export const testComponent = {
 
   propsHaveDefault: (component, props) => {
     test.each(props)('has a prop with a default: %s', prop => {
-      expect(getComponentProp(component, prop).default).toBeDefined();
+      const _default = getComponentPropDefault(component, prop);
+      expect(_default).toBeDefined();
     });
   },
-  prosHaveDefaultOfUndefined: (component, props) => {
+  propsHaveDefaultOfUndefined: (component, props) => {
     test.each(props)('has a prop with a default undefined: %s', prop => {
-      expect(getComponentProp(component, prop).default).not.toBeDefined();
+      const _default = getComponentPropDefault(component, prop);
+      expect(_default).not.toBeDefined();
     });
   },
 };

--- a/packages/core/__tests__/cv-button.test.js
+++ b/packages/core/__tests__/cv-button.test.js
@@ -16,7 +16,7 @@ describe('CvButton', () => {
     testComponent.propsAreType(CvButton, ['iconHref', 'kind', 'size'], String);
     testComponent.propsAreType(CvButton, ['icon'], [String, Object]);
     testComponent.propsHaveDefault(CvButton, ['kind']);
-    testComponent.prosHaveDefaultOfUndefined(CvButton, ['size', 'icon']);
+    testComponent.propsHaveDefaultOfUndefined(CvButton, ['size', 'icon']);
   });
 
   // ***************
@@ -68,7 +68,7 @@ describe('CvIconButton', () => {
     );
     testComponent.propsAreType(CvIconButton, ['icon'], [String, Object]);
     testComponent.propsHaveDefault(CvIconButton, ['kind']);
-    testComponent.prosHaveDefaultOfUndefined(CvIconButton, ['size', 'icon']);
+    testComponent.propsHaveDefaultOfUndefined(CvIconButton, ['size', 'icon']);
   });
 
   // ***************
@@ -113,7 +113,7 @@ describe('CvButtonSkeleton', () => {
   describe('Has expected properties', () => {
     // Deprecated props not tested
     testComponent.propsAreType(CvButtonSkeleton, ['size'], String);
-    testComponent.prosHaveDefaultOfUndefined(CvButtonSkeleton, ['size']);
+    testComponent.propsHaveDefaultOfUndefined(CvButtonSkeleton, ['size']);
   });
 
   // ***************

--- a/packages/core/__tests__/cv-checkbox.test.js
+++ b/packages/core/__tests__/cv-checkbox.test.js
@@ -6,25 +6,37 @@ import { settings } from 'carbon-components';
 const { prefix } = settings;
 
 describe('CvCheckbox', () => {
+  // ***************
+  // PROP CHECKS
+  // ***************
+  testComponent.propsAreType(CvCheckbox, ['label', 'name', 'value'], String);
+  testComponent.propsAreType(CvCheckbox, ['mixed', 'formItem', 'checked'], Boolean);
+  testComponent.propsAreType(CvCheckbox, ['modelValue'], [Array, Boolean]);
+
   testComponent.propsHaveDefault(CvCheckbox, ['formItem']);
+  testComponent.propsHaveDefaultOfUndefined(CvCheckbox, ['modelValue', 'checked']);
+
+  // ***************
+  // SNAPSHOT CHECKS
+  // ***************
 
   it('should render with the appropriate kind', () => {
     const propsData = { formItem: true, value: 'check-1' };
     const wrapper = shallow(CvCheckbox, { propsData });
-    expect(wrapper.classes(`${prefix}--form-item`)).toEqual(true);
-    expect(wrapper.classes(`${prefix}--checkbox-wrapper`)).toEqual(true);
-    expect(wrapper.find('label').classes(`${prefix}--checkbox-label`)).toEqual(true);
-    expect(wrapper.find('label').classes(`${prefix}--label--disabled`)).toEqual(false);
-    expect(wrapper.find('label').classes(`${prefix}--checkbox-label__focus`)).toEqual(false);
-    expect(wrapper.find('input').classes(`${prefix}--checkbox`)).toEqual(true);
+
+    expect(wrapper.html()).toMatchSnapshot();
   });
 
   it('should render with the appropriate kind when disabled', () => {
     const propsData = { formItem: true, value: 'check-1', disabled: true };
     const wrapper = shallow(CvCheckbox, { propsData });
-    expect(wrapper.find('label').classes(`${prefix}--label--disabled`)).toEqual(true);
+
+    expect(wrapper.html()).toMatchSnapshot();
   });
 
+  // ***************
+  // FUNCTIONAL CHECKS
+  // ***************
   it('should be unchecked when mixed is true and checked is false', () => {
     const propsData = { formItem: true, value: 'check-1', mixed: true, checked: false };
     const wrapper = shallow(CvCheckbox, { propsData });
@@ -151,12 +163,20 @@ describe('CvCheckbox', () => {
 });
 
 describe('CvCheckboxSkeleton', () => {
+  // ***************
+  // PROP CHECKS
+  // ***************
+
+  // ***************
+  // SNAPSHOT CHECKS
+  // ***************
   describe('Renders as expected', () => {
     const wrapper = shallow(CvCheckboxSkeleton);
 
-    it('Has the expected classes', () => {
-      expect(wrapper.find('label').classes(`${prefix}--skeleton`)).toEqual(true);
-      expect(wrapper.find('label').classes(`${prefix}--checkbox-label`)).toEqual(true);
-    });
+    expect(wrapper.html()).toMatchSnapshot();
   });
+
+  // ***************
+  // FUNCTIONAL CHECKS
+  // ***************
 });

--- a/packages/core/__tests__/cv-number-input.test.js
+++ b/packages/core/__tests__/cv-number-input.test.js
@@ -22,7 +22,7 @@ describe('CvNumberInput', () => {
     String
   );
 
-  testComponent.prosHaveDefaultOfUndefined(CvNumberInput, ['helperText', 'invalidMessage']);
+  testComponent.propsHaveDefaultOfUndefined(CvNumberInput, ['helperText', 'invalidMessage']);
 
   // ***************
   // SNAPSHOT TESTS

--- a/packages/core/__tests__/cv-wrapper.test.js
+++ b/packages/core/__tests__/cv-wrapper.test.js
@@ -11,7 +11,7 @@ describe('CvWrapper', () => {
   // ***************
   testComponent.propsAreType(CvWrapper, ['tagType'], String);
 
-  testComponent.prosHaveDefaultOfUndefined(CvWrapper, ['tagType']);
+  testComponent.propsHaveDefaultOfUndefined(CvWrapper, ['tagType']);
 
   // ***************
   // SNAPSHOT CHECKS
@@ -54,7 +54,6 @@ describe('CvWrapper', () => {
       }
     );
 
-    console.log(wrapper.html());
     expect(wrapper.attributes('test-attr')).toEqual('testAttr');
     expect(wrapper.attributes('style')).toContain('z-index: 99');
     expect(wrapper.attributes('style')).toContain('outline: none');


### PR DESCRIPTION
Update checkbox to use snapshot tests

#### Changelog

A       packages/core/__tests__/__snapshots__/cv-checkbox.test.js.snap
M       packages/core/__tests__/_helpers.js
M       packages/core/__tests__/cv-button.test.js
M       packages/core/__tests__/cv-checkbox.test.js
M       packages/core/__tests__/cv-number-input.test.js
M       packages/core/__tests__/cv-wrapper.test.js