### PR TITLE
Add `left` and `right` as valid option values

### DIFF
--- a/packages/core/src/components/cv-tooltip/cv-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-tooltip.vue
@@ -23,7 +23,7 @@ export default {
       type: String,
       default: 'top',
       validator(val) {
-        const validValues = ['top', 'bottom'];
+        const validValues = ['top', 'left', 'right', 'bottom'];
         const valid = validValues.includes(val);
         if (!valid) {
           console.warn(`CVTooltip.direction must be one of the following: ${validValues}`);


### PR DESCRIPTION
Closes #862

Accordingly to [this doc](https://vue.carbondesignsystem.com/?path=/info/components-cvtooltip--default-interactive-tootlip), the `direction` property can be configured with the values `'top', 'left', 'right', 'bottom'`.

The tooltip component currently accepts `top` and `bottom` as valid options in its validation logic, but if you do use `left` and `right` you get an error and the expected behavior IS applied.


#### Changelog

Add `left` and `right` options into the validator logic