### PR TITLE
fix: ensure build can complete without network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@ node_modules
 package-lock.json
 
 # package info, regenerated during builds
-package-info.json
+package-info.jsonl

--- a/storybook/.storybook/webpack.config.js
+++ b/storybook/.storybook/webpack.config.js
@@ -24,8 +24,13 @@ module.exports = async ({ config, mode }) => {
     include: path.resolve(__dirname, '../../'),
   });
 
+  config.module.rules.push({
+    test: /\.jsonl$/,
+    loaders: ['jsonlines-loader'],
+  });
+
   // auto prefix anything in a vue file
-  config.resolve.extensions.push('.js', '.vue', '.json');
+  config.resolve.extensions.push('.js', '.vue', '.json', '.jsonl');
   let vueLoaderConfig = config.module.rules.find(item => {
     return item.loader && item.loader.indexOf('vue-loader') > -1;
   });

--- a/storybook/_storybook/views/sv-template-view/sv-welcome.vue
+++ b/storybook/_storybook/views/sv-template-view/sv-welcome.vue
@@ -161,13 +161,15 @@
               >GitHub.</a
             >
           </p>
-          <ul>
+          <ul v-if="hasPackageInfo">
             <li>{{ packageName }} latest version: {{ packageLatest }}</li>
             <li v-for="(version, tag) of packageOtherTags" :key="tag">
               {{ packageName }} {{ tag }} version: {{ version }}
             </li>
           </ul>
-          <p>Last updated {{ packageUpdated }} <br />Copyright © 2019 IBM</p>
+          <p>
+            <span v-if="hasPackageInfo">Last updated {{ packageUpdated }} <br /></span>Copyright © 2019 IBM
+          </p>
         </div>
       </div>
       <div class="bx--row">
@@ -186,11 +188,15 @@
 </template>
 
 <script>
-import packageInfo from '../../../../package-info';
+import packageInfoRaw from '../../../../package-info';
+const packageInfo = Object.values(packageInfoRaw).reduce((acc, line) => (line.type === 'inspect' ? line : acc), 0);
 
 export default {
   name: 'SvWelcome',
   computed: {
+    hasPackageInfo() {
+      return !!packageInfo;
+    },
     packageName() {
       return packageInfo.data.name;
     },

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "> TODO: description",
   "scripts": {
-    "start": "yarn info @carbon/vue --json > ../package-info.json; start-storybook -p 9001 -c .storybook",
-    "build": "yarn info @carbon/vue --json > ../package-info.json; build-storybook"
+    "start": "yarn info @carbon/vue --json > ../package-info.jsonl; start-storybook -p 9001 -c .storybook",
+    "build": "yarn info @carbon/vue --json > ../package-info.jsonl; build-storybook"
   },
   "dependencies": {
     "@carbon/icons-vue": "10.6.1",
@@ -27,6 +27,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-vue": "^2.0.2",
+    "jsonlines-loader": "^1.0.1",
     "postcss-import": "^12.0.1",
     "postcss-loader": "^3.0.0",
     "postcss-preset-env": "^6.7.0",


### PR DESCRIPTION
Closes #712

parse package info more robustly, and cope with error logs in it

**NB** anyone with an existing clone of carbon-components-vue that they have built at least once will find an untracked file 'package-info.json' shows up when they pull this change in -- it should simply be deleted.

#### Changelog

M       .gitignore
M       storybook/.storybook/webpack.config.js
M       storybook/_storybook/views/sv-template-view/sv-welcome.vue
M       storybook/package.json
