### PR TITLE
Release 2-24-0

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2.24.0
+
+## Feat
+
+- Left and right options added to cv-tooltip
+
+### Fix
+
+- CvDropdown needed multiple tab presses to move past #868
+- CircleCI deployment fix
+
+### Chore
+
+- Warn on duplicate IDs in table row and tab
+- Dependency bot bumps
+- Other dependency version bumps
+- Update documentation on use of expanded/isExpanded in table rows
+
 ## 2.23.2
 
 Publis canary fixes as listed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/vue",
   "description": "A collection of components for the Carbon Design System built using Vue.js",
-  "version": "2.23.2",
+  "version": "2.24.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 2.24.0

## Feat

- Left and right options added to cv-tooltip

### Fix

- CvDropdown needed multiple tab presses to move past #868
- CircleCI deployment fix

### Chore

- Warn on duplicate IDs in table row and tab
- Dependency bot bumps
- Other dependency version bumps
- Update documentation on use of expanded/isExpanded in table rows