### PR TITLE
fix: remove down chevron role

### DIFF
--- a/packages/core/src/components/cv-dropdown/cv-dropdown.vue
+++ b/packages/core/src/components/cv-dropdown/cv-dropdown.vue
@@ -83,7 +83,6 @@
           />
           <div
             :class="[`${carbonPrefix}--list-box__menu-icon`, { [`${carbonPrefix}--list-box__menu-icon--open`]: open }]"
-            role="button"
           >
             <chevron-down-16 :aria-label="open ? 'Close menu' : 'Open menu'" />
           </div>


### PR DESCRIPTION
Closes #1042

Remove unnecessary role="button" on the dropdown chevron.

#### Changelog

M       packages/core/src/components/cv-dropdown/cv-dropdown.vue