### PR TITLE
fix(cv-dropdown): missing classes

### DIFF
--- a/packages/core/src/components/cv-dropdown/cv-dropdown.vue
+++ b/packages/core/src/components/cv-dropdown/cv-dropdown.vue
@@ -20,7 +20,12 @@
     <div
       :class="[
         `${carbonPrefix}--dropdown__wrapper`,
-        { [`${carbonPrefix}--dropdown__wrapper--inline`]: inline, 'cv-dropdown': !formItem },
+        `${carbonPrefix}--list-box__wrapper`,
+        {
+          [`${carbonPrefix}--dropdown__wrapper--inline`]: inline,
+          [`${carbonPrefix}--list-box__wrapper--inline`]: inline,
+          'cv-dropdown': !formItem,
+        },
       ]"
       :style="wrapperStyleOverride"
     >
@@ -41,6 +46,7 @@
             [`${carbonPrefix}--dropdown--light`]: theme === 'light',
             [`${carbonPrefix}--dropdown--up`]: up,
             [`${carbonPrefix}--dropdown--open`]: open,
+            [`${carbonPrefix}--list-box--expanded`]: open,
             [`${carbonPrefix}--dropdown--invalid`]: isInvalid,
             [`${carbonPrefix}--dropdown--disabled`]: disabled,
             [`${carbonPrefix}--dropdown--inline`]: inline,


### PR DESCRIPTION
Temporary fixes max-height. It may be replaced by a new implementation for #994  

Adds some missing classes from list-box component.
The code was based on carbon-components-react

References:
- https://github.com/carbon-design-system/carbon/blob/c5a64d27cd7bb41eeea9922bc05afe6c5c2059eb/packages/react/src/components/Dropdown/Dropdown.js#L100

- https://github.com/carbon-design-system/carbon/blob/c5a64d27cd7bb41eeea9922bc05afe6c5c2059eb/packages/react/src/components/Dropdown/Dropdown.js#L103

- https://github.com/carbon-design-system/carbon/blob/c5a64d27cd7bb41eeea9922bc05afe6c5c2059eb/packages/react/src/components/ListBox/ListBox.js#L53

#### Changelog

```
M       packages/core/src/components/cv-dropdown/cv-dropdown.vue
```