### PR TITLE
test: add tests for cv-inline-notification

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-inline-notification.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-inline-notification.test.js.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CvInlineNotification should render correctly 1`] = `
+<div data-notification="" role="alert" class="cv-inline-notification bx--inline-notification bx--inline-notification--error">
+  <div class="bx--inline-notification__details">
+    <errorfilled20-stub class="bx--inline-notification__icon"></errorfilled20-stub>
+    <div class="bx--inline-notification__text-wrapper">
+      <p class="bx--inline-notification__title"></p>
+      <p class="bx--inline-notification__subtitle"></p>
+    </div>
+  </div> <button type="button" class="bx--inline-notification__action-button bx--btn bx--btn--sm bx--btn--ghost">
+    test action label
+  </button> <button type="button" aria-label="Dismiss notification" data-notification-btn="" class="bx--inline-notification__close-button">
+    <close20-stub class="bx--inline-notification__close-icon"></close20-stub>
+  </button>
+</div>
+`;
+
+exports[`CvInlineNotification should render correctly 2`] = `
+<div data-notification="" aria-live="polite" class="cv-inline-notification bx--inline-notification bx--inline-notification--info">
+  <div class="bx--inline-notification__details">
+    <!---->
+    <div class="bx--inline-notification__text-wrapper">
+      <p class="bx--inline-notification__title"></p>
+      <p class="bx--inline-notification__subtitle"></p>
+    </div>
+  </div> <button type="button" class="bx--inline-notification__action-button bx--btn bx--btn--sm bx--btn--ghost">
+    test action label
+  </button> <button type="button" aria-label="Dismiss notification" data-notification-btn="" class="bx--inline-notification__close-button">
+    <close20-stub class="bx--inline-notification__close-icon"></close20-stub>
+  </button>
+</div>
+`;
+
+exports[`CvInlineNotification should render correctly 3`] = `
+<div data-notification="" role="alert" class="cv-inline-notification bx--inline-notification bx--inline-notification--warning">
+  <div class="bx--inline-notification__details">
+    <warningfilled20-stub class="bx--inline-notification__icon"></warningfilled20-stub>
+    <div class="bx--inline-notification__text-wrapper">
+      <p class="bx--inline-notification__title"></p>
+      <p class="bx--inline-notification__subtitle"></p>
+    </div>
+  </div> <button type="button" class="bx--inline-notification__action-button bx--btn bx--btn--sm bx--btn--ghost">
+    test action label
+  </button> <button type="button" aria-label="Dismiss notification" data-notification-btn="" class="bx--inline-notification__close-button">
+    <close20-stub class="bx--inline-notification__close-icon"></close20-stub>
+  </button>
+</div>
+`;
+
+exports[`CvInlineNotification should render correctly 4`] = `
+<div data-notification="" aria-live="polite" class="cv-inline-notification bx--inline-notification bx--inline-notification--success">
+  <div class="bx--inline-notification__details">
+    <checkmarkfilled20-stub class="bx--inline-notification__icon"></checkmarkfilled20-stub>
+    <div class="bx--inline-notification__text-wrapper">
+      <p class="bx--inline-notification__title"></p>
+      <p class="bx--inline-notification__subtitle"></p>
+    </div>
+  </div> <button type="button" class="bx--inline-notification__action-button bx--btn bx--btn--sm bx--btn--ghost">
+    test action label
+  </button> <button type="button" aria-label="Dismiss notification" data-notification-btn="" class="bx--inline-notification__close-button">
+    <close20-stub class="bx--inline-notification__close-icon"></close20-stub>
+  </button>
+</div>
+`;
+
+exports[`CvInlineNotification should render correctly when low contrast is used 1`] = `
+<div data-notification="" role="alert" class="cv-inline-notification bx--inline-notification bx--inline-notification--error bx--inline-notification--low-contrast">
+  <div class="bx--inline-notification__details">
+    <errorfilled20-stub class="bx--inline-notification__icon"></errorfilled20-stub>
+    <div class="bx--inline-notification__text-wrapper">
+      <p class="bx--inline-notification__title"></p>
+      <p class="bx--inline-notification__subtitle"></p>
+    </div>
+  </div> <button type="button" class="bx--inline-notification__action-button bx--btn bx--btn--sm bx--btn--ghost">
+    test action label
+  </button> <button type="button" aria-label="Dismiss notification" data-notification-btn="" class="bx--inline-notification__close-button">
+    <close20-stub class="bx--inline-notification__close-icon"></close20-stub>
+  </button>
+</div>
+`;
+
+exports[`CvInlineNotification should render correctly when low contrast is used 2`] = `
+<div data-notification="" aria-live="polite" class="cv-inline-notification bx--inline-notification bx--inline-notification--info bx--inline-notification--low-contrast">
+  <div class="bx--inline-notification__details">
+    <!---->
+    <div class="bx--inline-notification__text-wrapper">
+      <p class="bx--inline-notification__title"></p>
+      <p class="bx--inline-notification__subtitle"></p>
+    </div>
+  </div> <button type="button" class="bx--inline-notification__action-button bx--btn bx--btn--sm bx--btn--ghost">
+    test action label
+  </button> <button type="button" aria-label="Dismiss notification" data-notification-btn="" class="bx--inline-notification__close-button">
+    <close20-stub class="bx--inline-notification__close-icon"></close20-stub>
+  </button>
+</div>
+`;
+
+exports[`CvInlineNotification should render correctly when low contrast is used 3`] = `
+<div data-notification="" role="alert" class="cv-inline-notification bx--inline-notification bx--inline-notification--warning bx--inline-notification--low-contrast">
+  <div class="bx--inline-notification__details">
+    <warningfilled20-stub class="bx--inline-notification__icon"></warningfilled20-stub>
+    <div class="bx--inline-notification__text-wrapper">
+      <p class="bx--inline-notification__title"></p>
+      <p class="bx--inline-notification__subtitle"></p>
+    </div>
+  </div> <button type="button" class="bx--inline-notification__action-button bx--btn bx--btn--sm bx--btn--ghost">
+    test action label
+  </button> <button type="button" aria-label="Dismiss notification" data-notification-btn="" class="bx--inline-notification__close-button">
+    <close20-stub class="bx--inline-notification__close-icon"></close20-stub>
+  </button>
+</div>
+`;
+
+exports[`CvInlineNotification should render correctly when low contrast is used 4`] = `
+<div data-notification="" aria-live="polite" class="cv-inline-notification bx--inline-notification bx--inline-notification--success bx--inline-notification--low-contrast">
+  <div class="bx--inline-notification__details">
+    <checkmarkfilled20-stub class="bx--inline-notification__icon"></checkmarkfilled20-stub>
+    <div class="bx--inline-notification__text-wrapper">
+      <p class="bx--inline-notification__title"></p>
+      <p class="bx--inline-notification__subtitle"></p>
+    </div>
+  </div> <button type="button" class="bx--inline-notification__action-button bx--btn bx--btn--sm bx--btn--ghost">
+    test action label
+  </button> <button type="button" aria-label="Dismiss notification" data-notification-btn="" class="bx--inline-notification__close-button">
+    <close20-stub class="bx--inline-notification__close-icon"></close20-stub>
+  </button>
+</div>
+`;

--- a/packages/core/__tests__/cv-inline-notification.test.js
+++ b/packages/core/__tests__/cv-inline-notification.test.js
@@ -69,7 +69,7 @@ describe('CvInlineNotification', () => {
   //   for (const kind of kinds) {
   //     propsData.kind = kind;
   //     const wrapper = shallow(CvInlineNotification, { propsData });
-  //     expect(wrapper.vm.icon).toBe(kindToIconMapping[kind]);
+  //     expect(wrapper.vm.icon).toEqual(kindToIconMapping[kind]);
   //   }
   // });
 

--- a/packages/core/__tests__/cv-inline-notification.test.js
+++ b/packages/core/__tests__/cv-inline-notification.test.js
@@ -3,7 +3,7 @@ import { testComponent } from './_helpers';
 import { CvInlineNotification } from '@/components/cv-inline-notification';
 import ErrorFilled20 from '@carbon/icons-vue/es/error--filled/20';
 import CheckmarkFilled20 from '@carbon/icons-vue/es/checkmark--filled/20';
-import WarningAltFilled20 from '@carbon/icons-vue/es/warning--alt--filled/20';
+import WarningFilled20 from '@carbon/icons-vue/es/warning--filled/20';
 
 describe('CvInlineNotification', () => {
   const kinds = ['error', 'info', 'warning', 'success'];
@@ -58,20 +58,20 @@ describe('CvInlineNotification', () => {
   // FUNCTIONAL TESTS
   // ***************
 
-  // it('`icon` is computed correctly', () => {
-  //   const kindToIconMapping = {
-  //     error: ErrorFilled20,
-  //     warning: WarningAltFilled20,
-  //     success: CheckmarkFilled20,
-  //     info: '',
-  //   };
-  //   const propsData = { actionLabel: 'test action label', lowContrast: false, kind: '' };
-  //   for (const kind of kinds) {
-  //     propsData.kind = kind;
-  //     const wrapper = shallow(CvInlineNotification, { propsData });
-  //     expect(wrapper.vm.icon).toEqual(kindToIconMapping[kind]);
-  //   }
-  // });
+  it('`icon` is computed correctly', () => {
+    const kindToIconMapping = {
+      error: ErrorFilled20,
+      warning: WarningFilled20,
+      success: CheckmarkFilled20,
+      info: '',
+    };
+    const propsData = { actionLabel: 'test action label', lowContrast: false, kind: '' };
+    for (const kind of kinds) {
+      propsData.kind = kind;
+      const wrapper = shallow(CvInlineNotification, { propsData });
+      expect(wrapper.vm.icon).toEqual(kindToIconMapping[kind]);
+    }
+  });
 
   it('should emit close event when close button is clicked', () => {
     const propsData = { actionLabel: 'test action label', lowContrast: false };

--- a/packages/core/__tests__/cv-inline-notification.test.js
+++ b/packages/core/__tests__/cv-inline-notification.test.js
@@ -1,0 +1,89 @@
+import { shallowMount as shallow } from '@vue/test-utils';
+import { testComponent } from './_helpers';
+import { CvInlineNotification } from '@/components/cv-inline-notification';
+import ErrorFilled20 from '@carbon/icons-vue/es/error--filled/20';
+import CheckmarkFilled20 from '@carbon/icons-vue/es/checkmark--filled/20';
+import WarningAltFilled20 from '@carbon/icons-vue/es/warning--alt--filled/20';
+
+describe('CvInlineNotification', () => {
+  const kinds = ['error', 'info', 'warning', 'success'];
+
+  // ***************
+  // PROP CHECKS
+  // ***************
+  testComponent.propsAreType(CvInlineNotification, ['lowContrast'], Boolean);
+  testComponent.propsAreType(CvInlineNotification, ['actionLabel', 'closeAriaLabel', 'kind'], String);
+  testComponent.propsHaveDefault(CvInlineNotification, ['closeAriaLabel', 'kind', 'actionLabel']);
+
+  it('`kind` prop validator works as expected', () => {
+    const propsData = { lowContrast: false };
+
+    const wrapper = shallow(CvInlineNotification, { propsData });
+    for (const kind of kinds) {
+      expect(wrapper.vm.$options.props.kind.validator && wrapper.vm.$options.props.kind.validator(kind)).toBeTruthy();
+    }
+
+    // suppress the error message from the kind validator
+    const consoleError = console.error;
+    console.error = jest.fn();
+
+    expect(wrapper.vm.$options.props.kind.validator && wrapper.vm.$options.props.kind.validator('TEST')).toBeFalsy();
+
+    // restore
+    console.error = consoleError;
+  });
+
+  // ***************
+  // SNAPSHOT TESTS
+  // ***************
+  it('should render correctly', () => {
+    const propsData = { lowContrast: false, kind: '', actionLabel: 'test action label' };
+    for (const kind of kinds) {
+      propsData.kind = kind;
+      const wrapper = shallow(CvInlineNotification, { propsData });
+      expect(wrapper.html()).toMatchSnapshot();
+    }
+  });
+
+  it('should render correctly when low contrast is used', () => {
+    const propsData = { lowContrast: true, kind: '', actionLabel: 'test action label' };
+    for (const kind of kinds) {
+      propsData.kind = kind;
+      const wrapper = shallow(CvInlineNotification, { propsData });
+      expect(wrapper.html()).toMatchSnapshot();
+    }
+  });
+
+  // ***************
+  // FUNCTIONAL TESTS
+  // ***************
+
+  // it('`icon` is computed correctly', () => {
+  //   const kindToIconMapping = {
+  //     error: ErrorFilled20,
+  //     warning: WarningAltFilled20,
+  //     success: CheckmarkFilled20,
+  //     info: '',
+  //   };
+  //   const propsData = { actionLabel: 'test action label', lowContrast: false, kind: '' };
+  //   for (const kind of kinds) {
+  //     propsData.kind = kind;
+  //     const wrapper = shallow(CvInlineNotification, { propsData });
+  //     expect(wrapper.vm.icon).toBe(kindToIconMapping[kind]);
+  //   }
+  // });
+
+  it('should emit close event when close button is clicked', () => {
+    const propsData = { actionLabel: 'test action label', lowContrast: false };
+    const wrapper = shallow(CvInlineNotification, { propsData });
+    wrapper.find('.bx--inline-notification__close-button').trigger('click');
+    expect(wrapper.emitted().close).toBeTruthy();
+  });
+
+  it('should emit action event when action button is clicked', () => {
+    const propsData = { actionLabel: 'test action label', lowContrast: false };
+    const wrapper = shallow(CvInlineNotification, { propsData });
+    wrapper.find('.bx--inline-notification__action-button').trigger('click');
+    expect(wrapper.emitted().action).toBeTruthy();
+  });
+});

--- a/packages/core/src/components/cv-inline-notification/cv-inline-notification.vue
+++ b/packages/core/src/components/cv-inline-notification/cv-inline-notification.vue
@@ -70,7 +70,7 @@ export default {
         case 'success':
           return CheckmarkFilled20;
         default:
-          return null;
+          return '';
       }
     },
   },

--- a/packages/core/src/components/cv-inline-notification/cv-inline-notification.vue
+++ b/packages/core/src/components/cv-inline-notification/cv-inline-notification.vue
@@ -43,7 +43,7 @@
 import notificationMixin from '../../mixins/notification-mixin';
 import ErrorFilled20 from '@carbon/icons-vue/es/error--filled/20';
 import CheckmarkFilled20 from '@carbon/icons-vue/es/checkmark--filled/20';
-import WarningAltFilled20 from '@carbon/icons-vue/es/warning--filled/20';
+import WarningFilled20 from '@carbon/icons-vue/es/warning--filled/20';
 import Close20 from '@carbon/icons-vue/es/close/20';
 
 export default {
@@ -66,7 +66,7 @@ export default {
         case 'error':
           return ErrorFilled20;
         case 'warning':
-          return WarningAltFilled20;
+          return WarningFilled20;
         case 'success':
           return CheckmarkFilled20;
         default:


### PR DESCRIPTION
#182

Tests for `CvInlineNotification`. I am having a problem with testing computed `icon` value. It should be the same as for `CvToastNotification`, but it fails with the error and I have no idea why. The test is commented.

![image](https://user-images.githubusercontent.com/5481483/69880815-4b58e700-12cb-11ea-97ae-20a028fabce8.png)

#### Changelog

A       packages/core/__tests__/__snapshots__/cv-inline-notification.test.js.snap
A       packages/core/__tests__/cv-inline-notification.test.js
M       packages/core/src/components/cv-inline-notification/cv-inline-notification.vue
