### PR TITLE
fix: cv-tabs fails in focusout event when using router-link in a tab

### DIFF
--- a/packages/core/src/components/cv-tabs/cv-tabs.vue
+++ b/packages/core/src/components/cv-tabs/cv-tabs.vue
@@ -90,12 +90,12 @@ export default {
     this.$on('cv:enabled', srcComponent => this.onCvEnabled(srcComponent));
   },
   mounted() {
-    this.$refs.tabs.addEventListener('focusout', this.onFocusout)
-    this.$refs.tabs.addEventListener('focusin', this.onFocusin)
+    this.$refs.tabs.addEventListener('focusout', this.onFocusout);
+    this.$refs.tabs.addEventListener('focusin', this.onFocusin);
   },
   beforeDestroy() {
-    this.$refs.tabs.removeEventListener('focusout', this.onFocusout)
-    this.$refs.tabs.removeEventListener('focusin', this.onFocusin)
+    this.$refs.tabs.removeEventListener('focusout', this.onFocusout);
+    this.$refs.tabs.removeEventListener('focusin', this.onFocusin);
   },
   computed: {
     triggerStyleOverride() {

--- a/packages/core/src/components/cv-tabs/cv-tabs.vue
+++ b/packages/core/src/components/cv-tabs/cv-tabs.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="cv-tabs" @focusout="onFocusout" @focusin="onFocusin" style="width: 100%;">
+  <div class="cv-tabs" ref="tabs" style="width: 100%;">
     <div
       data-tabs
       :class="[`cv-tab ${carbonPrefix}--tabs`, { [`${carbonPrefix}--tabs--container`]: container }]"
@@ -88,6 +88,14 @@ export default {
     this.$on('cv:selected', srcComponent => this.onCvSelected(srcComponent));
     this.$on('cv:disabled', srcComponent => this.onCvDisabled(srcComponent));
     this.$on('cv:enabled', srcComponent => this.onCvEnabled(srcComponent));
+  },
+  mounted() {
+    this.$refs.tabs.addEventListener('focusout', this.onFocusout)
+    this.$refs.tabs.addEventListener('focusin', this.onFocusin)
+  },
+  beforeDestroy() {
+    this.$refs.tabs.removeEventListener('focusout', this.onFocusout)
+    this.$refs.tabs.removeEventListener('focusin', this.onFocusin)
   },
   computed: {
     triggerStyleOverride() {


### PR DESCRIPTION
Closes #1083

This PR changes the `cv-tabs` component, adds the event listeners on `mount` and removes them in `beforeDestroy`, doing this with `this.$refs.tabs` where `tabs` is the root div which previously had the listeners attached as `@focusout="onFocusout" @focusin="onFocusin"`.

#### Changelog

M       packages/core/src/components/cv-tabs/cv-tabs.vue
