### PR TITLE
docs: fix some typos

### DIFF
--- a/storybook/stories/cv-combo-box-story.js
+++ b/storybook/stories/cv-combo-box-story.js
@@ -129,7 +129,7 @@ let preKnobs = {
   autoHighlight: {
     group: 'attr',
     type: boolean,
-    config: ['auto hihglight', false], // consts.CONFIG], // fails when used with number in storybook 4.1.4
+    config: ['auto highlight', false], // consts.CONFIG], // fails when used with number in storybook 4.1.4
     prop: 'auto-highlight',
   },
   initialValue: {

--- a/storybook/stories/cv-multi-select-story.js
+++ b/storybook/stories/cv-multi-select-story.js
@@ -150,7 +150,7 @@ let preKnobs = {
   autoHighlight: {
     group: 'attr',
     type: boolean,
-    config: ['auto hihglight', false], // consts.CONFIG], // fails when used with number in storybook 4.1.4
+    config: ['auto highlight', false], // consts.CONFIG], // fails when used with number in storybook 4.1.4
     prop: 'auto-highlight',
   },
   initialValue: {


### PR DESCRIPTION
#### Changelog
Fixed 2 instances of typos: `hihglight` -> `highlight`.