### PR TITLE
fix: story copy button position

### DIFF
--- a/storybook/_storybook/views/sv-template-view/sv-template-view.vue
+++ b/storybook/_storybook/views/sv-template-view/sv-template-view.vue
@@ -190,7 +190,7 @@ $component-padding: 20px;
 
 .sv-template-view__copy {
   position: absolute;
-  top: 39px;
+  top: 54px;
   left: 0;
 
   &.sv-template-view__copy--copied::after {


### PR DESCRIPTION
Closes #801

Correct story copy button position.

#### Changelog

m storybook/_storybook/views/sv-template-view/sv-template-view.vue 