### PR TITLE
fix: ids for controlled panels

### DIFF
--- a/packages/core/src/components/cv-ui-shell/cv-header-panel.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-header-panel.vue
@@ -3,6 +3,7 @@
     class="cv-header-panel bx--header-panel"
     :class="{ 'bx--header-panel--expanded': panelExpanded }"
     :aria-hidden="!panelExpanded"
+    :id="id"
     @focusout="onFocusout"
     @mousedown="onMouseDown"
   >

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav.vue
@@ -8,6 +8,7 @@
       'bx--side-nav--ux': isChildOfHeader,
     }"
     :aria-hidden="!panelExpanded && !fixed"
+    :id="id"
     @focusout="onFocusout"
     @mousedown="onMouseDown"
   >


### PR DESCRIPTION
Add id attribute to panels controlled by header buttons

#### Changelog

m  packages/core/src/components/cv-ui-shell/cv-header-panel.vue 
m  packages/core/src/components/cv-ui-shell/cv-side-nav.vue 