### PR TITLE
test: add tests for cv-toolbar

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-toolbar.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-toolbar.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CvToolbar should render with slot correctly 1`] = `
+<div data-toolbar="" class="bx--toolbar" id="test-1">
+  <div>default test slot</div>
+</div>
+`;
+
+exports[`CvToolbar should render without slot correctly 1`] = `<div data-toolbar="" class="bx--toolbar" id="test-1"></div>`;
+
+exports[`CvToolbarDivider should render correctly 1`] = `<hr class="cv-toolbar-divider bx--toolbar-menu__divider" id="test-1">`;
+
+exports[`CvToolbarOption should render with slot correctly 1`] = `
+<li class="cv-toolbar-option bx--toolbar-menu__option" id="test-1">
+  <div>default test slot</div>
+</li>
+`;
+
+exports[`CvToolbarOption should render without slot correctly 1`] = `<li class="cv-toolbar-option bx--toolbar-menu__option" id="test-1"></li>`;
+
+exports[`CvToolbarSearch should render correctly 1`] = `<cv-search-stub id="test-1" theme="" cleararialabel="Clear search input" kind="toolbar" small="true" value="check-1" placeholder="Search" toolbararialabel="Toolbar search" class="cv-toolbar-search"></cv-search-stub>`;
+
+exports[`CvToolbarTitle should render correctly 1`] = `<li class="cv-toolbar-title bx--toolbar-menu__title" id="test-1">Toolbar test title</li>`;

--- a/packages/core/__tests__/cv-toolbar.test.js
+++ b/packages/core/__tests__/cv-toolbar.test.js
@@ -1,0 +1,160 @@
+import { testComponent, awaitNextTick } from './_helpers';
+const { shallowMount: shallow, trigger, mount } = awaitNextTick;
+import { CvToolbar, CvToolbarTitle, CvToolbarSearch, CvToolbarOption, CvToolbarDivider } from '@/components/cv-toolbar';
+import { settings as carbonSettings } from 'carbon-components';
+
+const carbonPrefix = carbonSettings.prefix;
+
+describe('CvToolbar', () => {
+  // ***************
+  // PROP CHECKS
+  // ***************
+
+  // ***************
+  // SNAPSHOT TESTS
+  // ***************
+
+  it('should render without slot correctly', async () => {
+    const propsData = { id: 'test-1' };
+    const wrapper = await shallow(CvToolbar, { propsData });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should render with slot correctly', async () => {
+    const propsData = { id: 'test-1' };
+    const wrapper = await shallow(CvToolbar, {
+      slots: {
+        default: '<div>default test slot</div>',
+      },
+      propsData,
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  // ***************
+  // FUNCTIONAL TESTS
+  // ***************
+});
+
+describe('CvToolbarTitle', () => {
+  // ***************
+  // PROP CHECKS
+  // ***************
+  testComponent.propsAreType(CvToolbarTitle, ['title'], String);
+  testComponent.propsAreRequired(CvToolbarTitle, ['title']);
+
+  // ***************
+  // SNAPSHOT TESTS
+  // ***************
+
+  it('should render correctly', async () => {
+    const propsData = { id: 'test-1', title: 'Toolbar test title' };
+    const wrapper = await shallow(CvToolbarTitle, { propsData });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  // ***************
+  // FUNCTIONAL TESTS
+  // ***************
+});
+
+describe('CvToolbarSearch', () => {
+  // ***************
+  // PROP CHECKS
+  // ***************
+  testComponent.propsAreType(CvToolbarSearch, ['value'], String);
+
+  // ***************
+  // SNAPSHOT TESTS
+  // ***************
+
+  it('should render correctly', async () => {
+    const propsData = { id: 'test-1', value: 'check-1' };
+    const wrapper = await shallow(CvToolbarSearch, { propsData });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  // ***************
+  // FUNCTIONAL TESTS
+  // ***************
+  it('should add active css class on focus and remove on blur', async () => {
+    const propsData = { id: 'test-1', value: 'check-1' };
+    const wrapper = await mount(CvToolbarSearch, { propsData });
+
+    await trigger(wrapper.find(`.${carbonPrefix}--toolbar-search__btn`), 'click');
+    expect(wrapper.classes()).toContain(`${carbonPrefix}--toolbar-search--active`);
+
+    await trigger(wrapper.find(`.${carbonPrefix}--toolbar-search__btn`), 'blur');
+    expect(wrapper.classes()).not.toContain(`${carbonPrefix}--toolbar-search--active`);
+  });
+});
+
+describe('CvToolbarOption', () => {
+  // ***************
+  // PROP CHECKS
+  // ***************
+
+  // ***************
+  // SNAPSHOT TESTS
+  // ***************
+
+  it('should render without slot correctly', async () => {
+    const propsData = { id: 'test-1' };
+    const wrapper = await shallow(CvToolbarOption, { propsData });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('should render with slot correctly', async () => {
+    const propsData = { id: 'test-1' };
+    const wrapper = await shallow(CvToolbarOption, {
+      slots: {
+        default: '<div>default test slot</div>',
+      },
+      propsData,
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  // ***************
+  // FUNCTIONAL TESTS
+  // ***************
+  it('parent should emit event on esc keydown', async () => {
+    const propsData = { id: 'test-1' };
+    const wrapper = await mount(CvToolbar, {
+      slots: {
+        default: CvToolbarOption,
+      },
+      propsData,
+    });
+
+    await trigger(wrapper.find(CvToolbarOption), 'keydown.esc');
+    expect(wrapper.emitted('cv:close')).toBeTruthy();
+  });
+});
+
+describe('CvToolbarDivider', () => {
+  // ***************
+  // PROP CHECKS
+  // ***************
+
+  // ***************
+  // SNAPSHOT TESTS
+  // ***************
+
+  it('should render correctly', async () => {
+    const propsData = { id: 'test-1' };
+    const wrapper = await shallow(CvToolbarDivider, { propsData });
+
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  // ***************
+  // FUNCTIONAL TESTS
+  // ***************
+});


### PR DESCRIPTION
#182

Add tests for CvToolbar component. Could not add coverage for @blur event for CvToolbarSearch, even though I tested that the 'active' class is removed on blur.

#### Changelog

A       packages/core/__tests__/__snapshots__/cv-toolbar.test.js.snap
A       packages/core/__tests__/cv-toolbar.test.js