### PR TITLE
Include `left` and `right` to direction validator.

### DIFF
--- a/packages/core/src/components/cv-tooltip/cv-definition-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-definition-tooltip.vue
@@ -30,7 +30,7 @@ export default {
       type: String,
       default: 'top',
       validator(val) {
-        const validValues = ['top', 'bottom'];
+        const validValues = ['top', 'left', 'right', 'bottom'];
         const valid = validValues.includes(val);
         if (!valid) {
           console.warn(`CVDefinitionTooltip.direction must be one of the following: ${validValues}`);


### PR DESCRIPTION
As of today, the definition tooltip only accepts `top` and `bottom`. To remain consistent with the `cv-tooltip` definition, I included `left` and `right` options.

Plus, left and right behavior is applied, but the validator function throws an error to the console.


