### PR TITLE
feat: use carbon flatpickr plugins

### DIFF
--- a/packages/core/src/components/cv-date-picker/cv-date-picker.vue
+++ b/packages/core/src/components/cv-date-picker/cv-date-picker.vue
@@ -137,7 +137,7 @@ export default {
       },
     },
     invalidMessage: { type: String, default: undefined },
-    value: [String, Object, Array],
+    value: [String, Object, Array, Date],
   },
   model: {
     prop: 'value',

--- a/packages/core/src/components/cv-date-picker/cv-date-picker.vue
+++ b/packages/core/src/components/cv-date-picker/cv-date-picker.vue
@@ -12,7 +12,7 @@
         },
       ]"
       ref="date-picker"
-      :id="formItem ? '' : uid"
+      :id="formItem ? undefined : uid"
     >
       <div
         :class="{
@@ -72,7 +72,11 @@
 <script>
 import Flatpickr from 'flatpickr';
 import l10n from 'flatpickr/dist/l10n/index';
-import RangePlugin from 'flatpickr/dist/plugins/rangePlugin';
+// import carbonFlatpickrAppendToPlugin from './plugins/appendToPlugin';
+import carbonFlatpickrFixEventsPlugin from './plugins/fixEventsPlugin';
+import carbonFlatpickrRangePlugin from './plugins/rangePlugin';
+import carbonFlatpickrMonthSelectPlugin from './plugins/monthSelectPlugin';
+
 import uidMixin from '../../mixins/uid-mixin';
 import themeMixin from '../../mixins/theme-mixin';
 import Calendar16 from '@carbon/icons-vue/es/calendar/16';
@@ -230,13 +234,33 @@ export default {
       }
       // _options.onValueUpdate = this.onChange;
 
-      if (this.isRange) {
-        // let curDate = new Date();
-        // let anotherDate = new Date();
-        // anotherDate = anotherDate.setDate(anotherDate.getDate() + 6);
-        // _options.defaultDate = [curDate, anotherDate];
-        _options.plugins = [new RangePlugin({ input: this.$refs.todate, position: 'left' })];
-      }
+      _options.plugins = [
+        this.isRange
+          ? new carbonFlatpickrRangePlugin({
+              input: this.$refs.todate,
+            })
+          : () => {},
+        carbonFlatpickrMonthSelectPlugin({
+          selectorFlatpickrMonthYearContainer: '.flatpickr-current-month',
+          selectorFlatpickrYearContainer: '.numInputWrapper',
+          selectorFlatpickrCurrentMonth: '.cur-month',
+          classFlatpickrCurrentMonth: 'cur-month',
+        }),
+        carbonFlatpickrFixEventsPlugin({
+          inputFrom: this.$refs.date,
+          inputTo: this.$refs.todate,
+        }),
+      ];
+      _options.nextArrow = `
+      <svg width="16px" height="16px" viewBox="0 0 16 16">
+        <polygon points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3 "/>
+        <rect width="16" height="16" style="fill:none" />
+      </svg>`;
+      _options.prevArrow = `
+      <svg width="16px" height="16px" viewBox="0 0 16 16">
+        <polygon points="5,8 10,3 10.7,3.7 6.4,8 10.7,12.3 10,13 "/>
+        <rect width="16" height="16" style="fill:none" />
+      </svg>`;
 
       return _options;
     },

--- a/packages/core/src/components/cv-date-picker/plugins/appendToPlugin.js
+++ b/packages/core/src/components/cv-date-picker/plugins/appendToPlugin.js
@@ -1,0 +1,52 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * COPIED FROM carbon-components-react
+ */
+
+/**
+ * @param {object} config Plugin configuration.
+ * @returns {Plugin} A Flatpickr plugin to put adjust the position of calendar dropdown.
+ */
+export default config => fp => {
+  /**
+   * Adjusts the floating meun position after Flatpicker sets it.
+   */
+  const handlePreCalendarPosition = () => {
+    Promise.resolve().then(() => {
+      const { calendarContainer, config: fpConfig, _positionElement: positionElement } = fp;
+      const { appendTo } = fpConfig;
+      const { left: containerLeft, top: containerTop } = appendTo.getBoundingClientRect();
+      const { left: refLeft, bottom: refBottom } = positionElement.getBoundingClientRect();
+      if (
+        (appendTo !== appendTo.ownerDocument.body || containerLeft !== 0 || containerTop !== 0) &&
+        appendTo.ownerDocument.defaultView.getComputedStyle(appendTo).getPropertyValue('position') === 'static'
+      ) {
+        throw new Error('Floating menu container must not have `position:static`.');
+      }
+      // `2` for negative mergin on calendar dropdown
+      calendarContainer.style.top = `${refBottom - containerTop + 2}px`;
+      calendarContainer.style.left = `${refLeft - containerLeft}px`;
+    });
+  };
+
+  /**
+   * Registers this Flatpickr plugin.
+   */
+  const register = () => {
+    fp.loadedPlugins.push('carbonFlatpickrAppendToPlugin');
+  };
+
+  return {
+    appendTo: config.appendTo,
+    onReady: register,
+    onPreCalendarPosition: handlePreCalendarPosition,
+  };
+};

--- a/packages/core/src/components/cv-date-picker/plugins/fixEventsPlugin.js
+++ b/packages/core/src/components/cv-date-picker/plugins/fixEventsPlugin.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * COPIED FROM carbon-components-react - amended to remove keyboard code dependency
+ */
+
+/**
+ * @param {object} config Plugin configuration.
+ * @returns {Plugin} A Flatpickr plugin to fix Flatpickr's behavior of certain events.
+ */
+export default config => fp => {
+  /**
+   * Handles `keydown` event.
+   */
+  const handleKeydown = event => {
+    const { inputFrom, inputTo } = config;
+    const { target } = event;
+    if (inputFrom === target || inputTo === target) {
+      if (event.key === 'Enter') {
+        // Makes sure the hitting enter key picks up pending values of both `<input>`
+        // Workaround for: https://github.com/flatpickr/flatpickr/issues/1942
+        fp.setDate([inputFrom.value, inputTo && inputTo.value], true, fp.config.dateFormat);
+        event.stopPropagation();
+      } else if (event.key === 'Left' || event.key === 'Right') {
+        // Prevents Flatpickr code from canceling the event if left/right arrow keys are hit on `<input>`,
+        // so user can move the keyboard cursor for editing dates
+        // Workaround for: https://github.com/flatpickr/flatpickr/issues/1943
+        event.stopPropagation();
+      } else if (event.key === 'Down') {
+        event.preventDefault();
+        fp.open();
+      }
+    }
+  };
+
+  /**
+   * Releases event listeners used in this Flatpickr plugin.
+   */
+  const release = () => {
+    const { inputFrom, inputTo } = config;
+    if (inputTo) {
+      inputTo.removeEventListener('keydown', handleKeydown, true);
+    }
+    inputFrom.removeEventListener('keydown', handleKeydown, true);
+  };
+
+  /**
+   * Sets up event listeners used for this Flatpickr plugin.
+   */
+  const init = () => {
+    release();
+    const { inputFrom, inputTo } = config;
+    inputFrom.addEventListener('keydown', handleKeydown, true);
+    if (inputTo) {
+      inputTo.addEventListener('keydown', handleKeydown, true);
+    }
+  };
+
+  /**
+   * Registers this Flatpickr plugin.
+   */
+  const register = () => {
+    fp.loadedPlugins.push('carbonFlatpickrFixEventsPlugin');
+  };
+
+  return {
+    onReady: [register, init],
+    onDestroy: [release],
+  };
+};

--- a/packages/core/src/components/cv-date-picker/plugins/monthSelectPlugin.js
+++ b/packages/core/src/components/cv-date-picker/plugins/monthSelectPlugin.js
@@ -1,0 +1,66 @@
+/*
+ * COPIED FROM carbon-components-react
+ */
+
+/**
+ * @param {number} monthNumber The month number.
+ * @param {boolean} shorthand `true` to use shorthand month.
+ * @param {Locale} locale The Flatpickr locale data.
+ * @returns {string} The month string.
+ */
+const monthToStr = (monthNumber, shorthand, locale) => locale.months[shorthand ? 'shorthand' : 'longhand'][monthNumber];
+
+/**
+ * @param {object} config Plugin configuration.
+ * @param {boolean} [config.shorthand] `true` to use shorthand month.
+ * @param {string} config.selectorFlatpickrMonthYearContainer The CSS selector for the container of month/year selection UI.
+ * @param {string} config.selectorFlatpickrYearContainer The CSS selector for the container of year selection UI.
+ * @param {string} config.selectorFlatpickrCurrentMonth The CSS selector for the text-based month selection UI.
+ * @param {string} config.classFlatpickrCurrentMonth The CSS class for the text-based month selection UI.
+ * @returns {Plugin} A Flatpickr plugin to use text instead of `<select>` for month picker.
+ */
+export default config => fp => {
+  const setupElements = () => {
+    if (!fp.monthElements) {
+      return;
+    }
+    fp.monthElements.forEach(elem => {
+      if (!elem.parentNode) return;
+      elem.parentNode.removeChild(elem);
+    });
+    fp.monthElements.splice(
+      0,
+      fp.monthElements.length,
+      ...fp.monthElements.map(() => {
+        // eslint-disable-next-line no-underscore-dangle
+        const monthElement = fp._createElement('span', config.classFlatpickrCurrentMonth);
+        monthElement.textContent = monthToStr(fp.currentMonth, config.shorthand === true, fp.l10n);
+        fp.yearElements[0]
+          .closest(config.selectorFlatpickrMonthYearContainer)
+          .insertBefore(monthElement, fp.yearElements[0].closest(config.selectorFlatpickrYearContainer));
+        return monthElement;
+      })
+    );
+  };
+
+  const updateCurrentMonth = () => {
+    const monthStr = monthToStr(fp.currentMonth, config.shorthand === true, fp.l10n);
+    fp.yearElements.forEach(elem => {
+      const currentMonthContainer = elem.closest(config.selectorFlatpickrMonthYearContainer);
+      Array.prototype.forEach.call(currentMonthContainer.querySelectorAll('.cur-month'), monthElement => {
+        monthElement.textContent = monthStr;
+      });
+    });
+  };
+
+  const register = () => {
+    fp.loadedPlugins.push('carbonFlatpickrMonthSelectPlugin');
+  };
+
+  return {
+    onMonthChange: updateCurrentMonth,
+    onValueUpdate: updateCurrentMonth,
+    onOpen: updateCurrentMonth,
+    onReady: [setupElements, updateCurrentMonth, register],
+  };
+};

--- a/packages/core/src/components/cv-date-picker/plugins/rangePlugin.js
+++ b/packages/core/src/components/cv-date-picker/plugins/rangePlugin.js
@@ -1,0 +1,45 @@
+import rangePlugin from 'flatpickr/dist/plugins/rangePlugin';
+
+/*
+ * COPIED FROM carbon-components-react
+ */
+
+/**
+ * @param {object} config Plugin configuration.
+ * @returns {Plugin} An extension of Flatpickr `rangePlugin` that does the following:
+ *   * Better ensures the calendar dropdown is always aligned to the `<input>` for the starting date.
+ *     Workaround for: https://github.com/flatpickr/flatpickr/issues/1944
+ *   * A logic to ensure `fp.setDate()` call won't end up with "startDate to endDate" set to the first `<input>`
+ */
+export default config => {
+  const factory = rangePlugin(Object.assign({ position: 'left' }, config));
+
+  return fp => {
+    const origSetDate = fp.setDate;
+
+    const init = () => {
+      fp.setDate = function setDate(dates, triggerChange, format) {
+        origSetDate.call(this, dates, triggerChange, format);
+        // If `triggerChange` is `true`, `onValueUpdate` Flatpickr event is fired
+        // where Flatpickr's range plugin takes care of fixing the first `<input>`
+        if (!triggerChange) {
+          const { _input: inputFrom } = fp;
+          const { input: inputTo } = config;
+          [inputFrom, inputTo].forEach((input, i) => {
+            if (input) {
+              input.value = !dates[i] ? '' : fp.formatDate(new Date(dates[i]), fp.config.dateFormat);
+            }
+          });
+        }
+      };
+    };
+
+    const origRangePlugin = factory(fp);
+    const { onReady: origOnReady } = origRangePlugin;
+
+    return Object.assign(origRangePlugin, {
+      onReady: [init, origOnReady],
+      onPreCalendarPosition() {},
+    });
+  };
+};


### PR DESCRIPTION
Closes #434

Makes use of carbon flatipickr plugins defined in carbon-components-react.

#### Changelog

M       packages/core/src/components/cv-date-picker/cv-date-picker.vue
A       packages/core/src/components/cv-date-picker/plugins/appendToPlugin.js
A       packages/core/src/components/cv-date-picker/plugins/fixEventsPlugin.js
A       packages/core/src/components/cv-date-picker/plugins/monthSelectPlugin.js
A       packages/core/src/components/cv-date-picker/plugins/rangePlugin.js