### PR TITLE
feat: add tests for radio button

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-radio-button.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-radio-button.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CvRadioButton matches render when checked 1`] = `
+<div class="cv-radio-button bx--radio-button-wrapper"><input id="1" type="radio" class="bx--radio-button" value=""> <label for="1" class="bx--radio-button__label"><span class="bx--radio-button__appearance"></span>
+    test label
+  </label></div>
+`;
+
+exports[`CvRadioButton matches render when modelValue is equal to value 1`] = `
+<div class="cv-radio-button bx--radio-button-wrapper"><input id="1" type="radio" class="bx--radio-button" value="test value"> <label for="1" class="bx--radio-button__label"><span class="bx--radio-button__appearance"></span>
+    test label
+  </label></div>
+`;
+
+exports[`CvRadioButton matches render when modelValue is not equal to value 1`] = `
+<div class="cv-radio-button bx--radio-button-wrapper"><input id="1" type="radio" class="bx--radio-button" value="test value"> <label for="1" class="bx--radio-button__label"><span class="bx--radio-button__appearance"></span>
+    test label
+  </label></div>
+`;
+
+exports[`CvRadioButton matches render with left label 1`] = `
+<div class="cv-radio-button bx--radio-button-wrapper bx--radio-button-wrapper--label-left"><input id="1" type="radio" class="bx--radio-button" value=""> <label for="1" class="bx--radio-button__label"><span class="bx--radio-button__appearance"></span>
+    left label
+  </label></div>
+`;
+
+exports[`CvRadioButton matches render with right label 1`] = `
+<div class="cv-radio-button bx--radio-button-wrapper"><input id="1" type="radio" class="bx--radio-button" value=""> <label for="1" class="bx--radio-button__label"><span class="bx--radio-button__appearance"></span>
+    right label
+  </label></div>
+`;
+
+exports[`CvRadioGroup matches render when horizontal 1`] = `
+<div class="cv-radio-group bx--form-item">
+  <div class="bx--radio-button-group">
+    <div class="cv-radio-button-stub">StubbyMcStubFace</div>
+  </div>
+</div>
+`;
+
+exports[`CvRadioGroup matches render when vertical 1`] = `
+<div class="cv-radio-group bx--form-item">
+  <div class="bx--radio-button-group bx--radio-button-group--vertical">
+    <div class="cv-radio-button-stub">StubbyMcStubFace</div>
+  </div>
+</div>
+`;

--- a/packages/core/__tests__/_helpers.js
+++ b/packages/core/__tests__/_helpers.js
@@ -25,7 +25,8 @@ const getComponentPropDefault = (component, prop) => {
 export const testComponent = {
   propsAreRequired: (component, props) => {
     test.each(props)('has a required prop: %s', prop => {
-      expect(component.props[prop].required).toBe(true);
+      let componentProp = getComponentProp(component, prop);
+      expect(componentProp.required).toBe(true);
     });
   },
 

--- a/packages/core/__tests__/cv-radio-button.test.js
+++ b/packages/core/__tests__/cv-radio-button.test.js
@@ -1,0 +1,151 @@
+import { shallowMount as shallow, mount } from '@vue/test-utils';
+import { testComponent } from './_helpers';
+import { CvRadioButton, CvRadioGroup } from '@/components/cv-radio-button/';
+
+describe('CvRadioButton', () => {
+  // ***************
+  // PROP CHECKS
+  // ***************
+  testComponent.propsAreType(CvRadioButton, ['labelLeft', 'checked'], Boolean);
+  testComponent.propsAreType(CvRadioButton, ['modelValue', 'value', 'label'], String);
+  testComponent.propsAreRequired(CvRadioButton, ['value']);
+
+  // ***************
+  // SNAPSHOT CHECKS
+  // ***************
+  it('matches render with right label', () => {
+    const wrapper = shallow(CvRadioButton, {
+      propsData: {
+        label: 'right label',
+        labelLeft: false,
+        id: '1',
+        value: '',
+      },
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('matches render with left label', () => {
+    const wrapper = shallow(CvRadioButton, {
+      propsData: {
+        label: 'left label',
+        labelLeft: true,
+        id: '1',
+        value: '',
+      },
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('matches render when checked', () => {
+    const wrapper = shallow(CvRadioButton, {
+      propsData: {
+        label: 'test label',
+        labelLeft: false,
+        id: '1',
+        value: '',
+        checked: true,
+      },
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('matches render when modelValue is equal to value', () => {
+    const wrapper = shallow(CvRadioButton, {
+      propsData: {
+        label: 'test label',
+        labelLeft: false,
+        id: '1',
+        value: 'test value',
+        modelValue: 'test value',
+      },
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('matches render when modelValue is not equal to value', () => {
+    const wrapper = shallow(CvRadioButton, {
+      propsData: {
+        label: 'test label',
+        labelLeft: false,
+        id: '1',
+        value: 'test value',
+        modelValue: 'not test value',
+      },
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  // ***************
+  // FUNCTIONAL CHECKS
+  // ***************
+  it('is not checked when checked and modelValue props are not set', () => {
+    const wrapper = shallow(CvRadioButton, {
+      propsData: {
+        labelLeft: false,
+        id: '1',
+        value: 'test value',
+      },
+    });
+    expect(wrapper.vm.isChecked).toEqual(false);
+  });
+
+  it('is checked when checked prop is set to true and modelValue prop is not set', () => {
+    const wrapper = shallow(CvRadioButton, {
+      propsData: {
+        labelLeft: false,
+        id: '1',
+        value: 'test value',
+        checked: true,
+      },
+    });
+    expect(wrapper.vm.isChecked).toEqual(true);
+  });
+
+  it('modelValue prop has higher priority than checked prop', () => {
+    const wrapper = shallow(CvRadioButton, {
+      propsData: {
+        labelLeft: false,
+        id: '1',
+        value: 'test value',
+        checked: true,
+        modelValue: 'not test value',
+      },
+    });
+    expect(wrapper.vm.isChecked).toEqual(false);
+  });
+});
+
+describe('CvRadioGroup', () => {
+  // ***************
+  // PROP CHECKS
+  // ***************
+  testComponent.propsAreType(CvRadioGroup, ['vertical'], Boolean);
+
+  // ***************
+  // SNAPSHOT CHECKS
+  // ***************
+  it('matches render when vertical', () => {
+    const wrapper = shallow(CvRadioGroup, {
+      propsData: { vertical: true },
+      slots: {
+        default: '<div class="cv-radio-button-stub">StubbyMcStubFace</div>',
+      },
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('matches render when horizontal', () => {
+    const wrapper = shallow(CvRadioGroup, {
+      propsData: { vertical: false },
+      slots: {
+        default: '<div class="cv-radio-button-stub">StubbyMcStubFace</div>',
+      },
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  // ***************
+  // FUNCTIONAL CHECKS
+  // ***************
+});


### PR DESCRIPTION
#182 

Added tests for CvRadioButton and CvRadioGroup. Did not know to to test events for these components.

#### Changelog

A       packages/core/__tests__/__snapshots__/cv-radio-button.test.js.snap
M       packages/core/__tests__/_helpers.js
A       packages/core/__tests__/cv-radio-button.test.js
