### PR TITLE
fix: overflow menu close on button click

### DIFF
--- a/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
+++ b/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
@@ -119,7 +119,7 @@ export default {
       if (this.open) {
         if (
           ev.relatedTarget === null ||
-          !(this.$el === ev.relatedTarget || this.$refs.popup.contains(ev.relatedTarget))
+          !(this.$refs.trigger === ev.relatedTarget || this.$refs.popup.contains(ev.relatedTarget))
         ) {
           this.open = false;
           this.positionListen(false);


### PR DESCRIPTION
Closes #655 

DOM Change in 2.16 for carbon 10.7 invalidated one of the focus checks

#### Changelog

M       packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
