### PR TITLE
Fix rollup

### DIFF
--- a/packages/core/src/components/cv-code-snippet/_cv-code-snippet-inline.vue
+++ b/packages/core/src/components/cv-code-snippet/_cv-code-snippet-inline.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-import CvFeedbackButton from './_cv-feedback-button';
+import CvFeedbackButton from '../cv-feedback-button/_cv-feedback-button';
 import themeMixin from '../../mixins/theme-mixin';
 
 export default {

--- a/packages/core/src/components/cv-code-snippet/_cv-code-snippet-multiline.vue
+++ b/packages/core/src/components/cv-code-snippet/_cv-code-snippet-multiline.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script>
-import CvFeedbackButton from './_cv-feedback-button';
+import CvFeedbackButton from '../cv-feedback-button/_cv-feedback-button';
 import CvButton from '../cv-button/cv-button';
 
 import Copy16 from '@carbon/icons-vue/es/copy/16';

--- a/packages/core/src/components/cv-code-snippet/_cv-code-snippet-oneline.vue
+++ b/packages/core/src/components/cv-code-snippet/_cv-code-snippet-oneline.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-import CvFeedbackButton from './_cv-feedback-button';
+import CvFeedbackButton from '../cv-feedback-button/_cv-feedback-button';
 
 import Copy16 from '@carbon/icons-vue/es/copy/16';
 

--- a/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
+++ b/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
@@ -22,9 +22,9 @@
     </td>
     <slot />
     <td v-if="hasOverflowMenu" class="bx--table-column-menu">
-      <cv-overflow-menu flip-menu>
+      <cv-overflow-menu v-bind="overflowMenuOptions">
         <cv-overflow-menu-item
-          v-for="(item, index) in overflowMenu"
+          v-for="(item, index) in overflowMenuButtons"
           :key="`${index}`"
           @click="
             onMenuItemClick({
@@ -96,6 +96,14 @@ export default {
     },
     isChecked() {
       return this.dataChecked;
+    },
+    overflowMenuButtons() {
+      return this.overflowMenu.filter(item => typeof item === 'string');
+    },
+    overflowMenuOptions() {
+      const incomingOptions = this.overflowMenu.find(item => typeof item === 'object') || {};
+      const defaultOptions = { flipMenu: true, label: 'Row overflow menu', tipPosition: 'left' };
+      return { ...defaultOptions, ...incomingOptions };
     },
   },
   methods: {

--- a/packages/core/src/components/cv-data-table/cv-data-table-notes.md
+++ b/packages/core/src/components/cv-data-table/cv-data-table-notes.md
@@ -83,6 +83,7 @@ Like sorting and filtering it is the users responsibility to deal with edited da
 - auto-width: (optional) table will size use auto sizing
 - borderless: (optional) table will have no border
 - overflow-menu(optional) : An array of overflow menu labels. On click CvDataTable will raise an 'overflow-menu-click' event passing an object containing menuIndex, menuLabel and rowValue
+- overflow-menu props: As part of the array pass an object containing props for the overflowMenu. E.g. { label: 'Overflow menu', tipAlignment: 'end', tipPosition: 'top' },
 - pagination: (optional) default: false, can be set to true or an object containing camel case props for a CvPagination component
 - sortable: (optional) can be sorted
 - row-size: (optional) default: '',

--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -142,7 +142,7 @@
                 :key="`cell:${colIndex}:${rowIndex}`"
                 :style="dataStyle(colIndex)"
               >
-                <cv-wrapper :tag-type="skeleton && rowIndex < 1 ? 'span' : ''">{{ cell }}</cv-wrapper>
+                <cv-wrapper :tag-type="skeleton ? 'span' : ''">{{ cell }}</cv-wrapper>
               </cv-data-table-cell>
             </cv-data-table-row>
           </slot>

--- a/packages/core/src/components/cv-dropdown/cv-dropdown.vue
+++ b/packages/core/src/components/cv-dropdown/cv-dropdown.vue
@@ -62,7 +62,7 @@
           aria-haspopup="true"
           :aria-expanded="open"
           :aria-controls="`${uid}-menu`"
-          :aria-labelledby="`${uid}-label ${uid}-value`"
+          :aria-labelledby="ariaLabeledBy"
           :disabled="disabled"
           type="button"
         >
@@ -163,6 +163,13 @@ export default {
     },
   },
   computed: {
+    ariaLabeledBy() {
+      if (this.label) {
+        return `${this.uid}-label ${this.uid}-value`;
+      } else {
+        return `${this.uid}-value`;
+      }
+    },
     internalCaption() {
       if (this.selectedChild) {
         return this.selectedChild.internalContent;

--- a/packages/core/src/components/cv-feedback-button/_cv-feedback-button.vue
+++ b/packages/core/src/components/cv-feedback-button/_cv-feedback-button.vue
@@ -1,5 +1,6 @@
 <template>
   <button
+    aria-label="ariaLabel"
     type="button"
     class="cv-feedback-button"
     v-bind="$attrs"
@@ -27,6 +28,7 @@ export default {
   name: 'cvFeedbackButton',
   inheritAttrs: false,
   props: {
+    ariaLabel: { type: String, default: 'Feedback button' },
     feedback: { type: String, required: true },
     inline: Boolean,
     timeout: { type: Number, default: 2000 },

--- a/storybook/_storybook/views/sv-template-view/sv-template-view.vue
+++ b/storybook/_storybook/views/sv-template-view/sv-template-view.vue
@@ -35,13 +35,19 @@
       <pre v-highlightjs="propsJSON">
         <code class="json"></code>
       </pre>
-      <button @click="sourceToClipboard" title="Copy to clipboard" class="sv-template-view__copy" ref="copyButton">
+      <button @click="sourceToClipboard" aria-label="Copy to clipboard" class="sv-template-view__copy" ref="copyButton">
         <svg width="18" height="24" viewBox="0 0 18 24" fill-rule="evenodd">
           <path d="M13 5V0H0v19h5v5h13V5h-5zM2 17V2h9v3H5v12H2zm14 5H7V7h9v15z" />
           <path d="M9 9h5v2H9zM9 12h5v2H9zM9 15h3v2H9z" />
         </svg>
       </button>
-      <textarea class="sv-template-view__clippy" aria-hidden="true" ref="clippy"></textarea>
+      <textarea
+        id="clipboard text area"
+        class="sv-template-view__clippy"
+        aria-hidden="true"
+        aria-label="hidden text area used by clipboard"
+        ref="clippy"
+      ></textarea>
     </section>
   </sv-view>
 </template>
@@ -50,6 +56,7 @@
 import Vue from 'vue';
 import SvView from './sv-view.vue';
 import { CvInlineNotification } from '../../../../packages/core/src';
+import { CvFeedbackButton } from '../../../../packages/core/src/components/cv-feedback-button/_cv-feedback-button';
 
 export default {
   name: 'SvTemplateView',

--- a/storybook/stories/cv-data-table-story.js
+++ b/storybook/stories/cv-data-table-story.js
@@ -501,7 +501,7 @@ for (const story of storySet) {
             filterValue: '',
             rowSelects: [],
             sortBy: undefined,
-            sampleOverflowMenu: ['Start', 'Stop', 'Delete 3'],
+            sampleOverflowMenu: ['Start', 'Stop', 'Delete 3', { label: 'Overflow menu' }],
             pageStart: 1,
             pageNumber: 1,
             pageLength: 5,


### PR DESCRIPTION
Closes #914 

- chore: fix aria label on template view
- fix: table skeleton appearance
- fix: dropdown aria warning with no label
- feat: add table oveflow options

#### Changelog

M       packages/core/src/components/cv-code-snippet/_cv-code-snippet-inline.vue
M       packages/core/src/components/cv-code-snippet/_cv-code-snippet-multiline.vue
M       packages/core/src/components/cv-code-snippet/_cv-code-snippet-oneline.vue
M       packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
M       packages/core/src/components/cv-data-table/cv-data-table-notes.md
M       packages/core/src/components/cv-data-table/cv-data-table.vue
M       packages/core/src/components/cv-dropdown/cv-dropdown.vue
R096    packages/core/src/components/cv-code-snippet/_cv-feedback-button.vue    packages/core/src/components/cv-feedback-button/_cv-feedback-button.vue
M       storybook/_storybook/views/sv-template-view/sv-template-view.vue
M       storybook/stories/cv-data-table-story.js