### PR TITLE
fix: update and emit dataValue on clearFilter

### DIFF
--- a/packages/core/src/components/cv-combo-box/cv-combo-box.vue
+++ b/packages/core/src/components/cv-combo-box/cv-combo-box.vue
@@ -206,10 +206,12 @@ export default {
   },
   methods: {
     clearFilter() {
+      this.internalUpdateValue('');
       this.filter = '';
       this.$refs.input.focus();
       this.doOpen(true);
       this.updateOptions();
+      this.$emit('change', this.dataValue);
     },
     checkHighlightPosition(newHiglight) {
       if (this.$refs.list && this.$refs.option) {


### PR DESCRIPTION
Closes #684 

The v-model was not updating when the clear icon button was clicked, this PR edits the method of that button `clearFilter()` to update the internal value to an empty string `''` (which will update `this.dataValue`), and then emit this change.

#### Changelog

`M       packages/core/src/components/cv-combo-box/cv-combo-box.vue`
