### PR TITLE
Add after hidden modal event

### DIFF
--- a/packages/core/src/components/cv-modal/cv-modal-notes.md
+++ b/packages/core/src/components/cv-modal/cv-modal-notes.md
@@ -66,5 +66,6 @@ This is done after the modal transitions into its visible state, which is trigge
 - modal-shown
 - modal-hidden
 - modal-hide-request - emitted when 'auto-hide-off' is set to true. Raw event with the additional attribute 'cv:reason' set to 'primary-click', 'secondary-click', 'escape-press', 'external-click' or 'close-click'
+- after-modal-hidden - emitted only after the modal hide transition is finished. It will NOT fire if the modal is hidden when it's not visible
 - primary-click
 - secondary-click

--- a/packages/core/src/components/cv-modal/cv-modal.vue
+++ b/packages/core/src/components/cv-modal/cv-modal.vue
@@ -251,5 +251,10 @@ export default {
       }
     },
   },
+  beforeDestroy() {
+    if (this.dataVisible) {
+      this.$emit('after-modal-hidden');
+    }
+  },
 };
 </script>

--- a/packages/core/src/components/cv-modal/cv-modal.vue
+++ b/packages/core/src/components/cv-modal/cv-modal.vue
@@ -228,8 +228,15 @@ export default {
       //restore any previous scrollability
       document.body.classList.remove(`${this.carbonPrefix}--body--with-modal-open`);
 
+      if (this.dataVisible) {
+        this.$el.addEventListener('transitionend', this.afterHide, { once: true });
+      }
+
       this.dataVisible = false;
       this.$emit('modal-hidden');
+    },
+    afterHide() {
+      this.$emit('after-modal-hidden');
     },
     onPrimaryClick(ev) {
       this.$emit('primary-click');

--- a/storybook/stories/cv-modal-story.js
+++ b/storybook/stories/cv-modal-story.js
@@ -129,7 +129,8 @@ const preKnobs = {
     group: 'attr',
     value: `@modal-shown="actionShown"
   @modal-hidden="actionHidden"
-  @modal-hide-request="actionHideRequest"`,
+  @modal-hide-request="actionHideRequest"
+  @after-modal-hidden="actionAfterHidden"`,
   },
   primarySecondaryEvents: {
     group: 'attr',
@@ -256,6 +257,7 @@ for (const story of storySet) {
           actionPrimary: action('CV Modal - primary-click'),
           actionSecondary: action('CV Modal - secondary-click'),
           actionHideRequest: action('Cv Modal - modal-hide-request'),
+          actionAfterHidden: action('CV Modal - after-modal-hidden'),
         },
         template: templateViewString,
       };


### PR DESCRIPTION
Closes #1068

Adds a new event to `cv-modal` called `after-modal-hidden`, which triggers once the hide transition is finished.

#### Changelog

M       packages/core/src/components/cv-modal/cv-modal-notes.md
M       packages/core/src/components/cv-modal/cv-modal.vue
M       storybook/stories/cv-modal-story.js
