### PR TITLE
fix: ensure that CvDropdown has single tabindex for accessibility

### DIFF
--- a/packages/core/src/components/cv-dropdown/cv-dropdown.vue
+++ b/packages/core/src/components/cv-dropdown/cv-dropdown.vue
@@ -40,7 +40,6 @@
         :data-value="internalValue"
         :data-invalid="isInvalid"
         class="bx--dropdown"
-        tabindex="0"
         :class="{
           'bx--dropdown--light': theme === 'light',
           'bx--dropdown--up': up,


### PR DESCRIPTION
Closes #868 

Ensures that the Dropdown component only has a single tab index.

#### Changelog

M packages/core/src/components/cv-dropdown/cv-dropdown.vue
