### PR TITLE
Number input decimal input

### DIFF
--- a/packages/core/src/components/cv-number-input/cv-number-input.vue
+++ b/packages/core/src/components/cv-number-input/cv-number-input.vue
@@ -105,7 +105,12 @@ export default {
   },
   watch: {
     value() {
-      this.internalValue = this.valueAsString(this.value);
+      if (parseFloat(this.internalValue) !== parseFloat(this.value)) {
+        // prevents this.value of 1 updating this.internalValue of 1.0
+        // which improves the typing experience
+        // does not matter if this.value is string or number
+        this.internalValue = this.value.toString();
+      }
     },
   },
   computed: {
@@ -118,6 +123,7 @@ export default {
       });
     },
     internalNumberValue() {
+      // NOTE: '10' === '10.'
       let numVal = parseFloat(this.internalValue, 10);
 
       if (isNaN(numVal)) {
@@ -223,11 +229,10 @@ export default {
     valueAsString(val) {
       let strVal;
       if (typeof val === 'number') {
-        strVal = val.toFixed(this.stepDecimalPlaces);
+        strVal = this.roundToPrecision(val, this.stepDecimalPlaces);
       } else {
         strVal = val;
       }
-
       return strVal;
     },
     roundToPrecision(x, optDecimalPlaces) {

--- a/storybook/stories/cv-number-input-story.js
+++ b/storybook/stories/cv-number-input-story.js
@@ -142,11 +142,11 @@ let variants = [
   },
   {
     name: 'helper and invalid slots',
-    excludes: ['vModel', 'events', 'numValue', 'vModelNum', , 'numMin', 'numMax', 'numStep'],
+    excludes: ['vModel', 'events', 'numValue', 'vModelNum', 'numMin', 'numMax', 'numStep'],
   },
   { name: 'minimal', includes: ['label'] },
-  { name: 'vModel', includes: ['label', 'vModel', 'events'] },
-  { name: 'vModelNum', includes: ['label', 'vModelNum', 'events'] },
+  { name: 'vModel', includes: ['label', 'vModel', 'step', 'events'] },
+  { name: 'vModelNum', includes: ['label', 'vModelNum', 'numStep', 'events'] },
 ];
 
 let storySet = knobsHelper.getStorySet(variants, preKnobs);
@@ -175,7 +175,7 @@ for (const story of storySet) {
       <template slot="other">
         <div v-if="${templateString.indexOf('v-model') > 0}">
           <label>Model value:
-            <input type="number" v-model="modelValue"/>
+            <input type="number" v-model="modelValue" :step="propStep" />
           </label>
         </div>
       </template>
@@ -195,24 +195,29 @@ for (const story of storySet) {
         },
         watch: {
           modelValue() {
-            let intVal = parseInt(this.modelValue, 10);
+            let val;
+            if (this.propStep.indexOf('.') >= 0) {
+              val = parseFloat(this.modelValue);
+            } else {
+              val = parseInt(this.modelValue);
+            }
 
-            if (isNaN(intVal)) {
-              intVal = 0;
+            if (isNaN(val)) {
+              val = 0;
             }
-            if (intVal !== this.modelValueNum) {
-              this.modelValueNum = intVal;
-            }
+            this.modelValueNum = val;
           },
           modelValueNum() {
-            let val = '' + this.modelValueNum;
-            if (this.modelValue !== val) {
-              this.modelValue = '' + this.modelValueNum;
-            }
+            this.modelValue = '' + this.modelValueNum;
           },
         },
         methods: {
           onInput: action('cv-number-input - input event'),
+        },
+        computed: {
+          propStep() {
+            return this.$props.step || this.$props.numStep.toString();
+          },
         },
       };
     },


### PR DESCRIPTION
Fixes a problem when using a number type for value and a step of 0.01 with v-model or bound value. In this case if the user tried typed to reduce the number of decimal places below 2 the component would add the decimal places back in and place the cursor after the last 0.

Updated storybook so step knob works with v-model

#### Changelog

M       packages/core/src/components/cv-number-input/cv-number-input.vue
M       storybook/stories/cv-number-input-story.js
