### PR TITLE
fix(inline-loading): change Error20 icon to ErrorFilled16

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-inline-loading.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-inline-loading.test.js.snap
@@ -8,7 +8,7 @@ exports[`CvInlineLoading should render correctly when state is ENDING\` 1`] = `
         <circle cx="0" cy="0" r="26.8125" class="bx--loading__stroke"></circle>
       </svg></div>
     <checkmarkfilled16-stub hidden="true" class="bx--inline-loading__checkmark-container"></checkmarkfilled16-stub>
-    <error20-stub hidden="true" class="bx--inline-loading--error"></error20-stub>
+    <errorfilled16-stub hidden="true" class="bx--inline-loading--error"></errorfilled16-stub>
   </div>
   <p class="bx--inline-loading__text">Load ending...</p>
 </div>
@@ -22,7 +22,7 @@ exports[`CvInlineLoading should render correctly when state is ERROR\` 1`] = `
         <circle cx="0" cy="0" r="26.8125" class="bx--loading__stroke"></circle>
       </svg></div>
     <checkmarkfilled16-stub hidden="true" class="bx--inline-loading__checkmark-container"></checkmarkfilled16-stub>
-    <error20-stub class="bx--inline-loading--error"></error20-stub>
+    <errorfilled16-stub class="bx--inline-loading--error"></errorfilled16-stub>
   </div>
   <p class="bx--inline-loading__text">error text test</p>
 </div>
@@ -36,7 +36,7 @@ exports[`CvInlineLoading should render correctly when state is LOADED\` 1`] = `
         <circle cx="0" cy="0" r="26.8125" class="bx--loading__stroke"></circle>
       </svg></div>
     <checkmarkfilled16-stub class="bx--inline-loading__checkmark-container"></checkmarkfilled16-stub>
-    <error20-stub hidden="true" class="bx--inline-loading--error"></error20-stub>
+    <errorfilled16-stub hidden="true" class="bx--inline-loading--error"></errorfilled16-stub>
   </div>
   <p class="bx--inline-loading__text">loaded text test</p>
 </div>
@@ -50,7 +50,7 @@ exports[`CvInlineLoading should render correctly when state is LOADING\` 1`] = `
         <circle cx="0" cy="0" r="26.8125" class="bx--loading__stroke"></circle>
       </svg></div>
     <checkmarkfilled16-stub hidden="true" class="bx--inline-loading__checkmark-container"></checkmarkfilled16-stub>
-    <error20-stub hidden="true" class="bx--inline-loading--error"></error20-stub>
+    <errorfilled16-stub hidden="true" class="bx--inline-loading--error"></errorfilled16-stub>
   </div>
   <p class="bx--inline-loading__text">loading text test</p>
 </div>

--- a/packages/core/src/components/cv-inline-loading/cv-inline-loading.vue
+++ b/packages/core/src/components/cv-inline-loading/cv-inline-loading.vue
@@ -11,7 +11,7 @@
         </svg>
       </div>
       <CheckmarkFilled16 :hidden="internalState !== STATES.LOADED" class="bx--inline-loading__checkmark-container" />
-      <Error20 :hidden="internalState !== STATES.ERROR" class="bx--inline-loading--error" />
+      <ErrorFilled16 :hidden="internalState !== STATES.ERROR" class="bx--inline-loading--error" />
     </div>
     <p class="bx--inline-loading__text">{{ stateText }}</p>
   </div>
@@ -19,12 +19,12 @@
 
 <script>
 import { STATES } from './consts';
-import Error20 from '@carbon/icons-vue/lib/error/20';
+import ErrorFilled16 from '@carbon/icons-vue/lib/error--filled/16';
 import CheckmarkFilled16 from '@carbon/icons-vue/lib/checkmark--filled/16';
 
 export default {
   name: 'CvInlineLoading',
-  components: { Error20, CheckmarkFilled16 },
+  components: { ErrorFilled16, CheckmarkFilled16 },
   created() {
     this.STATES = STATES;
   },


### PR DESCRIPTION
This PR brings over the icon change in the InlineLoading component from the react package: https://github.com/carbon-design-system/carbon/pull/5018

#### Changelog

```
M       packages/core/__tests__/__snapshots__/cv-inline-loading.test.js.snap
M       packages/core/src/components/cv-inline-loading/cv-inline-loading.vue
```