### PR TITLE
Fix property name causing reference issue

### DIFF
--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -215,7 +215,7 @@ export default {
     sortable: Boolean,
     title: String,
     columns: { type: Array, required: true },
-    data: { type: Array, requried: true },
+    data: { type: Array, required: true },
     zebra: Boolean,
     rowsSelected: { type: Array, default: () => [] },
     helperText: { type: String, default: undefined },

--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -215,7 +215,7 @@ export default {
     sortable: Boolean,
     title: String,
     columns: { type: Array, required: true },
-    data: { type: Array, required: true },
+    data: { type: Array },
     zebra: Boolean,
     rowsSelected: { type: Array, default: () => [] },
     helperText: { type: String, default: undefined },

--- a/packages/core/src/components/cv-date-picker/cv-date-picker.vue
+++ b/packages/core/src/components/cv-date-picker/cv-date-picker.vue
@@ -244,7 +244,7 @@ export default {
       if (this.dataValue) {
         if (this.isRange) {
           firstDate = dateToString(this.dataValue.startDate);
-          secondDate = dateToString(this.vdataValuealue.endDate);
+          secondDate = dateToString(this.dataValue.endDate);
         } else {
           firstDate = dateToString(this.dataValue);
         }


### PR DESCRIPTION
Closes #762

Fix `dataValue` property reference which was causing a runtime error while trying to access `endDate` value while on range mode of the `CvDatePicker` component.

#### Changelog

M packages/core/src/components/cv-date-picker/cv-date-picker.vue