### PR TITLE
Add heading slot to CvDataTable component

### DIFF
--- a/packages/core/src/components/cv-data-table/cv-data-table-notes.md
+++ b/packages/core/src/components/cv-data-table/cv-data-table-notes.md
@@ -62,6 +62,26 @@ Like sorting and filtering it is the users responsibility to deal with edited da
 </cv-data-table>
 ```
 
+### Slotting header cells
+
+User can supply slotted content using the CvDataTableHeading component or plain html.
+
+```html
+<cv-data-table :sortable="false" :columns="columns" :data="data">
+  <template slot="heading">
+    <cv-data-table-heading
+      v-for="(column, index) in columns"
+      :key="`column${index}`"
+      :value="`${column}`"
+      :heading="column"
+      :sortable="false"
+      order="none"
+      @sort="val => onSort(index, val)"
+    />
+  </template>
+</cv-data-table>
+```
+
 ## Attributes
 
 - columns: An array containing a list of columns
@@ -99,6 +119,7 @@ Like sorting and filtering it is the users responsibility to deal with edited da
 - batch-actions: Ghost style buttons shown when rows are selected. An array of selected row indexes is returend from the computed property CvDataTable.selectedRows.
 - actions
 - data: overrides passing data as a property, expects CvDataTableRow and CvDataTableCell. CvDataTableCell expects slotted content.
+- heading: expects CvDataTableHeading.
 - expandedContent: (part of cv-data-table-row) additional content displayed when row is expanded
 
 ## Events

--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -113,16 +113,18 @@
                 @change="onHeadingCheckChange"
               />
             </th>
-            <cv-data-table-heading
-              v-for="(column, index) in dataColumns"
-              :key="`${index}:${column}`"
-              :heading="columnHeading(column)"
-              :sortable="isColSortable(column)"
-              :order="column.order"
-              @sort="val => onSort(index, val)"
-              :heading-style="headingStyle(index)"
-              :skeleton="skeleton"
-            />
+            <slot name="heading">
+              <cv-data-table-heading
+                v-for="(column, index) in dataColumns"
+                :key="`${index}:${column}`"
+                :heading="columnHeading(column)"
+                :sortable="isColSortable(column)"
+                :order="column.order"
+                @sort="val => onSort(index, val)"
+                :heading-style="headingStyle(index)"
+                :skeleton="skeleton"
+              />
+            </slot>
             <th v-if="hasOverflowMenu"></th>
           </tr>
         </thead>


### PR DESCRIPTION
Add an option for slotting header cells.

#### Changelog

M packages/core/src/components/cv-data-table/cv-data-table.vue
M packages/core/src/components/cv-data-table/cv-data-table-notes.md
