### PR TITLE
fix: slot not updating with v-slot

### DIFF
--- a/packages/core/src/components/cv-combo-box/cv-combo-box.vue
+++ b/packages/core/src/components/cv-combo-box/cv-combo-box.vue
@@ -189,7 +189,7 @@ export default {
     this.highlighted = this.value ? this.value : this.highlight; // override highlight with value if provided
     this.checkSlots();
   },
-  beforeUpdate() {
+  updated() {
     this.checkSlots();
   },
   computed: {
@@ -225,7 +225,7 @@ export default {
   },
   methods: {
     checkSlots() {
-      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      // NOTE: this.$slots is not reactive so needs to be managed on updated
       this.isInvalid = !!(this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length));
       this.isHelper = !!(this.$slots['helper-text'] || (this.helperText && this.helperText.length));
     },

--- a/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
+++ b/packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
@@ -86,7 +86,7 @@ export default {
   mounted() {
     this.checkSlots();
   },
-  beforeUpdate() {
+  updated() {
     this.checkSlots();
   },
   watch: {
@@ -121,7 +121,7 @@ export default {
   },
   methods: {
     checkSlots() {
-      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      // NOTE: this.$slots is not reactive so needs to be managed on updated
       this.hasOverflowMenu = !!((this.overflowMenu && this.overflowMenu.length) || this.$slots['overflow-menu']);
     },
     onChange() {

--- a/packages/core/src/components/cv-data-table/cv-data-table-row.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table-row.vue
@@ -55,7 +55,7 @@ export default {
     },
   },
   mounted() {
-    // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+    // NOTE: this.$slots is not reactive so needs to be managed on updated
     this.dataExpandable = !!this.$slots.expandedContent;
     this.$parent.$emit('cv:mounted', this);
   },

--- a/packages/core/src/components/cv-data-table/cv-data-table-skeleton.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table-skeleton.vue
@@ -42,7 +42,7 @@ export default {
   mounted() {
     this.checkSlots();
   },
-  beforeUpdate() {
+  updated() {
     this.checkSlots();
   },
   computed: {
@@ -55,7 +55,7 @@ export default {
   },
   methods: {
     checkSlots() {
-      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      // NOTE: this.$slots is not reactive so needs to be managed on updated
       this.hasBatchActions = !!this.$slots['batch-actions'];
       this.hasHelperText = !!this.$slots['helper-text'];
       this.hasActions = !!this.$slots['actions'];

--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -276,7 +276,7 @@ export default {
     this.updateRowsSelected();
     this.checkSlots();
   },
-  beforeUpdate() {
+  updated() {
     this.checkSlots();
   },
   computed: {
@@ -341,7 +341,7 @@ export default {
   },
   methods: {
     checkSlots() {
-      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      // NOTE: this.$slots is not reactive so needs to be managed on updated
       this.hasBatchActions = !!this.$slots['batch-actions'];
       this.hasActions = !!this.$slots.actions;
       this.hasToolbar = !!(this.$slots.actions || this.$listeners.search || this.$slots['batch-actions']);

--- a/packages/core/src/components/cv-date-picker/cv-date-picker.vue
+++ b/packages/core/src/components/cv-date-picker/cv-date-picker.vue
@@ -199,7 +199,7 @@ export default {
   },
   methods: {
     checkSlots() {
-      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      // NOTE: this.$slots is not reactive so needs to be managed on updated
       this.isInvalid = !!(
         this.$slots['invalid-message'] ||
         (this.invalidMessage && this.invalidMessage.length) ||
@@ -327,7 +327,7 @@ export default {
     //   this.cal.setDate([curDate, anotherDate], true);
     // }, 2000);
   },
-  beforeUpdate() {
+  updated() {
     this.checkSlots();
   },
   beforeDestroy() {

--- a/packages/core/src/components/cv-dropdown/cv-dropdown.vue
+++ b/packages/core/src/components/cv-dropdown/cv-dropdown.vue
@@ -171,7 +171,7 @@ export default {
     this.updateChildren(this.internalValue);
     this.checkSlots();
   },
-  beforeUpdate() {
+  updated() {
     document.body.removeEventListener('click', this.checkSlots);
     this.checkSlots();
   },
@@ -252,7 +252,7 @@ export default {
       }
     },
     checkSlots() {
-      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      // NOTE: this.$slots is not reactive so needs to be managed on updated
       this.isInvalid = !!(this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length));
       this.isHelper = !!(this.$slots['helper-text'] || (this.helperText && this.helperText.length));
     },

--- a/packages/core/src/components/cv-modal/cv-modal.vue
+++ b/packages/core/src/components/cv-modal/cv-modal.vue
@@ -121,7 +121,7 @@ export default {
     }
     this.checkSlots();
   },
-  beforeUpdate() {
+  updated() {
     this.checkSlots();
   },
   watch: {
@@ -163,7 +163,7 @@ export default {
   },
   methods: {
     checkSlots() {
-      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      // NOTE: this.$slots is not reactive so needs to be managed on updated
       this.hasFooter = !!(this.$slots['primary-button'] || this.$slots['secondary-button']);
       this.hasHeaderLabel = !!this.$slots.label;
       this.hasSecondary = !!this.$slots['secondary-button'];

--- a/packages/core/src/components/cv-multi-select/cv-multi-select.vue
+++ b/packages/core/src/components/cv-multi-select/cv-multi-select.vue
@@ -252,7 +252,7 @@ export default {
     this.highlighted = this.value ? this.value : this.highlight; // override highlight with value if provided
     this.checkSlots();
   },
-  beforeUpdate() {
+  updated() {
     this.checkSlots();
   },
   computed: {
@@ -292,7 +292,7 @@ export default {
   },
   methods: {
     checkSlots() {
-      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      // NOTE: this.$slots is not reactive so needs to be managed on updated
       this.isInvalid = !!(this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length));
       this.isHelper = !!(this.$slots['helper-text'] || (this.helperText && this.helperText.length));
     },

--- a/packages/core/src/components/cv-number-input/cv-number-input.vue
+++ b/packages/core/src/components/cv-number-input/cv-number-input.vue
@@ -132,7 +132,7 @@ export default {
     this.internalValue = this.valueAsString(this.value);
     this.checkSlots();
   },
-  beforeUpdate() {
+  updated() {
     this.checkSlots();
   },
   watch: {
@@ -162,7 +162,7 @@ export default {
       this.emitValue();
     },
     checkSlots() {
-      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      // NOTE: this.$slots is not reactive so needs to be managed on updated
       this.isInvalid = !!(this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length));
       this.isHelper = !!(this.$slots['helper-text'] || (this.helperText && this.helperText.length));
     },

--- a/packages/core/src/components/cv-select/cv-select.vue
+++ b/packages/core/src/components/cv-select/cv-select.vue
@@ -115,7 +115,7 @@ export default {
     }
     this.checkSlots();
   },
-  beforeUpdate() {
+  updated() {
     this.checkSlots();
   },
   watch: {
@@ -152,7 +152,7 @@ export default {
   },
   methods: {
     checkSlots() {
-      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      // NOTE: this.$slots is not reactive so needs to be managed on updated
       this.isInvalid = !!(this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length));
       this.isHelper = !!(this.$slots['helper-text'] || (this.helperText && this.helperText.length));
     },

--- a/packages/core/src/components/cv-text-area/cv-text-area.vue
+++ b/packages/core/src/components/cv-text-area/cv-text-area.vue
@@ -69,7 +69,7 @@ export default {
   mounted() {
     this.checkSlots();
   },
-  beforeUpdate() {
+  updated() {
     this.checkSlots();
   },
   computed: {
@@ -85,7 +85,7 @@ export default {
   },
   methods: {
     checkSlots() {
-      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      // NOTE: this.$slots is not reactive so needs to be managed on updated
       this.isInvalid = !!(this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length));
       this.isHelper = !!(this.$slots['helper-text'] || (this.helperText && this.helperText.length));
     },

--- a/packages/core/src/components/cv-text-input/cv-text-input.vue
+++ b/packages/core/src/components/cv-text-input/cv-text-input.vue
@@ -96,7 +96,7 @@ export default {
   mounted() {
     this.checkSlots();
   },
-  beforeUpdate() {
+  updated() {
     this.checkSlots();
   },
   watch: {
@@ -131,7 +131,7 @@ export default {
   },
   methods: {
     checkSlots() {
-      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      // NOTE: this.$slots is not reactive so needs to be managed on updated
       this.isInvalid = !!(this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length));
       this.isHelper = !!(this.$slots['helper-text'] || (this.helperText && this.helperText.length));
     },

--- a/packages/core/src/components/cv-time-picker/cv-time-picker.vue
+++ b/packages/core/src/components/cv-time-picker/cv-time-picker.vue
@@ -103,7 +103,7 @@ export default {
   mounted() {
     this.checkSlots();
   },
-  beforeUpdate() {
+  updated() {
     this.checkSlots();
   },
   computed: {
@@ -133,7 +133,7 @@ export default {
   },
   methods: {
     checkSlots() {
-      // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+      // NOTE: this.$slots is not reactive so needs to be managed on updated
       this.isInvalid = !!(this.$slots['invalid-message'] || (this.invalidMessage && this.invalidMessage.length));
     },
   },

--- a/packages/core/src/components/cv-ui-shell/cv-header.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-header.vue
@@ -32,10 +32,10 @@ export default {
     };
   },
   mounted() {
-    // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+    // NOTE: this.$slots is not reactive so needs to be managed on updated
     this.hasGlobalHeader = !!this.$slots['header-global'];
   },
-  beforeUpdate() {
+  updated() {
     this.hasGlobalHeader = !!this.$slots['header-global'];
   },
   computed: {

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
@@ -40,7 +40,7 @@ export default {
       hasNavIcon: this.$slots['nav-icon'],
     };
   },
-  beforeUpdate() {
+  updated() {
     this.hasNavIcon = !!this.$slots['nav-icon'];
   },
 };

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav-menu.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav-menu.vue
@@ -56,10 +56,10 @@ export default {
     };
   },
   mounted() {
-    // NOTE: this.$slots is not reactive so needs to be managed on beforeUpdate
+    // NOTE: this.$slots is not reactive so needs to be managed on updated
     this.hasNavIcon = !!this.$slots['nav-icon'];
   },
-  beforeUpdate() {
+  updated() {
     this.hasNavIcon = !!this.$slots['nav-icon'];
   },
   computed: {

--- a/storybook/stories/cv-ui-shell-story.js
+++ b/storybook/stories/cv-ui-shell-story.js
@@ -32,9 +32,10 @@ import {
 import Fade16 from '@carbon/icons-vue/es/fade/16';
 import Notification20 from '@carbon/icons-vue/es/notification/20';
 import UserAvatar20 from '@carbon/icons-vue/es/user--avatar/20';
+import Login20 from '@carbon/icons-vue/es/login/20';
 import AppSwitcher20 from '@carbon/icons-vue/es/app-switcher/20';
 
-const storiesDefault = storiesOf('Components/CvUIShell - header', module);
+const storiesDefault = storiesOf('Components/CvUIShell', module);
 // const storiesExperimental = storiesOf('Experimental/CvUIShell - header', module);
 
 const preKnobs = {
@@ -92,7 +93,7 @@ const preKnobs = {
   },
   headerActions: {
     group: 'headerActions',
-    value: `<template slot="header-global">
+    value: `<template v-slot:header-global>
     <cv-header-global-action
       aria-label="Notifications"
       aria-controls="notifications-panel"
@@ -100,7 +101,8 @@ const preKnobs = {
       <Notification20 />
     </cv-header-global-action>
     <cv-header-global-action aria-label="User avatar" @click="actionUserAvatar" aria-controls="user-panel">
-      <UserAvatar20 />
+      <UserAvatar20 v-if="loggedIn"/>
+      <Login20 v-else />
     </cv-header-global-action>
     <cv-header-global-action
       aria-label="App switcher"
@@ -203,7 +205,7 @@ const preKnobs = {
     value: `<cv-side-nav id="side-nav" fixed expanded>
       <cv-side-nav-items>
         <cv-side-nav-menu title="L1 menu">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           <cv-side-nav-menu-item href="javascript:void(0)" active>
             L2 menu item
           </cv-side-nav-menu-item>
@@ -215,7 +217,7 @@ const preKnobs = {
           </cv-side-nav-menu-item>
         </cv-side-nav-menu>
         <cv-side-nav-menu title="L1 menu">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           <cv-side-nav-menu-item href="javascript:void(0)">
             L2 menu item
           </cv-side-nav-menu-item>
@@ -227,11 +229,11 @@ const preKnobs = {
           </cv-side-nav-menu-item>
         </cv-side-nav-menu>
         <cv-side-nav-link href="javascript:void(0)">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           L1 link
         </cv-side-nav-link>
         <cv-side-nav-link href="javascript:void(0)">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           L1 link
         </cv-side-nav-link>
       </cv-side-nav-items>
@@ -365,7 +367,7 @@ const preKnobs = {
     value: `<cv-side-nav id="side-nav">
       <cv-side-nav-items>
         <cv-side-nav-menu title="L1 menu">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           <cv-side-nav-menu-item href="javascript:void(0)" active>
             L2 menu item
           </cv-side-nav-menu-item>
@@ -377,7 +379,7 @@ const preKnobs = {
           </cv-side-nav-menu-item>
         </cv-side-nav-menu>
         <cv-side-nav-menu title="L1 menu">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           <cv-side-nav-menu-item href="javascript:void(0)">
             L2 menu item
           </cv-side-nav-menu-item>
@@ -389,11 +391,11 @@ const preKnobs = {
           </cv-side-nav-menu-item>
         </cv-side-nav-menu>
         <cv-side-nav-link href="javascript:void(0)">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           L1 link
         </cv-side-nav-link>
         <cv-side-nav-link href="javascript:void(0)">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           L1 link
         </cv-side-nav-link>
       </cv-side-nav-items>
@@ -439,7 +441,7 @@ const preKnobs = {
     value: `<cv-side-nav id="side-nav">
       <cv-side-nav-items>
         <cv-side-nav-menu title="L1 menu">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           <cv-side-nav-menu-item href="javascript:void(0)" active>
             L2 menu item
           </cv-side-nav-menu-item>
@@ -451,7 +453,7 @@ const preKnobs = {
           </cv-side-nav-menu-item>
         </cv-side-nav-menu>
         <cv-side-nav-menu title="L1 menu">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           <cv-side-nav-menu-item href="javascript:void(0)">
             L2 menu item
           </cv-side-nav-menu-item>
@@ -463,11 +465,11 @@ const preKnobs = {
           </cv-side-nav-menu-item>
         </cv-side-nav-menu>
         <cv-side-nav-link href="javascript:void(0)">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           L1 link
         </cv-side-nav-link>
         <cv-side-nav-link href="javascript:void(0)">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           L1 link
         </cv-side-nav-link>
       </cv-side-nav-items>
@@ -478,7 +480,7 @@ const preKnobs = {
     value: `<cv-side-nav id="side-nav" rail>
       <cv-side-nav-items>
         <cv-side-nav-menu title="L1 menu">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           <cv-side-nav-menu-item href="javascript:void(0)" active>
             L2 menu item
           </cv-side-nav-menu-item>
@@ -490,7 +492,7 @@ const preKnobs = {
           </cv-side-nav-menu-item>
         </cv-side-nav-menu>
         <cv-side-nav-menu title="L1 menu">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           <cv-side-nav-menu-item href="javascript:void(0)">
             L2 menu item
           </cv-side-nav-menu-item>
@@ -502,11 +504,11 @@ const preKnobs = {
           </cv-side-nav-menu-item>
         </cv-side-nav-menu>
         <cv-side-nav-link href="javascript:void(0)">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           L1 link
         </cv-side-nav-link>
         <cv-side-nav-link href="javascript:void(0)">
-          <template slot="nav-icon"><Fade16 /></template>
+          <template v-slot:nav-icon><Fade16 /></template>
           L1 link
         </cv-side-nav-link>
       </cv-side-nav-items>
@@ -574,10 +576,10 @@ for (const story of storySet) {
 
       // ----------------------------------------------------------------
       const templateString = `<cv-header aria-label="Carbon header">${settings.group.headerMenuButton}${settings.group.headerName}${settings.group.headerNav}${settings.group.headerActions}
-    <template slot="left-panels" v-if="areLeftPanels">
+    <template v-slot:left-panels v-if="areLeftPanels">
       ${settings.group.leftPanels}
     </template>
-    <template slot="right-panels" v-if="areRightPanels">
+    <template v-slot:right-panels v-if="areRightPanels">
     ${settings.group.rightPanels}
   </template>
 </cv-header>
@@ -594,7 +596,7 @@ ${settings.group.leftPanels2}
       sv-padding="150px 0 50px 0"
       :sv-extra-margin="areLeftPanels ? '300px' : ''"
       >
-      <template slot="component">${templateString}</template>
+      <template v-slot:component>${templateString}</template>
     </sv-template-view>
   `;
 
@@ -621,6 +623,7 @@ ${settings.group.leftPanels2}
           CvSwitcherItemLink,
           Notification20,
           UserAvatar20,
+          Login20,
           AppSwitcher20,
           Fade16,
         },
@@ -629,6 +632,12 @@ ${settings.group.leftPanels2}
         mounted() {
           this.doActionNotification = () => action('Notifications - click');
           this.doActionSwitcher = () => action('Notifications - click');
+          this.doActionUserAvatar = () => action('User avatar - click');
+        },
+        data() {
+          return {
+            loggedIn: false,
+          };
         },
         computed: {
           areLeftPanels() {
@@ -642,7 +651,10 @@ ${settings.group.leftPanels2}
           actionNotifications() {
             this.doActionNotification();
           },
-          actionUserAvatar: action('User avatar - click'),
+          actionUserAvatar() {
+            this.loggedIn = !this.loggedIn;
+            this.doActionUserAvatar();
+          },
           actionAppSwitcher() {
             this.doActionSwitcher();
           },


### PR DESCRIPTION
Closes #1025 #936 

When using the slot syntax slot="name" beofreUpdate is able to identify whether or not a slot exists. However when switching to the new syntax v-slot:name only the default slot appears in this.$slots. This PR moves the check for slot content to the updated lifecycle method which works for both old and newer syntax.

#### Changelog

M       packages/core/src/components/cv-combo-box/cv-combo-box.vue
M       packages/core/src/components/cv-data-table/_cv-data-table-row-inner.vue
M       packages/core/src/components/cv-data-table/cv-data-table-row.vue
M       packages/core/src/components/cv-data-table/cv-data-table-skeleton.vue
M       packages/core/src/components/cv-data-table/cv-data-table.vue
M       packages/core/src/components/cv-date-picker/cv-date-picker.vue
M       packages/core/src/components/cv-dropdown/cv-dropdown.vue
M       packages/core/src/components/cv-modal/cv-modal.vue
M       packages/core/src/components/cv-multi-select/cv-multi-select.vue
M       packages/core/src/components/cv-number-input/cv-number-input.vue
M       packages/core/src/components/cv-select/cv-select.vue
M       packages/core/src/components/cv-text-area/cv-text-area.vue
M       packages/core/src/components/cv-text-input/cv-text-input.vue
M       packages/core/src/components/cv-time-picker/cv-time-picker.vue
M       packages/core/src/components/cv-ui-shell/cv-header.vue
M       packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
M       packages/core/src/components/cv-ui-shell/cv-side-nav-menu.vue
M       storybook/stories/cv-ui-shell-story.js
