### PR TITLE
fix: CvComboBox set input placeholder to label

### DIFF
--- a/packages/core/src/components/cv-combo-box/cv-combo-box.vue
+++ b/packages/core/src/components/cv-combo-box/cv-combo-box.vue
@@ -47,7 +47,7 @@
           role="combobox"
           :aria-expanded="open"
           autocomplete="off"
-          placeholder="Filter"
+          placeholder="label"
           v-model="filter"
           @input="onInput"
           @focus="inputFocus"

--- a/packages/core/src/components/cv-combo-box/cv-combo-box.vue
+++ b/packages/core/src/components/cv-combo-box/cv-combo-box.vue
@@ -47,7 +47,7 @@
           role="combobox"
           :aria-expanded="open"
           autocomplete="off"
-          placeholder="label"
+          :placeholder="label"
           v-model="filter"
           @input="onInput"
           @focus="inputFocus"


### PR DESCRIPTION
Closes #679 

Sets the `placeholder` prop of in `input` element to the `{{label}}` vue prop

#### Changelog

`M       packages/core/src/components/cv-combo-box/cv-combo-box.vue`
