### PR TITLE
fix: slot hide show reactivity

### DIFF
--- a/packages/core/src/components/cv-combo-box/cv-combo-box.vue
+++ b/packages/core/src/components/cv-combo-box/cv-combo-box.vue
@@ -138,6 +138,8 @@ export default {
       dataValue: this.value,
       dataHighlighted: null,
       dataFilter: null,
+      isHelper: false,
+      isInvalid: false,
     };
   },
   model: {
@@ -163,17 +165,12 @@ export default {
   mounted() {
     this.filter = this.value;
     this.highlighted = this.value ? this.value : this.highlight; // override highlight with value if provided
-    console.warn(
-      `${this.$vnode.componentOptions.Ctor.extendOptions.name} - Under review. This component isn't quite ready. Hopefully no features will get broken but this cannot be guarenteed.`
-    );
+    this.checkSlots();
+  },
+  beforeUpdate() {
+    this.checkSlots();
   },
   computed: {
-    isInvalid() {
-      return this.$slots['invalid-message'] !== undefined || (this.invalidMessage && this.invalidMessage.length);
-    },
-    isHelper() {
-      return this.$slots['helper-text'] !== undefined || (this.helperText && this.helperText.length);
-    },
     highlighted: {
       get() {
         return this.dataHighlighted;
@@ -205,6 +202,11 @@ export default {
     },
   },
   methods: {
+    checkSlots() {
+      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      this.isInvalid = this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length);
+      this.isHelper = this.$slots['helper-text'] || (this.helperText && this.helperText.length);
+    },
     clearFilter() {
       this.filter = '';
       this.$refs.input.focus();

--- a/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
+++ b/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
@@ -58,7 +58,14 @@ export default {
       dataChecked: this.checked,
       dataExpanded: this.expanded,
       dataSomeExpandingRows: this.someExpandingRows,
+      hasOverflowMenu: false,
     };
+  },
+  mounted: function() {
+    this.checkSlots();
+  },
+  beforeUpdate() {
+    this.checkSlots();
   },
   watch: {
     checked() {
@@ -75,9 +82,6 @@ export default {
     isCvDataTableRow() {
       return true;
     },
-    hasOverflowMenu() {
-      return (this.overflowMenu && this.overflowMenu.length) || this.$slots['overflow-menu'];
-    },
     hasBatchActions() {
       return this.$parent.$parent.hasBatchActions;
     },
@@ -86,6 +90,10 @@ export default {
     },
   },
   methods: {
+    checkSlots() {
+      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      this.hasOverflowMenu = (this.overflowMenu && this.overflowMenu.length) || this.$slots['overflow-menu'];
+    },
     onChange() {
       this.$parent.$parent.onRowCheckChange(this.value, this.dataChecked);
     },

--- a/packages/core/src/components/cv-data-table/cv-data-table-action.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table-action.vue
@@ -9,7 +9,7 @@ export default {
   name: 'cv-data-table-action',
   mounted() {
     // ensure SVG has
-    this.$el.children[0].classList.add('class="bx--toolbar-action__icon');
+    this.$el.children[0].classList.add('bx--toolbar-action__icon');
   },
 };
 </script>

--- a/packages/core/src/components/cv-data-table/cv-data-table-row.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table-row.vue
@@ -37,7 +37,7 @@ export default {
   },
   data() {
     return {
-      dataExpandable: this.$slots.expandedContent !== undefined,
+      dataExpandable: false,
       dataSomeExpandingRows: false,
       dataExpanded: this.expanded,
     };
@@ -50,6 +50,8 @@ export default {
     },
   },
   mounted() {
+    // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+    this.dataExpandable = this.$slots.expandedContent !== undefined;
     this.$parent.$emit('cv:mounted', this);
   },
   updated() {

--- a/packages/core/src/components/cv-data-table/cv-data-table-skeleton.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table-skeleton.vue
@@ -1,14 +1,14 @@
 <template>
   <cv-data-table skeleton :data="data" :columns="cols" v-on="$listeners" v-bind="$attrs">
-    <template v-if="$slots['helper-text']" slot="helper-text">
+    <template v-if="hasBatchActions" slot="helper-text">
       <slot name="helper-text" />
     </template>
 
-    <template v-if="$slots['batch-actions']" slot="batch-actions">
+    <template v-if="hasBatchActions" slot="batch-actions">
       <slot name="batch-actions" />
     </template>
 
-    <template v-if="$slots.actions" slot="actions">
+    <template v-if="hasActions" slot="actions">
       <slot name="actions" />
     </template>
   </cv-data-table>
@@ -32,12 +32,33 @@ export default {
     hasExpandables: Boolean,
     rows: { type: Number, default: DEFAULTS.ROWS },
   },
+  data() {
+    return {
+      hasActions: false,
+      hasHelperText: false,
+      hasBatchActions: false,
+    };
+  },
+  mounted() {
+    this.checkSlots();
+  },
+  beforeUpdate() {
+    this.checkSlots();
+  },
   computed: {
     data() {
       return [...Array(Math.max(this.rows, 1))].map(item => Array(this.cols.length).fill(''));
     },
     cols() {
       return typeof this.columns !== 'number' ? this.columns : Array(Math.max(this.columns, 1)).fill('');
+    },
+  },
+  methods: {
+    checkSlots() {
+      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      this.hasBatchActions = this.$slots['batch-actions'];
+      this.hasHelperText = this.$slots['helper-text'];
+      this.hasActions = this.$slots['actions'];
     },
   },
 };

--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -32,7 +32,7 @@
           </div>
         </div>
 
-        <div v-if="($slots.actions || $listeners.search) && !batchActive" class="bx--toolbar-content">
+        <div v-if="(hasActions || $listeners.search) && !batchActive" class="bx--toolbar-content">
           <div
             v-if="$listeners.search"
             :class="{
@@ -235,6 +235,10 @@ export default {
             order: 'none',
           }))
         : this.columns,
+      hasBatchActions: false,
+      hasActions: false,
+      hasToolbar: false,
+      isHelper: false,
       batchActive: false,
       headingChecked: false,
       dataRowsSelected: this.rowsSelected,
@@ -263,17 +267,16 @@ export default {
   },
   mounted() {
     this.updateRowsSelected();
+    this.checkSlots();
+  },
+  beforeUpdate() {
+    this.checkSlots();
   },
   computed: {
-    hasBatchActions() {
-      return this.$slots['batch-actions'];
-    },
     hasTableHeader() {
       return this.title || this.isHelper;
     },
-    hasToolbar() {
-      return this.$slots.actions || this.$listeners.search || this.$slots['batch-actions'];
-    },
+
     hasExpandables() {
       return this.registeredRows.some(item => item.expandable);
     },
@@ -317,11 +320,15 @@ export default {
     selectedRows() {
       return this.dataRowsSelected;
     },
-    isHelper() {
-      return this.$slots['helper-text'] !== undefined || (this.helperText && this.helperText.length);
-    },
   },
   methods: {
+    checkSlots() {
+      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      this.hasBatchActions = this.$slots['batch-actions'];
+      this.hasActions = this.$slots.actions;
+      this.hasToolbar = this.$slots.actions || this.$listeners.search || this.$slots['batch-actions'];
+      this.isHelper = this.$slots['helper-text'] !== undefined || (this.helperText && this.helperText.length);
+    },
     onCvMount(row) {
       this.registeredRows.push(row);
       row.$on('cv:expanded-change', this.onCvExpandedChange);

--- a/packages/core/src/components/cv-date-picker/cv-date-picker.vue
+++ b/packages/core/src/components/cv-date-picker/cv-date-picker.vue
@@ -130,6 +130,7 @@ export default {
     return {
       dataValue: '',
       dataOptions: {},
+      isInvalid: false,
     };
   },
   watch: {
@@ -178,13 +179,6 @@ export default {
         }
       }
     },
-    isInvalid() {
-      return (
-        this.$slots['invalid-message'] !== undefined ||
-        (this.invalidMessage && this.invalidMessage.length) ||
-        (this.invalidDateMessage && this.invalidDateMessage.length)
-      );
-    },
     isRange() {
       return this.kind === 'range';
     },
@@ -193,6 +187,13 @@ export default {
     },
   },
   methods: {
+    checkSlots() {
+      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      this.isInvalid =
+        this.$slots['invalid-message'] !== undefined ||
+        (this.invalidMessage && this.invalidMessage.length) ||
+        (this.invalidDateMessage && this.invalidDateMessage.length);
+    },
     initFlatpickr() {
       if (['single', 'range'].includes(this.kind)) {
         // no need to call set value as it's done through getOptions
@@ -300,6 +301,7 @@ export default {
   },
   mounted() {
     this.initFlatpickr();
+    this.checkSlots();
     // this.cal.setDate([Date.now(), Date.now()]);
     // setTimeout(() => {
     //   let curDate = new Date();
@@ -307,6 +309,9 @@ export default {
     //   anotherDate = anotherDate.setDate(anotherDate.getDate() + 16);
     //   this.cal.setDate([curDate, anotherDate], true);
     // }, 2000);
+  },
+  beforeUpdate() {
+    this.checkSlots();
   },
   beforeDestroy() {
     if (this.cal) {

--- a/packages/core/src/components/cv-dropdown/cv-dropdown.vue
+++ b/packages/core/src/components/cv-dropdown/cv-dropdown.vue
@@ -122,6 +122,8 @@ export default {
     return {
       open: false,
       dataValue: this.value,
+      isHelper: false,
+      isInvalid: false,
     };
   },
   created() {
@@ -136,6 +138,10 @@ export default {
       }
     });
     this.internalValue = this.internalValue; // forces update of value
+    this.checkSlots();
+  },
+  beforeUpdate() {
+    this.checkSlots();
   },
   model: {
     prop: 'value',
@@ -147,12 +153,6 @@ export default {
     },
   },
   computed: {
-    isInvalid() {
-      return this.$slots['invalid-message'] !== undefined || (this.invalidMessage && this.invalidMessage.length);
-    },
-    isHelper() {
-      return this.$slots['helper-text'] !== undefined || (this.helperText && this.helperText.length);
-    },
     internalValue: {
       get() {
         return this.dataValue;
@@ -198,6 +198,11 @@ export default {
     },
   },
   methods: {
+    checkSlots() {
+      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      this.isInvalid = this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length);
+      this.isHelper = this.$slots['helper-text'] || (this.helperText && this.helperText.length);
+    },
     onCvMount(srcComponent) {
       if (srcComponent.internalSelected) {
         this.internalValue = srcComponent.value;

--- a/packages/core/src/components/cv-modal/cv-modal.vue
+++ b/packages/core/src/components/cv-modal/cv-modal.vue
@@ -20,7 +20,7 @@
         @focus="focusBeforeContent"
       />
       <div class="bx--modal-header">
-        <h4 class="bx--modal-header__label" v-if="$slots.label">
+        <h4 class="bx--modal-header__label" v-if="hasHeaderLabel">
           <slot name="label">label (Optional)</slot>
         </h4>
         <h2 class="bx--modal-header__heading">
@@ -41,13 +41,7 @@
       </div>
 
       <div class="bx--modal-footer" v-if="hasFooter">
-        <cv-button
-          type="button"
-          :kind="secondaryKind"
-          @click="onSecondaryClick"
-          v-if="this.$slots['secondary-button']"
-          ref="secondary"
-        >
+        <cv-button type="button" :kind="secondaryKind" @click="onSecondaryClick" v-if="hasSecondary" ref="secondary">
           <slot name="secondary-button">Secondary button</slot>
         </cv-button>
         <cv-button
@@ -55,7 +49,7 @@
           type="button"
           :kind="primaryKind"
           @click="onPrimaryClick"
-          v-if="this.$slots['primary-button']"
+          v-if="hasPrimary"
           ref="primary"
         >
           <slot name="primary-button">Primary button</slot>
@@ -98,12 +92,20 @@ export default {
     return {
       dataVisible: false,
       scrollable: false,
+      hasFooter: false,
+      hasHeaderLabel: false,
+      hasPrimary: false,
+      hasSecondary: false,
     };
   },
   mounted() {
     if (this.visible) {
       this.show();
     }
+    this.checkSlots();
+  },
+  beforeUpdate() {
+    this.checkSlots();
   },
   watch: {
     visible(val) {
@@ -125,15 +127,19 @@ export default {
     secondaryKind() {
       return 'secondary';
     },
-    hasFooter() {
-      return this.$slots['primary-button'] || this.$slots['secondary-button'];
-    },
   },
   model: {
     event: 'modelEvent',
     prop: 'visible',
   },
   methods: {
+    checkSlots() {
+      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      this.hasFooter = this.$slots['primary-button'] || this.$slots['secondary-button'];
+      this.hasHeaderLabel = this.$slots.label !== undefined;
+      this.hasSecondary = this.$slots['secondary-button'];
+      this.hasPrimary = this.$slots['primary-button'];
+    },
     focusBeforeContent() {
       if (this.$slots['primary-button']) {
         this.$refs.primary.$el.focus();

--- a/packages/core/src/components/cv-multi-select/cv-multi-select.vue
+++ b/packages/core/src/components/cv-multi-select/cv-multi-select.vue
@@ -199,6 +199,8 @@ export default {
       dataValue: '',
       dataHighlighted: null,
       dataFilter: '',
+      isHelper: false,
+      isInvalid: false,
     };
   },
   model: {
@@ -225,17 +227,12 @@ export default {
   },
   mounted() {
     this.highlighted = this.value ? this.value : this.highlight; // override highlight with value if provided
-    console.warn(
-      `${this.$vnode.componentOptions.Ctor.extendOptions.name} - Under review. This component isn't quite ready. Hopefully no features will get broken but this cannot be guarenteed.`
-    );
+    this.checkSlots();
+  },
+  beforeUpdate() {
+    this.checkSlots();
   },
   computed: {
-    isInvalid() {
-      return this.$slots['invalid-message'] !== undefined || (this.invalidMessage && this.invalidMessage.length);
-    },
-    isHelper() {
-      return this.$slots['helper-text'] !== undefined || (this.helperText && this.helperText.length);
-    },
     highlighted: {
       get() {
         return this.dataHighlighted;
@@ -271,6 +268,11 @@ export default {
     },
   },
   methods: {
+    checkSlots() {
+      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      this.isInvalid = this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length);
+      this.isHelper = this.$slots['helper-text'] || (this.helperText && this.helperText.length);
+    },
     clearFilter() {
       this.filter = '';
       this.$refs.input.focus();

--- a/packages/core/src/components/cv-number-input/cv-number-input.vue
+++ b/packages/core/src/components/cv-number-input/cv-number-input.vue
@@ -78,7 +78,15 @@ export default {
   data() {
     return {
       internalValue: this.valueAsString(this.value),
+      isHelper: false,
+      isInvalid: false,
     };
+  },
+  mounted() {
+    this.checkSlots();
+  },
+  beforeUpdate() {
+    this.checkSlots();
   },
   watch: {
     value() {
@@ -102,14 +110,13 @@ export default {
       }
       return intVal;
     },
-    isInvalid() {
-      return this.$slots['invalid-message'] !== undefined || (this.invalidMessage && this.invalidMessage.length);
-    },
-    isHelper() {
-      return this.$slots['helper-text'] !== undefined || (this.helperText && this.helperText.length);
-    },
   },
   methods: {
+    checkSlots() {
+      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      this.isInvalid = this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length);
+      this.isHelper = this.$slots['helper-text'] || (this.helperText && this.helperText.length);
+    },
     doUp() {
       this.internalValue = `${this.internalIntValue + 1}`;
       this.emitValue();

--- a/packages/core/src/components/cv-select/cv-select.vue
+++ b/packages/core/src/components/cv-select/cv-select.vue
@@ -92,7 +92,11 @@ export default {
     delete this.$attrs.multiple;
   },
   data() {
-    return { dataValue: undefined };
+    return {
+      dataValue: undefined,
+      isHelper: false,
+      isInvalid: false,
+    };
   },
   mounted() {
     // this is needed to ensure selected for an option when no value is supplied
@@ -104,6 +108,10 @@ export default {
         }
       }
     }
+    this.checkSlots();
+  },
+  beforeUpdate() {
+    this.checkSlots();
   },
   watch: {
     value() {
@@ -128,14 +136,15 @@ export default {
         input: event => this.$emit('input', event.target.value),
       };
     },
-    isInvalid() {
-      return this.$slots['invalid-message'] !== undefined || (this.invalidMessage && this.invalidMessage.length);
-    },
-    isHelper() {
-      return this.$slots['helper-text'] !== undefined || (this.helperText && this.helperText.length);
-    },
     internalValue() {
       return this.dataValue ? this.dataValue : this.value;
+    },
+  },
+  methods: {
+    checkSlots() {
+      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      this.isInvalid = this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length);
+      this.isHelper = this.$slots['helper-text'] || (this.helperText && this.helperText.length);
     },
   },
 };

--- a/packages/core/src/components/cv-text-area/cv-text-area.vue
+++ b/packages/core/src/components/cv-text-area/cv-text-area.vue
@@ -46,6 +46,18 @@ export default {
     label: String,
     value: String,
   },
+  data() {
+    return {
+      isHelper: false,
+      isInvalid: false,
+    };
+  },
+  mounted() {
+    this.checkSlots();
+  },
+  beforeUpdate() {
+    this.checkSlots();
+  },
   computed: {
     // Bind listeners at the component level to the embedded input element and
     // add our own input listener to service the v-model. See:
@@ -56,11 +68,12 @@ export default {
         input: event => this.$emit('input', event.target.value),
       };
     },
-    isInvalid() {
-      return this.$slots['invalid-message'] !== undefined || (this.invalidMessage && this.invalidMessage.length);
-    },
-    isHelper() {
-      return this.$slots['helper-text'] || (this.helperText && this.helperText.length);
+  },
+  methods: {
+    checkSlots() {
+      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      this.isInvalid = this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length);
+      this.isHelper = this.$slots['helper-text'] || (this.helperText && this.helperText.length);
     },
   },
 };

--- a/packages/core/src/components/cv-text-input/cv-text-input.vue
+++ b/packages/core/src/components/cv-text-input/cv-text-input.vue
@@ -70,7 +70,15 @@ export default {
     return {
       dataPasswordVisible: this.isPassword && this.passwordVisible,
       dataType: this.type,
+      isHelper: false,
+      isInvalid: false,
     };
+  },
+  mounted: function() {
+    this.checkSlots();
+  },
+  beforeUpdate() {
+    this.checkSlots();
   },
   watch: {
     passwordVisible() {
@@ -92,12 +100,6 @@ export default {
         input: event => this.$emit('input', event.target.value),
       };
     },
-    isInvalid() {
-      return this.$slots['invalid-message'] !== undefined || (this.invalidMessage && this.invalidMessage.length);
-    },
-    isHelper() {
-      return this.$slots['helper-text'] || (this.helperText && this.helperText.length);
-    },
     isPassword() {
       return this.type === 'password';
     },
@@ -109,6 +111,11 @@ export default {
     },
   },
   methods: {
+    checkSlots() {
+      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      this.isInvalid = this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length);
+      this.isHelper = this.$slots['helper-text'] || (this.helperText && this.helperText.length);
+    },
     togglePasswordVisibility() {
       const currentValue = this.$refs.input.value;
       this.dataPasswordVisible = !this.dataPasswordVisible;

--- a/packages/core/src/components/cv-time-picker/cv-time-picker.vue
+++ b/packages/core/src/components/cv-time-picker/cv-time-picker.vue
@@ -80,13 +80,18 @@ export default {
     timezones: { type: Array, default: () => [] },
     timezonesSelectLabel: { type: String, default: 'Select time zone' },
   },
+  data() {
+    return {
+      isInvalid: false,
+    };
+  },
+  mounted() {
+    this.checkSlots();
+  },
+  beforeUpdate() {
+    this.checkSlots();
+  },
   computed: {
-    isInvalid() {
-      return (
-        (this.$slots['invalid-message'] && this.$slots['invalid-message'].length) ||
-        (this.invalidMessage && this.invalidMessage.length > 0)
-      );
-    },
     validAmpm() {
       let result = this.ampm;
       if (!['AM', 'PM'].includes(this.ampm)) {
@@ -109,6 +114,12 @@ export default {
         }
       }
       return result;
+    },
+  },
+  methods: {
+    checkSlots() {
+      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      this.isInvalid = this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length);
     },
   },
 };

--- a/packages/core/src/components/cv-ui-shell/cv-header.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-header.vue
@@ -1,7 +1,7 @@
 <template>
   <header class="cv-header bx--header" role="banner" data-header>
     <slot />
-    <div v-if="$slots['header-global']" class="bx--header__global">
+    <div v-if="hasGlobalHeader" class="bx--header__global">
       <slot name="header-global" />
     </div>
     <slot name="left-panels" />
@@ -26,7 +26,15 @@ export default {
     return {
       panelControllers: [],
       panels: [],
+      hasGlobalHeader: false,
     };
+  },
+  mounted() {
+    // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+    this.hasGlobalHeader = this.$slots['header-global'] !== undefined;
+  },
+  beforeUpdate() {
+    this.hasGlobalHeader = this.$slots['header-global'] !== undefined;
   },
   computed: {
     isCvHeader() {

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
@@ -7,7 +7,7 @@
       v-bind="{ ...$attrs, ...linkProps }"
       :class="{ 'bx--side-nav__link--current': active }"
     >
-      <cv-side-nav-icon v-if="$slots['nav-icon'] !== undefined" small>
+      <cv-side-nav-icon v-if="hasNavIcon" small>
         <slot name="nav-icon" />
       </cv-side-nav-icon>
       <cv-side-nav-link-text>
@@ -30,6 +30,14 @@ export default {
   props: {
     active: Boolean,
     icon: Object,
+  },
+  data() {
+    return {
+      hasNavIcon: this.$slots['nav-icon'] !== undefined,
+    };
+  },
+  beforeUpdate() {
+    this.hasNavIcon = this.$slots['nav-icon'] !== undefined;
   },
 };
 </script>

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav-menu.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav-menu.vue
@@ -46,7 +46,15 @@ export default {
   data() {
     return {
       expanded: false,
+      hasNavIcon: false,
     };
+  },
+  mounted() {
+    // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+    this.hasNavIcon = this.$slots['nav-icon'] !== undefined;
+  },
+  beforeUpdate() {
+    this.hasNavIcon = this.$slots['nav-icon'] !== undefined;
   },
   computed: {
     hasIcon() {

--- a/storybook/_storybook/utils/knobs-helper.js
+++ b/storybook/_storybook/utils/knobs-helper.js
@@ -1,4 +1,4 @@
-import { number } from '@storybook/addon-knobs';
+import { number, boolean } from '@storybook/addon-knobs';
 
 const parsePreKnobs = (variant, preKnobs) => {
   return () => {
@@ -62,7 +62,11 @@ const parsePreKnobs = (variant, preKnobs) => {
         } else if (preKnob.slot) {
           // slot
           if (preKnob.slot !== 'default') {
-            knobs.group[preKnob.group] += `${prefix}<template slot="${preKnob.slot}">${preKnob.value}</template>`;
+            knobs.props[`use_${key}`] = { default: boolean(`use-sloted-content:${preKnob.slot}`, true) };
+            // knobs.data[key] = boolean(`slot:${preKnob.slot}`, false);
+            knobs.group[
+              preKnob.group
+            ] += `${prefix}<template v-if="use_${key}" slot="${preKnob.slot}">${preKnob.value}</template>`;
           } else {
             knobs.group[preKnob.group] += `${prefix}${preKnob.value}`;
           }

--- a/storybook/_storybook/views/sv-template-view/sv-template-view.vue
+++ b/storybook/_storybook/views/sv-template-view/sv-template-view.vue
@@ -100,6 +100,7 @@ export default {
       Vue.nextTick(this.$refs.copyButton.classList.add('sv-template-view__copy--copied'));
     },
     method(methodName) {
+      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
       const result = this.$slots.component[0].componentInstance[methodName];
       if (!result) {
         // console.dir(this.$slots.component[0].componentInstance);

--- a/storybook/stories/cv-combo-box-story.js
+++ b/storybook/stories/cv-combo-box-story.js
@@ -166,15 +166,7 @@ let variants = [
   },
   {
     name: 'slots',
-    excludes: [
-      'vModel',
-      'events',
-      'helperText',
-      'invalidMessage',
-      'userFilterOrHighlight',
-      'userFilter',
-      'userHighlight',
-    ],
+    excludes: ['vModel', 'events', 'userFilterOrHighlight', 'userFilter', 'userHighlight'],
   },
   { name: 'events', includes: ['events'] },
   { name: 'vModel', includes: ['vModel'] },

--- a/storybook/stories/cv-date-picker-story.js
+++ b/storybook/stories/cv-date-picker-story.js
@@ -106,7 +106,7 @@ const variants = [
   },
   {
     name: 'invalid message slot',
-    includes: ['theme', 'dateLabel', 'pattern', 'placeholder', 'invalidMessageSlot'],
+    includes: ['theme', 'dateLabel', 'pattern', 'placeholder', 'invalidMessage', 'invalidMessageSlot'],
   },
   { name: 'minimal', includes: ['eventsSimple'] },
   {

--- a/storybook/stories/cv-dropdown-story.js
+++ b/storybook/stories/cv-dropdown-story.js
@@ -109,7 +109,7 @@ let variants = [
   },
   {
     name: 'slots',
-    excludes: ['vModel', 'events', 'helperText', 'invalidMessage'],
+    excludes: ['vModel', 'events'],
   },
   { name: 'minimal', includes: ['value'] },
   { name: 'events', includes: ['value', 'events'] },

--- a/storybook/stories/cv-multi-select-story.js
+++ b/storybook/stories/cv-multi-select-story.js
@@ -179,15 +179,7 @@ let variants = [
   },
   {
     name: 'slots',
-    excludes: [
-      'vModel',
-      'events',
-      'helperText',
-      'invalidMessage',
-      'userFilter',
-      'userHighlight',
-      'userFilterOrHighlight',
-    ],
+    excludes: ['vModel', 'events', 'userFilter', 'userHighlight', 'userFilterOrHighlight'],
   },
   { name: 'events', includes: ['filterable', 'events'] },
   { name: 'vModel', includes: ['vModel'] },

--- a/storybook/stories/cv-select-story.js
+++ b/storybook/stories/cv-select-story.js
@@ -85,7 +85,7 @@ const variants = [
   },
   {
     name: 'slots',
-    excludes: ['vModel', 'events', 'helperText', 'invalidMessage'],
+    excludes: ['vModel', 'events'],
   },
   { name: 'minimal', includes: ['label'] },
   { name: 'events', includes: ['label', 'events'] },

--- a/storybook/stories/cv-time-picker-story.js
+++ b/storybook/stories/cv-time-picker-story.js
@@ -29,7 +29,7 @@ const preKnobs = {
     type: boolean,
     config: ['light-theme', false], // consts.CONFIG], // fails when used with number in storybook 4.1.4
     prop: 'theme',
-    value: val => (val ? 'xlight' : ''),
+    value: val => (val ? 'light' : ''),
   },
   label: {
     group: 'attr',


### PR DESCRIPTION
Closes #671

An assumption made about $slots and reactivity was causing the invalid-message slot to persist the invalid state of a component. The components now check during component update for the slots existence.

#### Changelog
M       packages/core/src/components/cv-combo-box/cv-combo-box.vue
M       packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
M       packages/core/src/components/cv-data-table/cv-data-table-action.vue
M       packages/core/src/components/cv-data-table/cv-data-table-row.vue
M       packages/core/src/components/cv-data-table/cv-data-table-skeleton.vue
M       packages/core/src/components/cv-data-table/cv-data-table.vue
M       packages/core/src/components/cv-date-picker/cv-date-picker.vue
M       packages/core/src/components/cv-dropdown/cv-dropdown.vue
M       packages/core/src/components/cv-modal/cv-modal.vue
M       packages/core/src/components/cv-multi-select/cv-multi-select.vue
M       packages/core/src/components/cv-number-input/cv-number-input.vue
M       packages/core/src/components/cv-select/cv-select.vue
M       packages/core/src/components/cv-text-area/cv-text-area.vue
M       packages/core/src/components/cv-text-input/cv-text-input.vue
M       packages/core/src/components/cv-time-picker/cv-time-picker.vue
M       packages/core/src/components/cv-ui-shell/cv-header.vue
M       packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
M       packages/core/src/components/cv-ui-shell/cv-side-nav-menu.vue
M       storybook/_storybook/utils/knobs-helper.js
M       storybook/_storybook/views/sv-template-view/sv-template-view.vue
M       storybook/stories/cv-combo-box-story.js
M       storybook/stories/cv-date-picker-story.js
M       storybook/stories/cv-dropdown-story.js
M       storybook/stories/cv-multi-select-story.js
M       storybook/stories/cv-select-story.js
M       storybook/stories/cv-time-picker-story.js