### PR TITLE
fix: snapshot test for cv-number-input with slots

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-number-input.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-number-input.test.js.snap
@@ -37,7 +37,9 @@ exports[`CvNumberInput should match snapshot when all props are provided 1`] = `
 exports[`CvNumberInput should match snapshot when helper-text slot is provided 1`] = `
 <cv-wrapper-stub tagtype="div" class="cv-number-input bx--form-item">
   <div data-numberinput="" class="bx--number bx--number--helpertext"><label for="1" class="bx--label"></label>
-    <div class="bx--form__helper-text">test</div>
+    <div class="bx--form__helper-text">
+      <div class="fake-slot">my helper text</div>
+    </div>
     <div class="bx--number__input-wrapper"><input id="1" type="number">
       <!---->
       <div class="bx--number__controls"><button type="button" aria-label="Increase number input" class="bx--number__control-btn up-icon">
@@ -53,7 +55,7 @@ exports[`CvNumberInput should match snapshot when helper-text slot is provided 1
 
 exports[`CvNumberInput should match snapshot when invalid-message slot is provided 1`] = `
 <cv-wrapper-stub tagtype="div" class="cv-number-input bx--form-item">
-  <div data-numberinput="" data-invalid="4" class="bx--number"><label for="1" class="bx--label"></label>
+  <div data-numberinput="" data-invalid="true" class="bx--number"><label for="1" class="bx--label"></label>
     <!---->
     <div class="bx--number__input-wrapper"><input id="1" type="number">
       <warningfilled16-stub class="bx--number__invalid"></warningfilled16-stub>
@@ -63,7 +65,9 @@ exports[`CvNumberInput should match snapshot when invalid-message slot is provid
           <caretdownglyph-stub></caretdownglyph-stub>
         </button></div>
     </div>
-    <div class="bx--form-requirement">test</div>
+    <div class="bx--form-requirement">
+      <div class="fake-slot">my invalid message</div>
+    </div>
   </div>
 </cv-wrapper-stub>
 `;

--- a/packages/core/__tests__/cv-number-input.test.js
+++ b/packages/core/__tests__/cv-number-input.test.js
@@ -92,32 +92,26 @@ describe('CvNumberInput', () => {
   it('should match snapshot when invalid-message slot is provided', () => {
     const id = '1';
     const value = 5;
-    const invalidMessage = 'test';
-    const wrapper = shallow(
-      CvNumberInput,
-      { propsData: { id, value, invalidMessage } },
-      {
-        slots: {
-          'invalid-message': '<div class="fake-slot">my invalid message</div>',
-        },
-      }
-    );
+    const propsData = { id, value };
+    const wrapper = shallow(CvNumberInput, {
+      slots: {
+        'invalid-message': '<div class="fake-slot">my invalid message</div>',
+      },
+      propsData,
+    });
     expect(wrapper.html()).toMatchSnapshot();
   });
 
   it('should match snapshot when helper-text slot is provided', () => {
     const id = '1';
     const value = 5;
-    const helperText = 'test';
-    const wrapper = shallow(
-      CvNumberInput,
-      { propsData: { id, value, helperText } },
-      {
-        slots: {
-          'helper-text': '<div class="fake-slot">my helper text</div>',
-        },
-      }
-    );
+    const propsData = { id, value };
+    const wrapper = shallow(CvNumberInput, {
+      slots: {
+        'helper-text': '<div class="fake-slot">my helper text</div>',
+      },
+      propsData,
+    });
     expect(wrapper.html()).toMatchSnapshot();
   });
 


### PR DESCRIPTION
#182

Noticed that slots were not used correctly in snapshot tests for CvNumberInput. Also I think isInvalid should return Boolean (I did not change that).

#### Changelog

M       packages/core/__tests__/__snapshots__/cv-number-input.test.js.snap
M       packages/core/__tests__/cv-number-input.test.js
