### PR TITLE
Cv input use fix

### DIFF
--- a/packages/core/src/components/cv-pagination/cv-pagination.vue
+++ b/packages/core/src/components/cv-pagination/cv-pagination.vue
@@ -6,7 +6,7 @@
         :label="`${pageSizesLabel}`"
         inline
         ref="pageSizeSelect"
-        @input="onPageSizeChange"
+        @change="onPageSizeChange"
         :value="`${pageSizeValue}`"
       >
         <cv-select-option
@@ -31,8 +31,9 @@
         inline
         hideLabel
         ref="pageSelect"
-        @input="onPageChange"
+        @change="onPageChange"
         :value="`${pageValue}`"
+        v-if="numberOfItems !== Infinity"
       >
         <cv-select-option
           v-for="pageNumber in pages"
@@ -189,7 +190,7 @@ export default {
       if (items !== Infinity) {
         return `of ${pages} pages`;
       }
-      return '';
+      return `Page ${this.pageValue}`;
     },
     rangeProps() {
       return {

--- a/packages/core/src/components/cv-time-picker/cv-time-picker.vue
+++ b/packages/core/src/components/cv-time-picker/cv-time-picker.vue
@@ -21,7 +21,7 @@
         :form-item="false"
         hide-label
         :label="ampmSelectLabel"
-        @input="$emit('update:ampm', $event)"
+        @change="$emit('update:ampm', $event)"
         :value="ampm"
         :disabled="disabled"
       >
@@ -36,7 +36,7 @@
         :label="timezonesSelectLabel"
         v-if="timezones.length > 0"
         :value="validTimezone"
-        @input="$emit('update:timezone', $event)"
+        @change="$emit('update:timezone', $event)"
         :disabled="disabled"
       >
         <cv-select-option class="bx--select-option" v-for="item in timezones" :key="item.value" :value="item.value">{{


### PR DESCRIPTION
Closes #821 #720

Use change event where CvSelect is used internally to support IE11. Pagination and  time picker are affected.

#### Changelog

m packages/core/src/components/cv-pagination/cv-pagination.vue 
m packages/core/src/components/cv-time-picker/cv-time-picker.vue 
