### PR TITLE
feat: add aria label for expanding row button

### DIFF
--- a/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
+++ b/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
@@ -8,7 +8,13 @@
       :class="`${carbonPrefix}--table-expand`"
       :data-previous-value="dataExpanded ? 'collapsed' : 'expanded'"
     >
-      <button v-if="expandingRow" :class="`${carbonPrefix}--table-expand__button`" @click="toggleExpand" type="button">
+      <button
+        v-if="expandingRow"
+        :class="`${carbonPrefix}--table-expand__button`"
+        @click="toggleExpand"
+        type="button"
+        :aria-label="dataExpanded ? ariaLabelCollapseRow : ariaLabelExpandRow"
+      >
         <ChevronRight16 :class="`${carbonPrefix}--table-expand__svg`" />
       </button>
     </td>
@@ -59,6 +65,8 @@ export default {
     checked: Boolean,
     expanded: Boolean,
     expandingRow: Boolean,
+    ariaLabelExpandRow: { type: String, default: 'Expand current row' },
+    ariaLabelCollapseRow: { type: String, default: 'Collapse current row' },
     overflowMenu: Array,
     someExpandingRows: Boolean,
     value: String,

--- a/packages/core/src/components/cv-data-table/cv-data-table-notes.md
+++ b/packages/core/src/components/cv-data-table/cv-data-table-notes.md
@@ -126,6 +126,9 @@ As per note sort and filter behviours are delegated to the component user.
 
 ### Attributes
 
+aria-label-for-batch-checkbox: Aria label for batch checkbox. default Select row N for batch action.
+aria-label-expand-row: Aria label for expanding row expansion button. default: 'Expand current row'
+aria-label-collapse-row: Aria label for expanding row collapse button. default: 'Collapse current row'
 expanded: initial state of the expanded row
 
 ### Computed

--- a/storybook/stories/cv-data-table-story.js
+++ b/storybook/stories/cv-data-table-story.js
@@ -269,7 +269,7 @@ let preKnobs = {
     group: 'slots',
     slot: 'data',
     value:
-      '\n    <cv-data-table-row v-for="(row, rowIndex) in internalData" :key="`${rowIndex}`" :value="`${rowIndex}`" :expanded="rowIndex === rowExpanded">' +
+      '\n    <cv-data-table-row v-for="(row, rowIndex) in internalData" :key="`${rowIndex}`" :value="`${rowIndex}`" :expanded="rowIndex === rowExpanded" aria-label-expand-row="Go large" aria-label-collapse-row="Go small">' +
       '\n       <cv-data-table-cell v-for="(cell, cellIndex) in row" :key="`${cellIndex}`" :value="`${cellIndex}`" v-html="cell"></cv-data-table-cell>' +
       '\n       <template slot="expandedContent">A variety of content types can live here. Be sure to follow Carbon design guidelines for spacing and alignment.</template>' +
       '\n    </cv-data-table-row>\n',


### PR DESCRIPTION
Closes #1006

Add aria labels for expanded and collapsed states of expanding rows in the data table.

#### Changelog

M       packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
M       packages/core/src/components/cv-data-table/cv-data-table-notes.md
M       storybook/stories/cv-data-table-story.js
