### PR TITLE
feat: support Location for router-link

### DIFF
--- a/packages/core/__tests__/cv-link.test.js
+++ b/packages/core/__tests__/cv-link.test.js
@@ -7,7 +7,8 @@ describe('CvLink', () => {
   // PROP CHECKS
   // ***************
   testComponent.propsAreType(CvLink, ['inline', 'disabled'], Boolean);
-  testComponent.propsAreType(CvLink, ['to', 'href'], String);
+  testComponent.propsAreType(CvLink, ['href'], String);
+  testComponent.propsAreType(CvLink, ['to'], [String, Object]);
 
   // ***************
   // SNAPSHOT TESTS

--- a/packages/core/src/mixins/link-mixin.js
+++ b/packages/core/src/mixins/link-mixin.js
@@ -1,7 +1,7 @@
 export default {
   props: {
     disabled: Boolean,
-    to: String,
+    to: { type: [String, Object] },
     href: String,
   },
   computed: {


### PR DESCRIPTION
Closes #738

Allow an object to be passed to the 'to' property of the cv-link

#### Changelog

M       packages/core/__tests__/cv-link.test.js
M       packages/core/src/mixins/link-mixin.js