### PR TITLE
fix: lower case loading states

### DIFF
--- a/packages/core/__tests__/cv-inline-loading.test.js
+++ b/packages/core/__tests__/cv-inline-loading.test.js
@@ -32,6 +32,23 @@ describe('CvInlineLoading', () => {
       wrapper.vm.$options.props.state.validator && wrapper.vm.$options.props.state.validator(STATES.ENDING)
     ).toBeTruthy();
 
+    // accept lower case
+    expect(
+      wrapper.vm.$options.props.state.validator &&
+        wrapper.vm.$options.props.state.validator(STATES.LOADED.toUpperCase())
+    ).toBeTruthy();
+    expect(
+      wrapper.vm.$options.props.state.validator && wrapper.vm.$options.props.state.validator(STATES.ERROR.toUpperCase())
+    ).toBeTruthy();
+    expect(
+      wrapper.vm.$options.props.state.validator &&
+        wrapper.vm.$options.props.state.validator(STATES.LOADING.toUpperCase())
+    ).toBeTruthy();
+    expect(
+      wrapper.vm.$options.props.state.validator &&
+        wrapper.vm.$options.props.state.validator(STATES.LOADED.toUpperCase())
+    ).toBeTruthy();
+
     // suppress the error message from the state validator
     const consoleError = console.error;
     console.error = jest.fn();

--- a/packages/core/src/components/cv-inline-loading/cv-inline-loading.vue
+++ b/packages/core/src/components/cv-inline-loading/cv-inline-loading.vue
@@ -47,10 +47,10 @@ export default {
       type: String,
       default: undefined,
       validator: val => {
-        if (Object.keys(STATES).some(state => STATES[state] === val)) {
+        if (Object.keys(STATES).some(state => STATES[state] === val.toLowerCase())) {
           return true;
         } else {
-          console.error(`CvInlineLoading: Valid states are ${JSON.stringify(Object.keys(STATES))}`);
+          console.error(`CvInlineLoading: Valid states are ${JSON.stringify(Object.values(STATES))}`);
           return false;
         }
       },
@@ -59,7 +59,7 @@ export default {
   computed: {
     internalState() {
       if (this.state !== undefined) {
-        return this.state;
+        return this.state.toLowerCase();
       } else {
         return this.active ? STATES.LOADING : STATES.LOADED;
       }


### PR DESCRIPTION
Closes #807

Allow case insensitiviy on inline loading states

#### Changelog

m packages/core/__tests__/cv-inline-loading.test.js 
m packages/core/src/components/cv-inline-loading/cv-inline-loading.vue 