### PR TITLE
fix: use warning--filled/20 icon for warning toast notification

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-toast-notification.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-toast-notification.test.js.snap
@@ -28,7 +28,7 @@ exports[`CvToastNotification should render correctly 2`] = `
 
 exports[`CvToastNotification should render correctly 3`] = `
 <div data-notification="" role="alert" class="cv-notifiation bx--toast-notification bx--toast-notification--warning">
-  <warningaltfilled20-stub class="bx--toast-notification__icon"></warningaltfilled20-stub>
+  <warningfilled20-stub class="bx--toast-notification__icon"></warningfilled20-stub>
   <div class="bx--toast-notification__details">
     <h3 class="bx--toast-notification__title"></h3>
     <p class="bx--toast-notification__subtitle"></p>
@@ -80,7 +80,7 @@ exports[`CvToastNotification should render correctly when low contrast is used 2
 
 exports[`CvToastNotification should render correctly when low contrast is used 3`] = `
 <div data-notification="" role="alert" class="cv-notifiation bx--toast-notification bx--toast-notification--warning bx--toast-notification--low-contrast">
-  <warningaltfilled20-stub class="bx--toast-notification__icon"></warningaltfilled20-stub>
+  <warningfilled20-stub class="bx--toast-notification__icon"></warningfilled20-stub>
   <div class="bx--toast-notification__details">
     <h3 class="bx--toast-notification__title"></h3>
     <p class="bx--toast-notification__subtitle"></p>

--- a/packages/core/__tests__/cv-toast-notification.test.js
+++ b/packages/core/__tests__/cv-toast-notification.test.js
@@ -3,7 +3,7 @@ import { testComponent } from './_helpers';
 import { CvToastNotification } from '@/components/cv-toast-notification';
 import ErrorFilled20 from '@carbon/icons-vue/es/error--filled/20';
 import CheckmarkFilled20 from '@carbon/icons-vue/es/checkmark--filled/20';
-import WarningAltFilled20 from '@carbon/icons-vue/es/warning--alt--filled/20';
+import WarningFilled20 from '@carbon/icons-vue/es/warning--filled/20';
 
 describe('CvToastNotification', () => {
   const kinds = ['error', 'info', 'warning', 'success'];
@@ -62,7 +62,7 @@ describe('CvToastNotification', () => {
   it('`icon` is computed correctly', () => {
     const kindToIconMapping = {
       error: ErrorFilled20,
-      warning: WarningAltFilled20,
+      warning: WarningFilled20,
       success: CheckmarkFilled20,
       info: '',
     };

--- a/packages/core/src/components/cv-toast-notification/cv-toast-notification.vue
+++ b/packages/core/src/components/cv-toast-notification/cv-toast-notification.vue
@@ -29,7 +29,7 @@
 import notificationMixin from '../../mixins/notification-mixin';
 import ErrorFilled20 from '@carbon/icons-vue/es/error--filled/20';
 import CheckmarkFilled20 from '@carbon/icons-vue/es/checkmark--filled/20';
-import WarningAltFilled20 from '@carbon/icons-vue/es/warning--alt--filled/20';
+import WarningFilled20 from '@carbon/icons-vue/es/warning--filled/20';
 import Close20 from '@carbon/icons-vue/es/close/20';
 
 export default {
@@ -52,7 +52,7 @@ export default {
         case 'error':
           return ErrorFilled20;
         case 'warning':
-          return WarningAltFilled20;
+          return WarningFilled20;
         case 'success':
           return CheckmarkFilled20;
         default:


### PR DESCRIPTION
According to carbon design website (https://www.carbondesignsystem.com/components/notification/code), warning toast notification uses warning--filled/20 icon instead of warning--alt--filled/20.

#### Changelog

M       packages/core/__tests__/__snapshots__/cv-toast-notification.test.js.snap
M       packages/core/__tests__/cv-toast-notification.test.js
M       packages/core/src/components/cv-toast-notification/cv-toast-notification.vue