### PR TITLE
fix: multi select use of filter tag

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Canary
+
+- fix: Combobox filter tag usage (causing validator warning)
+
 ## 2.29.0
 
 - feat: Includes use of coded prefix

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Canary
 
-- fix: Combobox filter tag usage (causing validator warning)
+- fix: Multiselect filter tag usage (causing validator warning)
 
 ## 2.29.0
 

--- a/packages/core/src/components/cv-combo-box/cv-combo-box.vue
+++ b/packages/core/src/components/cv-combo-box/cv-combo-box.vue
@@ -236,7 +236,7 @@ export default {
       this.$emit('change', this.dataValue);
     },
     checkHighlightPosition(newHiglight) {
-      if (this.$refs.list && this.$refs.option) {
+      if (this.$refs.list && this.$refs.option && this.$refs.option[newHiglight]) {
         if (this.$refs.list.scrollTop > this.$refs.option[newHiglight].offsetTop) {
           this.$refs.list.scrollTop = this.$refs.option[newHiglight].offsetTop;
         } else if (

--- a/packages/core/src/components/cv-multi-select/cv-multi-select-notes.md
+++ b/packages/core/src/components/cv-multi-select/cv-multi-select-notes.md
@@ -86,6 +86,7 @@ filterable: false
   - 'top': joins other selected options at the top immediately
   - 'fixed': stays where it is in the list.
     -filterable: If true the multi select list can be filtered.
+- filterTagKind: passed through to CvTag as kind property.
 
 Other standard props e.g. disabled and placeholder
 

--- a/packages/core/src/components/cv-multi-select/cv-multi-select.vue
+++ b/packages/core/src/components/cv-multi-select/cv-multi-select.vue
@@ -68,7 +68,8 @@
           :class="{ [`${carbonPrefix}--list-box__selection--multi`]: filterable && dataValue.length > 0 }"
           :disabled="disabled"
           v-show="dataValue.length > 0"
-          kind="filter"
+          :kind="filterTagKind"
+          filter
           :label="`${dataValue.length}`"
           @remove="clearValues"
           ref="tag"
@@ -170,6 +171,7 @@ export default {
     autoFilter: Boolean,
     autoHighlight: Boolean,
     disabled: Boolean,
+    filterTagKind: { type: String, default: 'high-contrast' },
     inline: Boolean,
     invalidMessage: { type: String, default: undefined },
     helperText: { type: String, default: undefined },


### PR DESCRIPTION
Closes #956 

Removes validator warning

#### Changelog

m - packages/core/src/components/cv-combo-box/cv-combo-box.vue 
