### PR TITLE
fix: firefox dropdown close

### DIFF
--- a/packages/core/src/components/cv-dropdown/cv-dropdown.vue
+++ b/packages/core/src/components/cv-dropdown/cv-dropdown.vue
@@ -52,6 +52,7 @@
         @keydown.up.prevent="onUp"
         @keydown.enter.prevent="onClick"
         @keydown.esc.prevent="onEsc"
+        @keydown.tab="onTab"
         @click="onClick"
       >
         <button
@@ -80,13 +81,13 @@
           </div>
         </button>
         <ul
-          :class="`${carbonPrefix}--dropdown-list`"
+          :class="`${carbonPrefix}--list-box__menu`"
           :id="`${uid}-menu`"
           role="menu"
           :aria-hidden="!open ? 'true' : 'false'"
-          wh-menu-anchor="left"
           :aria-labelledby="`${uid}-label`"
           ref="droplist"
+          tabindex="-1"
         >
           <slot>
             <cv-dropdown-item v-for="item in items" v-bind:key="item" :value="item">{{ item }}</cv-dropdown-item>
@@ -163,15 +164,12 @@ export default {
     this.$on('cv:beforeDestroy', srcComponent => this.onCvBeforeDestroy(srcComponent));
   },
   mounted() {
-    this.$el.addEventListener('focusout', ev => {
-      if (ev.relatedTarget === null || !this.$el.contains(ev.relatedTarget)) {
-        this.open = false;
-      }
-    });
+    document.body.addEventListener('click', this.checkClickOut);
     this.updateChildren(this.internalValue);
     this.checkSlots();
   },
   beforeUpdate() {
+    document.body.removeEventListener('click', this.checkSlots);
     this.checkSlots();
   },
   model: {
@@ -228,6 +226,11 @@ export default {
     },
   },
   methods: {
+    checkClickOut(ev) {
+      if (ev.target === null || !this.$el.contains(ev.target)) {
+        this.open = false;
+      }
+    },
     updateChildren(val) {
       const childItems = this.dropdownItems();
       let foundSelection = false;
@@ -303,7 +306,11 @@ export default {
     },
     doFocus() {
       this.$nextTick(() => {
-        this.focus();
+        if (this.open) {
+          this.$refs.droplist.focus();
+        } else {
+          this.focus();
+        }
       });
     },
     onDown() {
@@ -321,6 +328,19 @@ export default {
     onEsc() {
       this.open = false;
       this.doFocus();
+    },
+    onTab(ev) {
+      if (this.open) {
+        if (this.$refs.button.$el === ev.target) {
+          // button has focus ensure we are closed
+          this.open = false;
+        } else if (ev.target === null || this.$el.contains(ev.target)) {
+          // list has focus, close and return focus to dropdown
+          this.open = false;
+          this.doFocus();
+          ev.preventDefault();
+        }
+      }
     },
     onClick(ev) {
       if (this.disabled) {

--- a/packages/core/src/components/cv-dropdown/cv-dropdown.vue
+++ b/packages/core/src/components/cv-dropdown/cv-dropdown.vue
@@ -54,6 +54,7 @@
         @keydown.esc.prevent="onEsc"
         @keydown.tab="onTab"
         @click="onClick"
+        ref="listbox"
       >
         <button
           :class="`${carbonPrefix}--list-box__field`"
@@ -227,7 +228,7 @@ export default {
   },
   methods: {
     checkClickOut(ev) {
-      if (ev.target === null || !this.$el.contains(ev.target)) {
+      if (ev.target === null || !this.$refs.listboxntains(ev.target)) {
         this.open = false;
       }
     },
@@ -334,7 +335,7 @@ export default {
         if (this.$refs.button.$el === ev.target) {
           // button has focus ensure we are closed
           this.open = false;
-        } else if (ev.target === null || this.$el.contains(ev.target)) {
+        } else if (ev.target === null || this.$refs.listbox.contains(ev.target)) {
           // list has focus, close and return focus to dropdown
           this.open = false;
           this.doFocus();

--- a/packages/core/src/components/cv-dropdown/cv-dropdown.vue
+++ b/packages/core/src/components/cv-dropdown/cv-dropdown.vue
@@ -228,7 +228,7 @@ export default {
   },
   methods: {
     checkClickOut(ev) {
-      if (ev.target === null || !this.$refs.listboxntains(ev.target)) {
+      if (ev.target === null || !this.$refs.listbox.contains(ev.target)) {
         this.open = false;
       }
     },


### PR DESCRIPTION
Chrome, Firefox and Safari deal with buttons differently. Chrome sets focus on click, Firefox and Safari do not. As a result, it is harder to manage the open state of a dropdown using focus alone. This PR switches to using click outside and tab monitoring instead of focusout.
