### PR TITLE
fix: notes links to carbondesignsystem.com

### DIFF
--- a/packages/core/src/components/cv-combo-box/cv-combo-box-notes.md
+++ b/packages/core/src/components/cv-combo-box/cv-combo-box-notes.md
@@ -2,7 +2,7 @@
 
 A Vue implementation of a Carbon Components multi-select
 
-https://www.carbondesignsystem.com/components/multi-select/code
+https://www.carbondesignsystem.com/components/dropdown/code
 
 ## Usage
 

--- a/packages/core/src/components/cv-data-table/cv-data-table-notes.md
+++ b/packages/core/src/components/cv-data-table/cv-data-table-notes.md
@@ -2,7 +2,7 @@
 
 A Vue implementation of a Carbon Components DataTable.
 
-http://www.carbondesignsystem.com/components/DataTable/code
+https://www.carbondesignsystem.com/components/data-table/code
 
 ## Usage
 

--- a/packages/core/src/components/cv-multi-select/cv-multi-select-notes.md
+++ b/packages/core/src/components/cv-multi-select/cv-multi-select-notes.md
@@ -2,7 +2,7 @@
 
 A Vue implementation of a Carbon Components multi-select
 
-https://www.carbondesignsystem.com/components/multi-select/code
+https://www.carbondesignsystem.com/components/dropdown/code
 
 ## Usage
 

--- a/packages/core/src/components/cv-search/cv-search-notes.md
+++ b/packages/core/src/components/cv-search/cv-search-notes.md
@@ -2,7 +2,7 @@
 
 A Vue implementation of a Carbon Components search
 
-http://www.carbondesignsystem.com/components/text-input/code
+https://www.carbondesignsystem.com/components/search/code
 
 ## Usage
 

--- a/packages/core/src/components/cv-time-picker/cv-time-picker-notes.md
+++ b/packages/core/src/components/cv-time-picker/cv-time-picker-notes.md
@@ -2,7 +2,7 @@
 
 A Vue implementation of a Carbon Components time-picker
 
-http://www.carbondesignsystem.com/components/time-picker/code
+https://www.carbondesignsystem.com/components/date-picker/code
 
 ## Usage
 

--- a/packages/core/src/components/cv-toolbar/cv-toolbar-notes.md
+++ b/packages/core/src/components/cv-toolbar/cv-toolbar-notes.md
@@ -1,8 +1,6 @@
 # CvToolbar
 
-A Vue implementation of a Carbon Components Toolbar.
-
-http://www.carbondesignsystem.com/components/Toolbar/code
+A Vue implementation of a Carbon Components Toolbar (Deprecated).
 
 ## Usage
 

--- a/packages/core/src/components/cv-ui-shell/cv-ui-shell-notes.md
+++ b/packages/core/src/components/cv-ui-shell/cv-ui-shell-notes.md
@@ -2,7 +2,9 @@
 
 A Vue implementation of a Carbon Components Header
 
-https://www.carbondesignsystem.com/experimental/ui-shell/code
+- https://www.carbondesignsystem.com/components/UI-shell-header/usage
+- https://www.carbondesignsystem.com/components/UI-shell-left-panel/usage
+- https://www.carbondesignsystem.com/components/UI-shell-right-panel/usage
 
 ## Usage
 


### PR DESCRIPTION
Closes #1037

Fix incorrect links into core carbon site.

#### Changelog

M       packages/core/src/components/cv-combo-box/cv-combo-box-notes.md
M       packages/core/src/components/cv-data-table/cv-data-table-notes.md
M       packages/core/src/components/cv-multi-select/cv-multi-select-notes.md
M       packages/core/src/components/cv-search/cv-search-notes.md
M       packages/core/src/components/cv-time-picker/cv-time-picker-notes.md
M       packages/core/src/components/cv-toolbar/cv-toolbar-notes.md
M       packages/core/src/components/cv-ui-shell/cv-ui-shell-notes.md
