### PR TITLE
Slotted headings

### DIFF
--- a/packages/core/src/components/cv-data-table/_cv-data-table-heading.vue
+++ b/packages/core/src/components/cv-data-table/_cv-data-table-heading.vue
@@ -1,5 +1,5 @@
 <template>
-  <th :aria-sort="sortOrder" :style="skeleton && headingStyle">
+  <th :aria-sort="internalOrder" :style="skeleton && headingStyle">
     <button
       type="button"
       v-if="sortable"
@@ -7,13 +7,15 @@
       @click="onSortClick"
       :style="headingStyle"
     >
-      <cv-wrapper :tag-type="headingLabelTag" class="bx--table-header-label">{{ heading }}</cv-wrapper>
+      <cv-wrapper :tag-type="headingLabelTag" class="bx--table-header-label">
+        <slot>{{ heading }}</slot>
+      </cv-wrapper>
       <ArrowDown16 class="bx--table-sort__icon" />
       <Arrows16 class="bx--table-sort__icon-unsorted" />
     </button>
-    <cv-wrapper v-else :tag-type="headingLabelTag" class="bx--table-header-label" :style="headingStyle">{{
-      heading
-    }}</cv-wrapper>
+    <cv-wrapper v-else :tag-type="headingLabelTag" class="bx--table-header-label" :style="headingStyle">
+      <slot>{{ heading }}</slot>
+    </cv-wrapper>
   </th>
 </template>
 
@@ -21,8 +23,9 @@
 import ArrowDown16 from '@carbon/icons-vue/es/arrow--down/16';
 import Arrows16 from '@carbon/icons-vue/es/arrows/16';
 import CvWrapper from '../cv-wrapper/_cv-wrapper';
+import uidMixin from '../../mixins/uid-mixin';
 
-const nextSortOrder = {
+const nextOrder = {
   ascending: 'descending',
   descending: 'none',
   none: 'ascending',
@@ -31,37 +34,64 @@ const nextSortOrder = {
 export default {
   name: 'CvDataTableHeading',
   components: { ArrowDown16, Arrows16, CvWrapper },
+  mixins: [uidMixin],
   props: {
-    heading: { type: String, required: true },
+    dataStyle: Object,
+    heading: String,
     sortable: Boolean,
     order: { type: String, default: 'none' },
     skeleton: Boolean,
     headingStyle: Object,
   },
+  data() {
+    return {
+      dataOrder: this.order,
+    };
+  },
+  mounted() {
+    this.$_CvDataTableHeading = true; // for use by parent with $children
+    this.$parent.$emit('cv:mounted', this);
+  },
+  beforeDestroy() {
+    this.$parent.$emit('cv:beforeDestroy', this);
+  },
+  watch: {
+    order() {
+      this.dataOrder = this.order;
+    },
+  },
   computed: {
-    sortOrder() {
-      if (this.order !== 'ascending' && this.order !== 'descending') {
-        return 'none';
-      } else {
-        return this.order;
-      }
+    internalOrder: {
+      get() {
+        if (this.dataOrder !== 'ascending' && this.dataOrder !== 'descending') {
+          return 'none';
+        } else {
+          return this.dataOrder;
+        }
+      },
+      set(val) {
+        if (['ascending', 'descending', 'none'].includes(val)) {
+          this.dataOrder = val;
+        }
+      },
     },
     sortText() {
-      return this.sortOrder !== 'descending'
+      return this.internalOrder !== 'descending'
         ? 'Sort rows by this header in descending order'
         : 'Sort rows by this header in ascending order';
     },
     orderClass() {
       let result = '';
-      if (this.sortOrder === 'descending') {
+      if (this.internalOrder === 'descending') {
         result = 'bx--table-sort--active';
-      } else if (this.sortOrder === 'ascending') {
+      } else if (this.internalOrder === 'ascending') {
         result = 'bx--table-sort--active bx--table-sort--ascending';
       }
       return result;
     },
     headingLabelTag() {
-      return this.heading.length === 0 || !this.skeleton ? 'span' : '';
+      // no tag if non-blank skeleton
+      return this.skeleton && this.heading && this.heading.length > 0 ? '' : 'span';
     },
   },
   model: {
@@ -70,7 +100,7 @@ export default {
   },
   methods: {
     onSortClick() {
-      this.$emit('sort', nextSortOrder[this.sortOrder]);
+      this.$parent.$emit('cv:sort', this, nextOrder[this.internalOrder]);
     },
   },
 };

--- a/packages/core/src/components/cv-data-table/cv-data-table-heading-label.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table-heading-label.vue
@@ -1,0 +1,11 @@
+<template>
+  <span class="bx--table-header-label">
+    <slot />
+  </span>
+</template>
+
+<script>
+export default {
+  name: 'CvDataTableHeadingLabel',
+};
+</script>

--- a/packages/core/src/components/cv-data-table/cv-data-table-notes.md
+++ b/packages/core/src/components/cv-data-table/cv-data-table-notes.md
@@ -18,6 +18,12 @@ http://www.carbondesignsystem.com/components/DataTable/code
 
 See Attributes, Slots and Events to see how to add additional features to the table.
 
+### Slotting headings - WARNING EXPERIMENTAL
+
+Headings can be slotted as per the 'Slotted headings' exmaple.
+
+NOTE: When slotted headings are used only plain text content is styled by default.
+
 ### Slotting data
 
 Instead of supply data as two dimensional array the user can supply slotted content using the CvDataTableRow and CvDataTableCell components.
@@ -66,10 +72,11 @@ Like sorting and filtering it is the users responsibility to deal with edited da
 
 - columns: An array containing a list of columns
   - Columns can be string labels or objects
-  - If objects they must contain a 'label' and can optionally contain
-    - a headingStyle object to be applied to the column headings.
-    - a dataStyle object to be applied to the data in the column.
-    - an optional sortable property - if any column sets this to true then only columns with sortable set to true are sortable. NOTE: table sortable property ignored.
+  - If objects
+    - MUST contain a label if headings are not slotted
+    - Optionally a headingStyle object to be applied to the column headings if not slotted.
+    - Optionally a dataStyle object to be applied to the data in the column.
+    - Optionally a sortable property - if any column sets this to true then only columns with sortable set to true are sortable. NOTE: table sortable property not required.
 - data: Two dimensional array of strings.
 - rows-selected: An array containing the selected row values. Supports v-model via the row-select-changes event.
 

--- a/packages/core/src/components/cv-data-table/index.js
+++ b/packages/core/src/components/cv-data-table/index.js
@@ -2,6 +2,7 @@ import CvDataTableAction from './cv-data-table-action';
 import CvDataTableCell from './cv-data-table-cell';
 import CvDataTableRow from './cv-data-table-row';
 import CvDataTable from './cv-data-table';
+import CvDataTableHeading from './_cv-data-table-heading';
 import CvDataTableSkeleton from './cv-data-table-skeleton';
 
-export { CvDataTable, CvDataTableRow, CvDataTableCell, CvDataTableAction, CvDataTableSkeleton };
+export { CvDataTable, CvDataTableRow, CvDataTableCell, CvDataTableAction, CvDataTableHeading, CvDataTableSkeleton };

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -39,6 +39,7 @@ import {
   CvDataTableCell,
   CvDataTableAction,
   CvDataTableSkeleton,
+  CvDataTableHeading,
 } from './components/cv-data-table';
 import { CvDatePicker } from './components/cv-date-picker';
 import { CvDropdown, CvDropdownItem, CvDropdownSkeleton } from './components/cv-dropdown';
@@ -107,7 +108,7 @@ export { CvCheckbox, CvCheckboxSkeleton };
 export { CvCodeSnippet, CvCodeSnippetSkeleton };
 export { CvComboBox };
 export { CvContentSwitcher, CvContentSwitcherButton, CvContentSwitcherContent };
-export { CvDataTable, CvDataTableRow, CvDataTableCell, CvDataTableAction, CvDataTableSkeleton };
+export { CvDataTable, CvDataTableRow, CvDataTableCell, CvDataTableAction, CvDataTableSkeleton, CvDataTableHeading };
 export { CvDatePicker };
 export { CvDropdown, CvDropdownItem, CvDropdownSkeleton };
 export { CvFileUploader, CvFileUploaderSkeleton };

--- a/storybook/stories/cv-data-table-story.js
+++ b/storybook/stories/cv-data-table-story.js
@@ -385,7 +385,7 @@ let variants = [
   },
   { name: 'slotted HTML', includes: ['columns', 'htmlData', 'basicPagination'] },
   { name: 'styled columns', includes: ['sortable', 'columns2', 'data', 'sort'] },
-  { name: 'Slotted headings', includes: ['slottedHeadings', 'data', 'sort'] },
+  { name: 'Slotted headings (EXPERIMENTAL)', includes: ['slottedHeadings', 'data', 'sort'] },
 ];
 
 let storySet = knobsHelper.getStorySet(variants, preKnobs);

--- a/storybook/stories/cv-data-table-story.js
+++ b/storybook/stories/cv-data-table-story.js
@@ -17,6 +17,8 @@ import {
   CvOverflowMenuItem,
   CvTag,
   CvDataTableSkeleton,
+  CvDataTableHeading,
+  CvTooltip,
 } from '../../packages/core/src/';
 import TrashCan16 from '@carbon/icons-vue/es/trash-can/16';
 import Save16 from '@carbon/icons-vue/es/save/16';
@@ -228,6 +230,18 @@ let preKnobs = {
     prop: 'hasExpandingRows',
     value: val => val,
   },
+  slottedHeadings: {
+    group: 'slots',
+    slot: 'headings',
+    value:
+      '\n    <cv-data-table-heading heading="Name" sortable />' +
+      '\n    <cv-data-table-heading>Protocol<cv-tooltip direction="bottom" tip="How comms get done" /></cv-data-table-heading>' +
+      '\n    <cv-data-table-heading><cv-tooltip direction="bottom" tip="The port number">Port</cv-tooltip></cv-data-table-heading>' +
+      '\n    <cv-data-table-heading heading="Rule" />' +
+      '\n    <cv-data-table-heading heading="Attatched Groups" />' +
+      '\n    <cv-data-table-heading heading="Status" />' +
+      '\n',
+  },
   slottedData: {
     group: 'slots',
     slot: 'data',
@@ -308,6 +322,7 @@ let variants = [
       'search2',
       'columns2',
       'columns3',
+      'slottedHeadings',
       'slottedData',
       'htmlData',
       'helperTextSlot',
@@ -329,6 +344,7 @@ let variants = [
       'search',
       'columns2',
       'columns3',
+      'slottedHeadings',
       'slottedData',
       'htmlData',
       'helperTextSlot',
@@ -346,6 +362,7 @@ let variants = [
       'search2',
       'columns2',
       'columns3',
+      'slottedHeadings',
       'slottedData',
       'htmlData',
       'helperTextSlot',
@@ -367,7 +384,8 @@ let variants = [
     includes: ['columns', 'expandingSlottedData', 'rowExpanded', 'data', 'basicPagination', 'hasExpandAll'],
   },
   { name: 'slotted HTML', includes: ['columns', 'htmlData', 'basicPagination'] },
-  { name: 'styled columns', includes: ['sortable', 'columns2', 'data'] },
+  { name: 'styled columns', includes: ['sortable', 'columns2', 'data', 'sort'] },
+  { name: 'Slotted headings', includes: ['slottedHeadings', 'data', 'sort'] },
 ];
 
 let storySet = knobsHelper.getStorySet(variants, preKnobs);
@@ -404,6 +422,7 @@ for (const story of storySet) {
       return {
         components: {
           CvDataTable,
+          CvDataTableHeading,
           CvDataTableAction,
           SvTemplateView,
           CvDataTableRow,
@@ -415,6 +434,7 @@ for (const story of storySet) {
           TrashCan16,
           Save16,
           CvTag,
+          CvTooltip,
         },
         template: templateViewString,
         props: settings.props,


### PR DESCRIPTION
Addresses  #890 #758 #891

An experimental effort to allow slotted data table headings but keep style and sort options

#### Changelog

R050    packages/core/src/components/cv-data-table/_cv-data-table-heading.vue   packages/core/src/components/cv-data-table/cv-data-table-heading.vue
M       packages/core/src/components/cv-data-table/cv-data-table-notes.md
M       packages/core/src/components/cv-data-table/cv-data-table.vue
M       packages/core/src/components/cv-data-table/index.js
M       packages/core/src/index.js
M       storybook/stories/cv-data-table-story.js
