### PR TITLE
fix: ie11 svg class usage

### DIFF
--- a/packages/core/src/components/cv-data-table/cv-data-table-action.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table-action.vue
@@ -13,9 +13,12 @@ export default {
     // ensure SVG has
     if (this.$el.children[0].classList) {
       this.$el.children[0].classList.add(`${this.carbonPrefix}--toolbar-action__icon`);
-    } else if (this.$el.children[0].className) {
+    } else if (this.$el.children[0].class) {
       // IE 11 and Edge pre-crhomium
-      this.$el.children[0].className += ` ${this.carbonPrefix}--toolbar-action__icon`;
+      this.$el.children[0].setAttribute(
+        'class',
+        `${this.$el.children[0].getAttribute('class')} ${this.carbonPrefix}--toolbar-action__icon`
+      );
     }
   },
 };


### PR DESCRIPTION
Closes #970

IE 11 SVG class usage

#### Changelog

m packages/core/src/components/cv-data-table/cv-data-table-action.vue 