### PR TITLE
fix: add role tablist to CvContentSwitcher

### DIFF
--- a/packages/core/src/components/cv-content-switcher/cv-content-switcher.vue
+++ b/packages/core/src/components/cv-content-switcher/cv-content-switcher.vue
@@ -1,5 +1,5 @@
 <template>
-  <div data-content-switcher class="cv-content-switcher bx--content-switcher">
+  <div data-content-switcher class="cv-content-switcher bx--content-switcher" role="tablist">
     <slot></slot>
   </div>
 </template>


### PR DESCRIPTION
Closes #849

Additional update to add tablist to CvContnetSwitcher

#### Changelog

m.  packages/core/src/components/cv-content-switcher/cv-content-switcher.vue
