### PR TITLE
fix: use of uidMixin without id use

### DIFF
--- a/packages/core/src/components/cv-content-switcher/cv-content-switcher-button.vue
+++ b/packages/core/src/components/cv-content-switcher/cv-content-switcher-button.vue
@@ -23,6 +23,7 @@
     ]"
     :data-target="contentSelector"
     :aria-selected="dataSelected ? 'true' : 'false'"
+    :id="uid"
     @click="open"
   >
     <CvSvg v-if="icon" :svg="icon" :class="`${carbonPrefix}--content-switcher__icon`" height="16" width="16" />

--- a/packages/core/src/components/cv-data-table/cv-data-table-heading.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table-heading.vue
@@ -1,5 +1,5 @@
 <template>
-  <th :aria-sort="internalOrder" :style="skeleton && headingStyle">
+  <th :aria-sort="internalOrder" :style="skeleton && headingStyle" :id="uid">
     <button
       type="button"
       v-if="sortable"

--- a/packages/core/src/components/cv-data-table/cv-data-table-row.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table-row.vue
@@ -1,5 +1,5 @@
 <template>
-  <tbody v-if="someExpandingRows" class="cv-data-table-row cv-data-table-row--expandable">
+  <tbody v-if="someExpandingRows" class="cv-data-table-row cv-data-table-row--expandable" :id="uid">
     <cv-data-table-row-inner
       ref="row"
       v-bind="$attrs"
@@ -23,7 +23,7 @@
       </td>
     </tr>
   </tbody>
-  <cv-data-table-row-inner v-else ref="row" v-bind="$attrs" v-on="$listeners" class="cv-data-table-row">
+  <cv-data-table-row-inner v-else ref="row" v-bind="$attrs" v-on="$listeners" class="cv-data-table-row" :id="uid">
     <slot />
   </cv-data-table-row-inner>
 </template>

--- a/packages/core/src/components/cv-date-picker/cv-date-picker.vue
+++ b/packages/core/src/components/cv-date-picker/cv-date-picker.vue
@@ -1,5 +1,5 @@
 <template>
-  <cv-wrapper :tag-type="formItem ? 'div' : ''" :class="`cv-date-picker ${carbonPrefix}--form-item`">
+  <cv-wrapper :tag-type="formItem ? 'div' : ''" :class="`cv-date-picker ${carbonPrefix}--form-item`" :id="uid">
     <div
       :data-date-picker="['single', 'range'].includes(kind)"
       :data-date-picker-type="kind"
@@ -12,6 +12,7 @@
         },
       ]"
       ref="date-picker"
+      :id="formItem ? '' : uid"
     >
       <div
         :class="{

--- a/packages/core/src/components/cv-dropdown/cv-dropdown.vue
+++ b/packages/core/src/components/cv-dropdown/cv-dropdown.vue
@@ -16,7 +16,7 @@
 -->
 
 <template>
-  <div :class="{ [`${carbonPrefix}--form-item`]: formItem }">
+  <div :class="{ [`${carbonPrefix}--form-item`]: formItem }" :id="uid">
     <div
       :class="[
         `${carbonPrefix}--dropdown__wrapper`,

--- a/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
+++ b/packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
@@ -1,5 +1,5 @@
 <template>
-  <div data-overflow-menu :class="`cv-overflow-menu ${carbonPrefix}--overflow-menu`">
+  <div data-overflow-menu :class="`cv-overflow-menu ${carbonPrefix}--overflow-menu`" :id="uid">
     <button
       :class="[
         `${carbonPrefix}--overflow-menu__trigger ${carbonPrefix}--tooltip__trigger`,

--- a/packages/core/src/components/cv-toggle/cv-toggle-skeleton.vue
+++ b/packages/core/src/components/cv-toggle/cv-toggle-skeleton.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="`cv-toggle ${carbonPrefix}--form-item`">
+  <div :class="`cv-toggle ${carbonPrefix}--form-item`" :id="uid">
     <label
       :class="`${carbonPrefix}--toggle__label ${carbonPrefix}--skeleton`"
       :for="uid"

--- a/packages/core/src/components/cv-tooltip/cv-definition-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-definition-tooltip.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="`cv-definition-tooltip ${carbonPrefix}--tooltip--definition ${carbonPrefix}--tooltip--a11y`">
+  <div :class="`cv-definition-tooltip ${carbonPrefix}--tooltip--definition ${carbonPrefix}--tooltip--a11y`" :id="uid">
     <button
       :aria-describedby="`${uid}-label`"
       :class="[

--- a/packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
@@ -22,7 +22,7 @@
     </div>
 
     <div
-      :id="`${uid}`"
+      :id="uid"
       aria-hidden="true"
       :data-floating-menu-direction="direction"
       :class="[`${carbonPrefix}--tooltip`, { [`${carbonPrefix}--tooltip--shown`]: dataVisible }]"

--- a/packages/core/src/components/cv-ui-shell/cv-header-global-action.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-header-global-action.vue
@@ -12,6 +12,7 @@
     :aria-expanded="active ? 'true' : 'false'"
     @click="gaToggle"
     @focusout="gaFocusout"
+    :id="uid"
   >
     <slot />
   </button>

--- a/packages/core/src/components/cv-ui-shell/cv-header-menu-button.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-header-menu-button.vue
@@ -17,6 +17,7 @@
     :aria-expanded="active ? 'true' : 'false'"
     @click="gaToggle"
     @focusout="gaFocusout"
+    :id="uid"
   >
     <Close20 v-if="dataActive" />
     <Menu20 v-if="!dataActive" />


### PR DESCRIPTION
Addresses issue raised int #1007

Add ID to the outer element when ID not otherwise used. A potential breaking change for v3 would separate top level ID from inner IDs.

#### Changelog

M       packages/core/src/components/cv-content-switcher/cv-content-switcher-button.vue
M       packages/core/src/components/cv-data-table/cv-data-table-heading.vue
M       packages/core/src/components/cv-data-table/cv-data-table-row.vue
M       packages/core/src/components/cv-date-picker/cv-date-picker.vue
M       packages/core/src/components/cv-dropdown/cv-dropdown.vue
M       packages/core/src/components/cv-overflow-menu/cv-overflow-menu.vue
M       packages/core/src/components/cv-toggle/cv-toggle-skeleton.vue
M       packages/core/src/components/cv-tooltip/cv-definition-tooltip.vue
M       packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
M       packages/core/src/components/cv-ui-shell/cv-header-global-action.vue
M       packages/core/src/components/cv-ui-shell/cv-header-menu-button.vue
