### PR TITLE
fix: correct overflow menu dom

### DIFF
--- a/packages/core/src/components/cv-overflow-menu/cv-overflow-menu-item.vue
+++ b/packages/core/src/components/cv-overflow-menu/cv-overflow-menu-item.vue
@@ -15,7 +15,9 @@
       v-on="$listeners"
       @click="onClick"
     >
-      <slot></slot>
+      <span class="bx--overflow-menu-options__option-content">
+        <slot></slot>
+      </span>
     </button>
   </li>
 </template>


### PR DESCRIPTION
Updated overflow menu html to include bx--overflow-menu-options__option-content which was missing

#### Changelog

M       packages/core/src/components/cv-overflow-menu/cv-overflow-menu-item.vue
