### PR TITLE
feat: add tests for cv-text-area component|

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-text-area.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-text-area.test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CvTextArea should render correctly 1`] = `
+<div class="cv-text-area bx--form-item"><label for="1" class="bx--label">test label</label>
+  <!---->
+  <div class="bx--text-area__wrapper">
+    <!----> <textarea id="1" class="bx--text-area"></textarea></div>
+  <!---->
+</div>
+`;
+
+exports[`CvTextArea should render correctly when helper text is provided 1`] = `
+<div class="cv-text-area bx--form-item"><label for="1" class="bx--label">test label</label>
+  <div class="bx--form__helper-text">helper test message</div>
+  <div class="bx--text-area__wrapper">
+    <!----> <textarea id="1" class="bx--text-area"></textarea></div>
+  <!---->
+</div>
+`;
+
+exports[`CvTextArea should render correctly when helper text slot is provided 1`] = `
+<div class="cv-text-area bx--form-item"><label for="1" class="bx--label">test label</label>
+  <div class="bx--form__helper-text">
+    <div class="helper-text-class">helper text slot</div>
+  </div>
+  <div class="bx--text-area__wrapper">
+    <!----> <textarea id="1" class="bx--text-area"></textarea></div>
+  <!---->
+</div>
+`;
+
+exports[`CvTextArea should render correctly when invalid message is provided 1`] = `
+<div class="cv-text-area bx--form-item"><label for="1" class="bx--label">test label</label>
+  <!---->
+  <div data-invalid="true" class="bx--text-area__wrapper">
+    <warningfilled16-stub class="bx--text-area__invalid-icon"></warningfilled16-stub> <textarea id="1" class="bx--text-area bx--text-area--invalid"></textarea>
+  </div>
+  <div class="bx--form-requirement">invalid test message</div>
+</div>
+`;
+
+exports[`CvTextArea should render correctly when invalid message slot is provided 1`] = `
+<div class="cv-text-area bx--form-item"><label for="1" class="bx--label">test label</label>
+  <!---->
+  <div data-invalid="true" class="bx--text-area__wrapper">
+    <warningfilled16-stub class="bx--text-area__invalid-icon"></warningfilled16-stub> <textarea id="1" class="bx--text-area bx--text-area--invalid"></textarea>
+  </div>
+  <div class="bx--form-requirement">
+    <div class="invalid-message-class">invalid message slot</div>
+  </div>
+</div>
+`;
+
+exports[`CvTextArea should render correctly when light theme is used 1`] = `
+<div class="cv-text-area bx--form-item"><label for="1" class="bx--label">test label</label>
+  <!---->
+  <div class="bx--text-area__wrapper">
+    <!----> <textarea id="1" class="bx--text-area bx--text-area--light"></textarea></div>
+  <!---->
+</div>
+`;

--- a/packages/core/__tests__/cv-text-area.test.js
+++ b/packages/core/__tests__/cv-text-area.test.js
@@ -1,0 +1,119 @@
+import { shallowMount as shallow, mount } from '@vue/test-utils';
+import { testComponent } from './_helpers';
+import { CvTextArea } from '@/components/cv-text-area';
+
+describe('CvTextArea', () => {
+  // ***************
+  // PROP CHECKS
+  // ***************
+  testComponent.propsAreType(CvTextArea, ['helperText', 'invalidMessage', 'label', 'value', 'id', 'theme'], String);
+  testComponent.propsHaveDefaultOfUndefined(CvTextArea, ['helperText', 'invalidMessage']);
+  testComponent.propsHaveDefault(CvTextArea, ['theme']);
+
+  // ***************
+  // SNAPSHOT TESTS
+  // ***************
+  it('should render correctly', () => {
+    const propsData = { label: 'test label', value: 'test value', id: '1' };
+    const wrapper = shallow(CvTextArea, { propsData });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should render correctly when light theme is used', () => {
+    const propsData = { label: 'test label', value: 'test value', id: '1', theme: 'light' };
+    const wrapper = shallow(CvTextArea, { propsData });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should render correctly when invalid message is provided', () => {
+    const propsData = { label: 'test label', value: 'test value', invalidMessage: 'invalid test message', id: '1' };
+    const wrapper = shallow(CvTextArea, { propsData });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should render correctly when invalid message slot is provided', () => {
+    const propsData = { label: 'test label', value: 'test value', id: '1' };
+    const wrapper = shallow(CvTextArea, {
+      slots: {
+        'invalid-message': '<div class="invalid-message-class">invalid message slot</div>',
+      },
+      propsData,
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should render correctly when helper text is provided', () => {
+    const propsData = { label: 'test label', value: 'test value', helperText: 'helper test message', id: '1' };
+    const wrapper = shallow(CvTextArea, { propsData });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should render correctly when helper text slot is provided', () => {
+    const propsData = { label: 'test label', value: 'test value', id: '1' };
+    const wrapper = shallow(CvTextArea, {
+      slots: {
+        'helper-text': '<div class="helper-text-class">helper text slot</div>',
+      },
+      propsData,
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  // ***************
+  // FUNCTIONAL TESTS
+  // ***************
+
+  it('inValid should be true when invalid message is provided', () => {
+    const propsData = { label: 'test label', value: 'test value', invalidMessage: 'invalid test message', id: '1' };
+    const wrapper = shallow(CvTextArea, { propsData });
+    expect(wrapper.vm.isInvalid).toEqual(true);
+  });
+
+  it('inValid should be true when invalid message slot is provided', () => {
+    const propsData = { label: 'test label', value: 'test value', id: '1' };
+    const wrapper = mount(CvTextArea, {
+      slots: {
+        'invalid-message': '<div class="invalid-message-class">invalid message slot</div>',
+      },
+      propsData,
+    });
+    expect(wrapper.vm.isInvalid).toEqual(true);
+  });
+
+  it('inValid should be false when invalid message slot and invalid message are not provided', () => {
+    const propsData = { label: 'test label', value: 'test value', id: '1' };
+    const wrapper = shallow(CvTextArea, { propsData });
+    expect(wrapper.vm.isInvalid).toEqual(false);
+  });
+
+  it('isHelper should be true when helper text is provided', () => {
+    const propsData = { label: 'test label', value: 'test value', helperText: 'helper text test message', id: '1' };
+    const wrapper = shallow(CvTextArea, { propsData });
+    expect(wrapper.vm.isHelper).toEqual(true);
+  });
+
+  it('isHelper should be true when helper text slot is provided', () => {
+    const propsData = { label: 'test label', value: 'test value', id: '1' };
+    const wrapper = shallow(CvTextArea, {
+      slots: {
+        'helper-text': '<div class="helper-text-class">helper text slot</div>',
+      },
+      propsData,
+    });
+    expect(wrapper.vm.isHelper).toEqual(true);
+  });
+
+  it('isHelper should be false when helper text slot and helper text are not provided', () => {
+    const propsData = { label: 'test label', value: 'test value', id: '1' };
+    const wrapper = shallow(CvTextArea, { propsData });
+    expect(wrapper.vm.isHelper).toEqual(false);
+  });
+
+  it('should emit current value on change', () => {
+    const value = 'test value';
+    const propsData = { label: 'test label', value, id: '1' };
+    const wrapper = shallow(CvTextArea, { propsData });
+    wrapper.find('textarea').trigger('input');
+    expect(wrapper.emitted().input[0]).toEqual([value]);
+  });
+});

--- a/packages/core/src/components/cv-text-area/cv-text-area.vue
+++ b/packages/core/src/components/cv-text-area/cv-text-area.vue
@@ -57,10 +57,12 @@ export default {
       };
     },
     isInvalid() {
-      return this.$slots['invalid-message'] !== undefined || (this.invalidMessage && this.invalidMessage.length);
+      return Boolean(
+        this.$slots['invalid-message'] !== undefined || (this.invalidMessage && this.invalidMessage.length)
+      );
     },
     isHelper() {
-      return this.$slots['helper-text'] || (this.helperText && this.helperText.length);
+      return Boolean(this.$slots['helper-text'] || (this.helperText && this.helperText.length));
     },
   },
 };


### PR DESCRIPTION
#182

Add tests for CvTextArea component. Noticed, that isInvalid and isHelper computed values return Number, not Boolean - changed that.

#### Changelog

A       packages/core/__tests__/__snapshots__/cv-text-area.test.js.snap
A       packages/core/__tests__/cv-text-area.test.js
M       packages/core/src/components/cv-text-area/cv-text-area.vue
