### PR TITLE
fix: content switcher accessibility

### DIFF
--- a/packages/core/src/components/cv-content-switcher/cv-content-switcher-button.vue
+++ b/packages/core/src/components/cv-content-switcher/cv-content-switcher-button.vue
@@ -13,6 +13,7 @@
 <template>
   <button
     type="button"
+    role="tab"
     class="cv-content-switcher-button"
     :class="[
       'bx--content-switcher-btn',
@@ -26,7 +27,7 @@
   >
     <component v-if="typeof icon === 'object'" :is="icon" class="bx--content-switcher__icon" />
     <svg v-if="typeof icon === 'string'" class="bx--content-switcher__icon" height="16" width="16">
-      <use :href="icon"></use>
+      <use :href="icon" />
     </svg>
     <span class="bx--content-switcher__label">
       <slot></slot>


### PR DESCRIPTION
Closes #849

Add role="tab" attribute to content switcher buttons to allow aria-selected

#### Changelog

m. packages/core/src/components/cv-content-switcher/cv-content-switcher-button.vue