### PR TITLE
fix: dropdown clearing of value

### DIFF
--- a/packages/core/src/components/cv-dropdown/cv-dropdown.vue
+++ b/packages/core/src/components/cv-dropdown/cv-dropdown.vue
@@ -28,9 +28,8 @@
         v-if="label"
         :id="`${uid}-label`"
         :class="[`${carbonPrefix}--label`, { [`${carbonPrefix}--label--disabled`]: disabled }]"
+        >{{ label }}</span
       >
-        {{ label }}
-      </span>
 
       <div
         data-dropdown
@@ -219,6 +218,7 @@ export default {
   methods: {
     updateChildren(val) {
       const childItems = this.dropdownItems();
+      let foundSelection = false;
 
       for (let index in childItems) {
         let child = childItems[index];
@@ -226,8 +226,13 @@ export default {
         child.internalSelected = selected;
 
         if (selected) {
+          foundSelection = true;
           this.selectedChild = child;
         }
+      }
+
+      if (!foundSelection) {
+        this.selectedChild = null;
       }
     },
     checkSlots() {


### PR DESCRIPTION
Clears CvDropdown when value set to a non-child value

#### Changelog

m packages/core/src/components/cv-dropdown/cv-dropdown.vue 
