### PR TITLE
fix: labels in table checkboxes

### DIFF
--- a/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
+++ b/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
@@ -16,7 +16,8 @@
         v-model="dataChecked"
         @change="onChange"
         ref="rowChecked"
-        :aria-label="ariaLabelForBatchCheckbox || `Select row ${value} for batch action`"
+        :label="ariaLabelForBatchCheckbox || `Select row ${value} for batch action`"
+        hideLabel
       />
     </td>
     <slot />

--- a/packages/core/src/components/cv-data-table/cv-data-table-notes.md
+++ b/packages/core/src/components/cv-data-table/cv-data-table-notes.md
@@ -80,7 +80,6 @@ Like sorting and filtering it is the users responsibility to deal with edited da
 - data: Two dimensional array of strings.
 - rows-selected: An array containing the selected row values. Supports v-model via the row-select-changes event.
 
-- action-bar-label: (optional) alternative aria label for the toolbar
 - auto-width: (optional) table will size use auto sizing
 - borderless: (optional) table will have no border
 - overflow-menu(optional) : An array of overflow menu labels. On click CvDataTable will raise an 'overflow-menu-click' event passing an object containing menuIndex, menuLabel and rowValue
@@ -93,6 +92,10 @@ Like sorting and filtering it is the users responsibility to deal with edited da
 - searchPlaceholder: (optional) { type: String, default: 'Search' },
 - searchClearLabel: (optional) { type: String, default: 'Clear search' },
 - batchCancelLabel: (optional) { type: String, default: 'Cancel' },
+- actionBarAriaLabel: { type: String, default: 'Table Action Bar' },
+- collapseAllAriaLabel: { type: String, default: 'Collapse all rows' },
+- expandAllAriaLabel: { type: String, default: 'Expand all rows' },
+- selectAllAriaLabel: { type: String, default: 'Select all rows' },
 
 ## Scoped slots
 

--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -109,6 +109,8 @@
                 value="headingCheck"
                 v-model="headingChecked"
                 @change="onHeadingCheckChange"
+                :label="selectAllAriaLabel"
+                hideLabel
               />
             </th>
             <slot name="headings">
@@ -197,6 +199,7 @@ export default {
     actionBarAriaLabel: { type: String, default: 'Table Action Bar' },
     collapseAllAriaLabel: { type: String, default: 'Collapse all rows' },
     expandAllAriaLabel: { type: String, default: 'Expand all rows' },
+    selectAllAriaLabel: { type: String, default: 'Select all rows' },
     autoWidth: Boolean,
     batchCancelLabel: { type: String, default: 'cancel' },
     borderless: Boolean,


### PR DESCRIPTION
Closes #903

Adds label text to checkboxes in table.

#### Changelog

M       packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
M       packages/core/src/components/cv-data-table/cv-data-table-notes.md
M       packages/core/src/components/cv-data-table/cv-data-table.vue

