### PR TITLE
fix: ignore side panel focusout b4 click on safari

### DIFF
--- a/packages/core/src/components/cv-ui-shell/cv-header-panel.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-header-panel.vue
@@ -62,7 +62,7 @@ export default {
       this.$parent.$emit('cv:panel-focusout', this, ev);
     },
     onMouseDown(ev) {
-      if (this.$el === ev.target) {
+      if (this.$el == ev.target || this.$el.contains(ev.target)) {
         // ignore mousedown on panel can cause focus event
         ev.preventDefault();
       }

--- a/packages/core/src/components/cv-ui-shell/cv-side-nav.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav.vue
@@ -80,7 +80,7 @@ export default {
       this.$parent.$emit('cv:panel-focusout', this, ev);
     },
     onMouseDown(ev) {
-      if (this.$el === ev.target) {
+      if (this.$el == ev.target || this.$el.contains(ev.target)) {
         // ignore mousedown on panel can cause focus event
         ev.preventDefault();
       }


### PR DESCRIPTION
Closes #1056

Addresses loss of focus prior to click on side panel link in Safari. The UIShell/side panel still has a number of keyboard accessibility issues which should be raised as another issue.

#### Changelog

m packages/core/src/components/cv-ui-shell/cv-header-panel.vue 
m packages/core/src/components/cv-ui-shell/cv-side-nav.vue 
