### PR TITLE
fix: empty space in combo and multi

### DIFF
--- a/packages/core/src/components/cv-combo-box/cv-combo-box.vue
+++ b/packages/core/src/components/cv-combo-box/cv-combo-box.vue
@@ -44,7 +44,7 @@
       >
         <input
           ref="input"
-          :class="[`${carbonPrefix}--text-input`]"
+          :class="[`${carbonPrefix}--text-input`, { [`${carbonPrefix}--text-input--empty`]: dataInput.length === 0 }]"
           :aria-controls="uid"
           aria-autocomplete="list"
           role="combobox"

--- a/packages/core/src/components/cv-multi-select/cv-multi-select.vue
+++ b/packages/core/src/components/cv-multi-select/cv-multi-select.vue
@@ -79,7 +79,7 @@
         <template v-else>
           <input
             ref="input"
-            :class="`${carbonPrefix}--text-input`"
+            :class="[`${carbonPrefix}--text-input`, { [`${carbonPrefix}--text-input--empty`]: dataInput.length === 0 }]"
             :aria-controls="uid"
             aria-autocomplete="list"
             role="combobox"


### PR DESCRIPTION
Closes #678 

Add the empty class which makes available the space reserved for the clear button

#### Changelog

M	packages/core/src/components/cv-combo-box/cv-combo-box.vue
M	packages/core/src/components/cv-multi-select/cv-multi-select.vue
