### PR TITLE
test: add tests for cv-toast-notification

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-toast-notification.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-toast-notification.test.js.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CvToastNotification should render correctly 1`] = `
+<div data-notification="" role="alert" class="cv-notifiation bx--toast-notification bx--toast-notification--error">
+  <errorfilled20-stub class="bx--toast-notification__icon"></errorfilled20-stub>
+  <div class="bx--toast-notification__details">
+    <h3 class="bx--toast-notification__title"></h3>
+    <p class="bx--toast-notification__subtitle"></p>
+    <p class="bx--toast-notification__caption">TEST</p>
+  </div> <button aria-label="Dismiss notification" type="button" data-notification-btn="" class="bx--toast-notification__close-button">
+    <close20-stub class="bx--toast-notification__close-icon"></close20-stub>
+  </button>
+</div>
+`;
+
+exports[`CvToastNotification should render correctly 2`] = `
+<div data-notification="" aria-live="polite" class="cv-notifiation bx--toast-notification bx--toast-notification--info">
+  <!---->
+  <div class="bx--toast-notification__details">
+    <h3 class="bx--toast-notification__title"></h3>
+    <p class="bx--toast-notification__subtitle"></p>
+    <p class="bx--toast-notification__caption">TEST</p>
+  </div> <button aria-label="Dismiss notification" type="button" data-notification-btn="" class="bx--toast-notification__close-button">
+    <close20-stub class="bx--toast-notification__close-icon"></close20-stub>
+  </button>
+</div>
+`;
+
+exports[`CvToastNotification should render correctly 3`] = `
+<div data-notification="" role="alert" class="cv-notifiation bx--toast-notification bx--toast-notification--warning">
+  <warningaltfilled20-stub class="bx--toast-notification__icon"></warningaltfilled20-stub>
+  <div class="bx--toast-notification__details">
+    <h3 class="bx--toast-notification__title"></h3>
+    <p class="bx--toast-notification__subtitle"></p>
+    <p class="bx--toast-notification__caption">TEST</p>
+  </div> <button aria-label="Dismiss notification" type="button" data-notification-btn="" class="bx--toast-notification__close-button">
+    <close20-stub class="bx--toast-notification__close-icon"></close20-stub>
+  </button>
+</div>
+`;
+
+exports[`CvToastNotification should render correctly 4`] = `
+<div data-notification="" aria-live="polite" class="cv-notifiation bx--toast-notification bx--toast-notification--success">
+  <checkmarkfilled20-stub class="bx--toast-notification__icon"></checkmarkfilled20-stub>
+  <div class="bx--toast-notification__details">
+    <h3 class="bx--toast-notification__title"></h3>
+    <p class="bx--toast-notification__subtitle"></p>
+    <p class="bx--toast-notification__caption">TEST</p>
+  </div> <button aria-label="Dismiss notification" type="button" data-notification-btn="" class="bx--toast-notification__close-button">
+    <close20-stub class="bx--toast-notification__close-icon"></close20-stub>
+  </button>
+</div>
+`;

--- a/packages/core/__tests__/cv-toast-notification.test.js
+++ b/packages/core/__tests__/cv-toast-notification.test.js
@@ -1,0 +1,74 @@
+import { shallowMount as shallow } from '@vue/test-utils';
+import { testComponent } from './_helpers';
+import { CvToastNotification } from '@/components/cv-toast-notification';
+import ErrorFilled20 from '@carbon/icons-vue/es/error--filled/20';
+import CheckmarkFilled20 from '@carbon/icons-vue/es/checkmark--filled/20';
+import WarningAltFilled20 from '@carbon/icons-vue/es/warning--alt--filled/20';
+
+describe('CvToastNotification', () => {
+  const kinds = ['error', 'info', 'warning', 'success'];
+
+  // ***************
+  // PROP CHECKS
+  // ***************
+  testComponent.propsAreType(CvToastNotification, ['lowContrast'], Boolean);
+  testComponent.propsAreType(CvToastNotification, ['caption', 'closeAriaLabel', 'kind'], String);
+  testComponent.propsHaveDefault(CvToastNotification, ['closeAriaLabel', 'kind']);
+
+  it('`kind` prop validator works as expected', () => {
+    const propsData = { caption: 'TEST', lowContrast: false };
+
+    const wrapper = shallow(CvToastNotification, { propsData });
+    for (const kind of kinds) {
+      expect(wrapper.vm.$options.props.kind.validator && wrapper.vm.$options.props.kind.validator(kind)).toBeTruthy();
+    }
+
+    // suppress the error message from the kind validator
+    const consoleError = console.error;
+    console.error = jest.fn();
+
+    expect(wrapper.vm.$options.props.kind.validator && wrapper.vm.$options.props.kind.validator('TEST')).toBeFalsy();
+
+    // restore
+    console.error = consoleError;
+  });
+
+  // ***************
+  // SNAPSHOT TESTS
+  // ***************
+
+  it('should render correctly', () => {
+    const propsData = { caption: 'TEST', lowContrast: false, kind: '' };
+    for (const kind of kinds) {
+      propsData.kind = kind;
+      const wrapper = shallow(CvToastNotification, { propsData });
+      expect(wrapper.html()).toMatchSnapshot();
+    }
+  });
+
+  // ***************
+  // FUNCTIONAL TESTS
+  // ***************
+
+  it('`icon` is computed correctly', () => {
+    const kindToIconMapping = {
+      error: ErrorFilled20,
+      warning: WarningAltFilled20,
+      success: CheckmarkFilled20,
+      info: '',
+    };
+    const propsData = { caption: 'TEST', lowContrast: false, kind: '' };
+    for (const kind of kinds) {
+      propsData.kind = kind;
+      const wrapper = shallow(CvToastNotification, { propsData });
+      expect(wrapper.vm.icon).toEqual(kindToIconMapping[kind]);
+    }
+  });
+
+  it('should emit close event when close button is clicked', () => {
+    const propsData = { caption: 'TEST', lowContrast: false };
+    const wrapper = shallow(CvToastNotification, { propsData });
+    wrapper.find('button').trigger('click');
+    expect(wrapper.emitted().close).toBeTruthy();
+  });
+});

--- a/packages/core/src/components/cv-toast-notification/cv-toast-notification.vue
+++ b/packages/core/src/components/cv-toast-notification/cv-toast-notification.vue
@@ -56,7 +56,7 @@ export default {
         case 'success':
           return CheckmarkFilled20;
         default:
-          return null;
+          return '';
       }
     },
   },


### PR DESCRIPTION
#182 

Add tests for CvToastNotification component. I changed small part in the component to get rid of this error when I was using 'info' toast notification:
![image](https://user-images.githubusercontent.com/5481483/69804934-e7a5bf80-11df-11ea-8c41-ce5fd26ab9f9.png)


#### Changelog

A       packages/core/__tests__/__snapshots__/cv-toast-notification.test.js.snap
A       packages/core/__tests__/cv-toast-notification.test.js
M       packages/core/src/components/cv-toast-notification/cv-toast-notification.vue
