### PR TITLE
fix: cvmultiselect label not used when filterable is true

### DIFF
--- a/packages/core/src/components/cv-multi-select/cv-multi-select.vue
+++ b/packages/core/src/components/cv-multi-select/cv-multi-select.vue
@@ -73,7 +73,7 @@
             role="combobox"
             :aria-expanded="open"
             autocomplete="off"
-            placeholder="Filter"
+            :placeholder="label"
             v-model="filter"
             @input="onInput"
             @focus="inputFocus"


### PR DESCRIPTION
Closes #699 

Makes the input's placeholder use the `label` prop

#### Changelog

M packages/core/src/components/cv-multi-select/cv-multi-select.vue
