### PR TITLE
fix: tooltip on icon only button

### DIFF
--- a/packages/core/src/components/cv-button/button-mixin.js
+++ b/packages/core/src/components/cv-button/button-mixin.js
@@ -71,7 +71,7 @@ export default {
           classes.push(`${carbonSettings.prefix}--btn--field`);
         }
 
-        return classes;
+        return classes.join(' ');
       };
     },
   },

--- a/packages/core/src/components/cv-button/cv-icon-button.vue
+++ b/packages/core/src/components/cv-button/cv-icon-button.vue
@@ -27,7 +27,7 @@ export default {
   },
   computed: {
     buttonClasses() {
-      return this.buttonClassOpts({ iconOnly: true });
+      return `${this.buttonClassOpts({ iconOnly: true })} ${this.tipClasses}`;
     },
     tipClasses() {
       const tipPosition = this.tipPosition || 'bottom';


### PR DESCRIPTION
Closes #889

Fix icon-only button tooltip

#### Changelog

M       packages/core/src/components/cv-button/button-mixin.js
M       packages/core/src/components/cv-button/cv-icon-button.vue
