### PR TITLE
fix: multi select user filter

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Canary
 
 - fix: Multiselect filter tag usage (causing validator warning)
+- fix: Combobox and multiselect user filter for non-existent item
 
 ## 2.29.0
 

--- a/packages/core/src/components/cv-multi-select/cv-multi-select.vue
+++ b/packages/core/src/components/cv-multi-select/cv-multi-select.vue
@@ -299,7 +299,7 @@ export default {
       this.updateOptions();
     },
     checkHighlightPosition(newHiglight) {
-      if (this.$refs.list && this.$refs.option) {
+      if (this.$refs.list && this.$refs.option && this.$refs.option[newHiglight]) {
         if (this.$refs.list.scrollTop > this.$refs.option[newHiglight].offsetTop) {
           this.$refs.list.scrollTop = this.$refs.option[newHiglight].offsetTop;
         } else if (


### PR DESCRIPTION
Closes #954 

Fixes multi-select with same issue to 954. Combobox fixed accidentally in preverious PR.

#### Changelog

M       packages/core/CHANGELOG.md
M       packages/core/src/components/cv-multi-select/cv-multi-select.vue
