### PR TITLE
feat: add disabled pagination forwards backwards btn

### DIFF
--- a/packages/core/src/components/cv-pagination/cv-pagination-notes.md
+++ b/packages/core/src/components/cv-pagination/cv-pagination-notes.md
@@ -23,6 +23,8 @@ Minimal
 
 ## Attributes
 
+- backwards-button-disabled: manually disable the backwards/previous button
+- forwards-button-disabled: manually disable the foarwards/next button
 - backwards-text: Aria label on page down arrow. Optional defaults to "Previous page"
 - forwards-text: Aria label on page up arrow. Optional defaults to "Next page"
 - page-number-label: Hidden label for page number select. Defaults to "Page number"

--- a/packages/core/src/components/cv-pagination/cv-pagination.vue
+++ b/packages/core/src/components/cv-pagination/cv-pagination.vue
@@ -124,6 +124,8 @@ export default {
   name: 'CvPagination',
   components: { CvSelect, CvSelectOption, CaretLeft16, CaretRight16 },
   props: {
+    backwardsButtonDisabled: Boolean,
+    forwardsButtonDisabled: Boolean,
     backwardText: { type: String, default: 'Prev page' },
     forwardText: { type: String, default: 'Next page' },
     pageNumberLabel: { type: String, default: 'Page number:' },
@@ -173,10 +175,10 @@ export default {
   },
   computed: {
     noWayBack() {
-      return this.pageValue === 1;
+      return this.backwardsButtonDisabled || this.pageValue === 1;
     },
     noWayForward() {
-      return this.pageValue === this.pageCount;
+      return this.forwardsButtonDisabled || this.pageValue === this.pageCount;
     },
     ofNPagesProps() {
       return {

--- a/storybook/stories/cv-pagination-story.js
+++ b/storybook/stories/cv-pagination-story.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/vue';
-import { text, object, number } from '@storybook/addon-knobs';
+import { text, object, number, boolean } from '@storybook/addon-knobs';
 
 import { action } from '@storybook/addon-actions';
 
@@ -57,6 +57,18 @@ const preKnobs = {
     prop: 'page-sizes',
     value: val => val.list,
   },
+  disableBackwards: {
+    group: 'attr',
+    type: boolean,
+    config: ['Disable backwards button', false], // consts.CONFIG], // fails when used with number in storybook 4.1.4
+    prop: 'backwards-button-disabled',
+  },
+  disabledForwards: {
+    group: 'attr',
+    type: boolean,
+    config: ['Disable forwards button', false], // consts.CONFIG], // fails when used with number in storybook 4.1.4
+    prop: 'forwards-button-disabled',
+  },
   events: {
     group: 'attr',
     value: `@change="onChange"`,
@@ -72,7 +84,7 @@ const preKnobs = {
 const variants = [
   { name: 'default', excludes: ['events', 'slots'] },
   { name: 'slottedFields', excludes: ['events'] },
-  { name: 'minimal', includes: [] },
+  { name: 'minimal', includes: ['disabledForwards'] },
   { name: 'events', includes: ['events'] },
 ];
 


### PR DESCRIPTION
Closes #893 

Allow user to manually disable forwards and backwards buttons

#### Changelog

M       packages/core/src/components/cv-pagination/cv-pagination-notes.md
M       packages/core/src/components/cv-pagination/cv-pagination.vue
M       storybook/stories/cv-pagination-story.js
