### PR TITLE
Number input test upd

### DIFF
--- a/packages/core/__tests__/cv-number-input.test.js
+++ b/packages/core/__tests__/cv-number-input.test.js
@@ -164,7 +164,7 @@ describe('CvNumberInput', () => {
 
   it('should emit String when value prop is String', () => {
     const id = '1';
-    const value = '5';
+    const value = '555';
     const wrapper = shallow(CvNumberInput, { propsData: { id, value } });
     wrapper.find('.up-icon').trigger('click');
     expect(wrapper.emitted().input[0]).toEqual([(parseInt(value) + 1).toString()]);

--- a/packages/core/src/components/cv-number-input/cv-number-input.vue
+++ b/packages/core/src/components/cv-number-input/cv-number-input.vue
@@ -229,7 +229,7 @@ export default {
     valueAsString(val) {
       let strVal;
       if (typeof val === 'number') {
-        strVal = this.roundToPrecision(val, this.stepDecimalPlaces);
+        strVal = this.roundToPrecision(val, this.stepDecimalPlaces).toString();
       } else {
         strVal = val;
       }


### PR DESCRIPTION
Correct type emitted from CvNumberInput when value is string

#### Changelog

M       packages/core/__tests__/cv-number-input.test.js
M       packages/core/src/components/cv-number-input/cv-number-input.vue

