### PR TITLE
Fix typo in property declaration

### DIFF
--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -215,7 +215,7 @@ export default {
     sortable: Boolean,
     title: String,
     columns: { type: Array, required: true },
-    data: { type: Array, requried: true },
+    data: { type: Array, required: true },
     zebra: Boolean,
     rowsSelected: { type: Array, default: () => [] },
     helperText: { type: String, default: undefined },

--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -215,7 +215,7 @@ export default {
     sortable: Boolean,
     title: String,
     columns: { type: Array, required: true },
-    data: { type: Array, required: true },
+    data: { type: Array },
     zebra: Boolean,
     rowsSelected: { type: Array, default: () => [] },
     helperText: { type: String, default: undefined },


### PR DESCRIPTION
Closes #749

Fix `required` property typo in `CvDataTable` component

#### Changelog

The git diff returns nothing, this is the commit info:

```
commit 4f25b400ae2ff627084ceb68f6e6e50f3a8ed63f (HEAD -> master, origin/master, origin/HEAD)
``` 
