### PR TITLE
fix: remove extra tabIndex in tag

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-tag.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-tag.test.js.snap
@@ -1,57 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CvTag should render 1`] = `
-<span tabindex="0" role="listitem" class="cv-tag bx--tag bx--tag--red"><span class="bx--tag__label">test</span>
+<span role="listitem" class="cv-tag bx--tag bx--tag--red"><span class="bx--tag__label">test</span>
 <!----></span>
 `;
 
 exports[`CvTag should render 2`] = `
-<span tabindex="0" role="listitem" class="cv-tag bx--tag bx--tag--magenta"><span class="bx--tag__label">test</span>
+<span role="listitem" class="cv-tag bx--tag bx--tag--magenta"><span class="bx--tag__label">test</span>
 <!----></span>
 `;
 
 exports[`CvTag should render 3`] = `
-<span tabindex="0" role="listitem" class="cv-tag bx--tag bx--tag--purple"><span class="bx--tag__label">test</span>
+<span role="listitem" class="cv-tag bx--tag bx--tag--purple"><span class="bx--tag__label">test</span>
 <!----></span>
 `;
 
 exports[`CvTag should render 4`] = `
-<span tabindex="0" role="listitem" class="cv-tag bx--tag bx--tag--blue"><span class="bx--tag__label">test</span>
+<span role="listitem" class="cv-tag bx--tag bx--tag--blue"><span class="bx--tag__label">test</span>
 <!----></span>
 `;
 
 exports[`CvTag should render 5`] = `
-<span tabindex="0" role="listitem" class="cv-tag bx--tag bx--tag--cyan"><span class="bx--tag__label">test</span>
+<span role="listitem" class="cv-tag bx--tag bx--tag--cyan"><span class="bx--tag__label">test</span>
 <!----></span>
 `;
 
 exports[`CvTag should render 6`] = `
-<span tabindex="0" role="listitem" class="cv-tag bx--tag bx--tag--teal"><span class="bx--tag__label">test</span>
+<span role="listitem" class="cv-tag bx--tag bx--tag--teal"><span class="bx--tag__label">test</span>
 <!----></span>
 `;
 
 exports[`CvTag should render 7`] = `
-<span tabindex="0" role="listitem" class="cv-tag bx--tag bx--tag--green"><span class="bx--tag__label">test</span>
+<span role="listitem" class="cv-tag bx--tag bx--tag--green"><span class="bx--tag__label">test</span>
 <!----></span>
 `;
 
 exports[`CvTag should render 8`] = `
-<span tabindex="0" role="listitem" class="cv-tag bx--tag bx--tag--gray"><span class="bx--tag__label">test</span>
+<span role="listitem" class="cv-tag bx--tag bx--tag--gray"><span class="bx--tag__label">test</span>
 <!----></span>
 `;
 
 exports[`CvTag should render 9`] = `
-<span tabindex="0" role="listitem" class="cv-tag bx--tag bx--tag--cool-gray"><span class="bx--tag__label">test</span>
+<span role="listitem" class="cv-tag bx--tag bx--tag--cool-gray"><span class="bx--tag__label">test</span>
 <!----></span>
 `;
 
 exports[`CvTag should render 10`] = `
-<span tabindex="0" role="listitem" class="cv-tag bx--tag bx--tag--warm-gray"><span class="bx--tag__label">test</span>
+<span role="listitem" class="cv-tag bx--tag bx--tag--warm-gray"><span class="bx--tag__label">test</span>
 <!----></span>
 `;
 
 exports[`CvTag should render 11`] = `
-<span tabindex="0" role="listitem" class="cv-tag bx--tag bx--tag--high-contrast"><span class="bx--tag__label">test</span>
+<span role="listitem" class="cv-tag bx--tag bx--tag--high-contrast"><span class="bx--tag__label">test</span>
 <!----></span>
 `;
 

--- a/packages/core/src/components/cv-tag/cv-tag.vue
+++ b/packages/core/src/components/cv-tag/cv-tag.vue
@@ -8,7 +8,6 @@
         [`${carbonPrefix}--tag--disabled`]: disabled,
       },
     ]"
-    :tabindex="!disabled ? 0 : undefined"
     role="listitem"
     :title="title"
     @keydown.enter.stop.prevent="$emit('remove')"


### PR DESCRIPTION
Closes #1032 

Remove tabindex which was no longer needed 

#### Changelog

M       packages/core/__tests__/__snapshots__/cv-tag.test.js.snap
M       packages/core/src/components/cv-tag/cv-tag.vue