### PR TITLE
feat: add tests for cv-inline-loading

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-inline-loading.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-inline-loading.test.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CvInlineLoading should render correctly when state is ENDING\` 1`] = `
+<div data-inline-loading="" role="alert" aria-live="assertive" class="bx--inline-loading">
+  <div class="bx--inline-loading__animation bx--loading--stop">
+    <div class="bx--loading bx--loading--small"><svg viewBox="-75 -75 150 150" class="bx--loading__svg">
+        <circle cx="0" cy="0" r="26.8125" class="bx--loading__background"></circle>
+        <circle cx="0" cy="0" r="26.8125" class="bx--loading__stroke"></circle>
+      </svg></div>
+    <checkmarkfilled16-stub hidden="true" class="bx--inline-loading__checkmark-container"></checkmarkfilled16-stub>
+    <error20-stub hidden="true" class="bx--inline-loading--error"></error20-stub>
+  </div>
+  <p class="bx--inline-loading__text">Load ending...</p>
+</div>
+`;
+
+exports[`CvInlineLoading should render correctly when state is ERROR\` 1`] = `
+<div data-inline-loading="" role="alert" aria-live="assertive" class="bx--inline-loading">
+  <div class="bx--inline-loading__animation">
+    <div class="bx--loading bx--loading--small" style="display: none;"><svg viewBox="-75 -75 150 150" class="bx--loading__svg">
+        <circle cx="0" cy="0" r="26.8125" class="bx--loading__background"></circle>
+        <circle cx="0" cy="0" r="26.8125" class="bx--loading__stroke"></circle>
+      </svg></div>
+    <checkmarkfilled16-stub hidden="true" class="bx--inline-loading__checkmark-container"></checkmarkfilled16-stub>
+    <error20-stub class="bx--inline-loading--error"></error20-stub>
+  </div>
+  <p class="bx--inline-loading__text">error text test</p>
+</div>
+`;
+
+exports[`CvInlineLoading should render correctly when state is LOADED\` 1`] = `
+<div data-inline-loading="" role="alert" aria-live="assertive" class="bx--inline-loading">
+  <div class="bx--inline-loading__animation">
+    <div class="bx--loading bx--loading--small" style="display: none;"><svg viewBox="-75 -75 150 150" class="bx--loading__svg">
+        <circle cx="0" cy="0" r="26.8125" class="bx--loading__background"></circle>
+        <circle cx="0" cy="0" r="26.8125" class="bx--loading__stroke"></circle>
+      </svg></div>
+    <checkmarkfilled16-stub class="bx--inline-loading__checkmark-container"></checkmarkfilled16-stub>
+    <error20-stub hidden="true" class="bx--inline-loading--error"></error20-stub>
+  </div>
+  <p class="bx--inline-loading__text">loaded text test</p>
+</div>
+`;
+
+exports[`CvInlineLoading should render correctly when state is LOADING\` 1`] = `
+<div data-inline-loading="" role="alert" aria-live="assertive" class="bx--inline-loading">
+  <div class="bx--inline-loading__animation">
+    <div class="bx--loading bx--loading--small"><svg viewBox="-75 -75 150 150" class="bx--loading__svg">
+        <circle cx="0" cy="0" r="26.8125" class="bx--loading__background"></circle>
+        <circle cx="0" cy="0" r="26.8125" class="bx--loading__stroke"></circle>
+      </svg></div>
+    <checkmarkfilled16-stub hidden="true" class="bx--inline-loading__checkmark-container"></checkmarkfilled16-stub>
+    <error20-stub hidden="true" class="bx--inline-loading--error"></error20-stub>
+  </div>
+  <p class="bx--inline-loading__text">loading text test</p>
+</div>
+`;

--- a/packages/core/__tests__/cv-inline-loading.test.js
+++ b/packages/core/__tests__/cv-inline-loading.test.js
@@ -1,0 +1,121 @@
+import { shallowMount as shallow } from '@vue/test-utils';
+import { testComponent } from './_helpers';
+import { CvInlineLoading } from '@/components/cv-inline-loading';
+
+describe('CvInlineLoading', () => {
+  const STATES = CvInlineLoading.CONSTS().STATES;
+
+  // ***************
+  // PROP CHECKS
+  // ***************
+  testComponent.propsAreType(CvInlineLoading, ['active'], Boolean);
+  testComponent.propsAreType(
+    CvInlineLoading,
+    ['endingText', 'errorText', 'loadingText', 'loadedText', 'state'],
+    String
+  );
+  testComponent.propsHaveDefault(CvInlineLoading, ['endingText', 'errorText', 'loadingText', 'loadedText']);
+  testComponent.propsHaveDefaultOfUndefined(CvInlineLoading, ['active', 'state']);
+
+  it('`state` prop validator works as expected', () => {
+    const wrapper = shallow(CvInlineLoading);
+    expect(
+      wrapper.vm.$options.props.state.validator && wrapper.vm.$options.props.state.validator(STATES.LOADED)
+    ).toBeTruthy();
+    expect(
+      wrapper.vm.$options.props.state.validator && wrapper.vm.$options.props.state.validator(STATES.ERROR)
+    ).toBeTruthy();
+    expect(
+      wrapper.vm.$options.props.state.validator && wrapper.vm.$options.props.state.validator(STATES.LOADING)
+    ).toBeTruthy();
+    expect(
+      wrapper.vm.$options.props.state.validator && wrapper.vm.$options.props.state.validator(STATES.ENDING)
+    ).toBeTruthy();
+
+    // suppress the error message from the state validator
+    const consoleError = console.error;
+    console.error = jest.fn();
+
+    expect(wrapper.vm.$options.props.state.validator && wrapper.vm.$options.props.state.validator('TEST')).toBeFalsy();
+
+    // restore
+    console.error = consoleError;
+  });
+
+  // ***************
+  // SNAPSHOT TESTS
+  // ***************
+
+  it('should render correctly when state is LOADED`', () => {
+    const propsData = { state: STATES.LOADED, loadedText: 'loaded text test' };
+    const wrapper = shallow(CvInlineLoading, { propsData });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should render correctly when state is LOADING`', () => {
+    const propsData = { state: STATES.LOADING, loadingText: 'loading text test' };
+    const wrapper = shallow(CvInlineLoading, { propsData });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should render correctly when state is ERROR`', () => {
+    const propsData = { state: STATES.ERROR, errorText: 'error text test' };
+    const wrapper = shallow(CvInlineLoading, { propsData });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should render correctly when state is ENDING`', () => {
+    const propsData = { state: STATES.ENDING, errorText: 'ending text test' };
+    const wrapper = shallow(CvInlineLoading, { propsData });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  // ***************
+  // FUNCTIONAL TESTS
+  // ***************
+  it('`state` prop overrides `active` prop', () => {
+    const propsData = { state: STATES.ERROR, active: true };
+    const wrapper = shallow(CvInlineLoading, { propsData });
+    expect(wrapper.vm.internalState).toEqual(STATES.ERROR);
+  });
+
+  it('`active` truthy prop results in LOADING `internalState`', () => {
+    const propsData = { active: true };
+    const wrapper = shallow(CvInlineLoading, { propsData });
+    expect(wrapper.vm.internalState).toEqual(STATES.LOADING);
+  });
+
+  it('`active` falsy prop results in LOADED `internalState`', () => {
+    const propsData = { active: false };
+    const wrapper = shallow(CvInlineLoading, { propsData });
+    expect(wrapper.vm.internalState).toEqual(STATES.LOADED);
+  });
+
+  it('`stateText` should be equal to `loadedText` prop when state is LOADED', () => {
+    const loadedText = 'loaded text test';
+    const propsData = { state: STATES.LOADED, loadedText };
+    const wrapper = shallow(CvInlineLoading, { propsData });
+    expect(wrapper.vm.stateText).toEqual(loadedText);
+  });
+
+  it('`stateText` should be equal to `errorText` prop when state is ERROR', () => {
+    const errorText = 'error text test';
+    const propsData = { state: STATES.ERROR, errorText };
+    const wrapper = shallow(CvInlineLoading, { propsData });
+    expect(wrapper.vm.stateText).toEqual(errorText);
+  });
+
+  it('`stateText` should be equal to `ending` prop when state is ENDING', () => {
+    const endingText = 'ending text test';
+    const propsData = { state: STATES.ENDING, endingText };
+    const wrapper = shallow(CvInlineLoading, { propsData });
+    expect(wrapper.vm.stateText).toEqual(endingText);
+  });
+
+  it('`stateText` should be equal to `ending` prop when state is LOADING', () => {
+    const loadingText = 'loading text test';
+    const propsData = { state: STATES.LOADING, loadingText };
+    const wrapper = shallow(CvInlineLoading, { propsData });
+    expect(wrapper.vm.stateText).toEqual(loadingText);
+  });
+});

--- a/packages/core/src/components/cv-inline-loading/cv-inline-loading.vue
+++ b/packages/core/src/components/cv-inline-loading/cv-inline-loading.vue
@@ -50,7 +50,7 @@ export default {
         if (Object.keys(STATES).some(state => STATES[state] === val)) {
           return true;
         } else {
-          console.error(`CvInlineLoading: Valid states are ${STATES}`);
+          console.error(`CvInlineLoading: Valid states are ${JSON.stringify(Object.keys(STATES))}`);
           return false;
         }
       },


### PR DESCRIPTION
#182

Add tests for CvInlineLoading component. I changed one output inside a prop validator to make the error message more informative:

From:
![image](https://user-images.githubusercontent.com/5481483/69729003-dd26ef80-1125-11ea-9a9b-9e2f4f607199.png)

To: 

![image](https://user-images.githubusercontent.com/5481483/69729014-e0ba7680-1125-11ea-86df-a4684b40d8b6.png)

#### Changelog

A       packages/core/__tests__/__snapshots__/cv-inline-loading.test.js.snap
A       packages/core/__tests__/cv-inline-loading.test.js
M       packages/core/src/components/cv-inline-loading/cv-inline-loading.vue
