### PR TITLE
feat: add ending state to inline loading

### DIFF
--- a/packages/core/src/components/cv-inline-loading/consts.js
+++ b/packages/core/src/components/cv-inline-loading/consts.js
@@ -2,6 +2,7 @@ const STATES = {
   LOADED: 'loaded',
   ERROR: 'error',
   LOADING: 'loading',
+  ENDING: 'ending',
 };
 
 export { STATES };

--- a/packages/core/src/components/cv-inline-loading/cv-inline-loading-notes.md
+++ b/packages/core/src/components/cv-inline-loading/cv-inline-loading-notes.md
@@ -13,6 +13,7 @@ http://www.carbondesignsystem.com/components/inline-loading/code
 ## Attributes
 
 - loadingText: Text shown in loading state
+- endingText: Text shown in when load is ending
 - loadedText: Text shown in complete state
 - errorText: Text shown in error state
-- state: String containing 'loading', 'loaded' or 'error'
+- state: String containing 'loading', 'ending', 'loaded' or 'error'

--- a/packages/core/src/components/cv-inline-loading/cv-inline-loading.vue
+++ b/packages/core/src/components/cv-inline-loading/cv-inline-loading.vue
@@ -1,7 +1,15 @@
 <template>
   <div data-inline-loading class="bx--inline-loading" role="alert" aria-live="assertive">
-    <div class="bx--inline-loading__animation">
-      <cv-loading :hidden="internalState !== STATES.LOADING" small />
+    <div class="bx--inline-loading__animation" :class="{ 'bx--loading--stop': internalState === STATES.ENDING }">
+      <div
+        v-show="internalState === STATES.LOADING || internalState === STATES.ENDING"
+        class="bx--loading bx--loading--small"
+      >
+        <svg class="bx--loading__svg" viewBox="-75 -75 150 150">
+          <circle class="bx--loading__background" cx="0" cy="0" r="26.8125" />
+          <circle class="bx--loading__stroke" cx="0" cy="0" r="26.8125" />
+        </svg>
+      </div>
       <CheckmarkFilled16 :hidden="internalState !== STATES.LOADED" class="bx--inline-loading__checkmark-container" />
       <Error20 :hidden="internalState !== STATES.ERROR" class="bx--inline-loading--error" />
     </div>
@@ -11,13 +19,12 @@
 
 <script>
 import { STATES } from './consts';
-import CvLoading from '../cv-loading/cv-loading';
 import Error20 from '@carbon/icons-vue/lib/error/20';
 import CheckmarkFilled16 from '@carbon/icons-vue/lib/checkmark--filled/16';
 
 export default {
   name: 'CvInlineLoading',
-  components: { CvLoading, Error20, CheckmarkFilled16 },
+  components: { Error20, CheckmarkFilled16 },
   created() {
     this.STATES = STATES;
   },
@@ -32,6 +39,7 @@ export default {
         return true;
       },
     },
+    endingText: { type: String, default: 'Load ending...' },
     errorText: { type: String, default: 'Loading data failed.' },
     loadingText: { type: String, default: 'Loading data...' },
     loadedText: { type: String, default: 'Data loaded.' },
@@ -62,6 +70,8 @@ export default {
           return this.loadedText;
         case STATES.ERROR:
           return this.errorText;
+        case STATES.ENDING:
+          return this.endingText;
         default:
           return this.loadingText;
       }

--- a/storybook/stories/cv-inline-loading-story.js
+++ b/storybook/stories/cv-inline-loading-story.js
@@ -12,6 +12,12 @@ const storiesDefault = storiesOf('Components/CvInlineLoading', module);
 const storiesExperimental = storiesOf('Experimental/CvInlineLoading', module);
 
 const preKnobs = {
+  endingText: {
+    group: 'attr',
+    type: text,
+    config: ['ending text', 'Ending...'],
+    prop: 'ending-text',
+  },
   errorText: {
     group: 'attr',
     type: text,


### PR DESCRIPTION
Adds ending state to inline loading component

#### Changelog

M       packages/core/src/components/cv-inline-loading/consts.js
M       packages/core/src/components/cv-inline-loading/cv-inline-loading-notes.md
M       packages/core/src/components/cv-inline-loading/cv-inline-loading.vue
M       storybook/stories/cv-inline-loading-story.js
