### PR TITLE
fix: ensure no previous transitionend event triggers after-modal-hidden

### DIFF
--- a/packages/core/src/components/cv-modal/cv-modal.vue
+++ b/packages/core/src/components/cv-modal/cv-modal.vue
@@ -245,14 +245,17 @@ export default {
       document.body.classList.remove(`${this.carbonPrefix}--body--with-modal-open`);
 
       if (this.dataVisible) {
-        this.$el.addEventListener('transitionend', this.afterHide, { once: true });
+        this.$el.addEventListener('transitionend', this.afterHide);
       }
 
       this.dataVisible = false;
       this.$emit('modal-hidden');
     },
-    afterHide() {
-      this.$emit('after-modal-hidden');
+    afterHide(event) {
+      if (event.propertyName === 'opacity') {
+        this.$emit('after-modal-hidden');
+        this.$el.removeEventListener('transitionend', this.afterHide);
+      }
     },
     onPrimaryClick(ev) {
       this.$emit('primary-click');


### PR DESCRIPTION
Closes #1080 

Currently a `border-bottom` transition can trigger the event early. This fix ensures that the event is only triggered after the modal is no longer visible.

#### Changelog

M       packages/core/src/components/cv-modal/cv-modal.vue