### PR TITLE
fix: cv-data-table listener is called after navigation

### DIFF
--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -49,7 +49,6 @@
                 @keydown.enter.prevent="checkSearchExpand(true)"
                 @keydown.space.prevent
                 @keyup.space.prevent="checkSearchExpand(true)"
-                @blur="checkSearchFocus"
                 ref="magnifier"
               >
                 <Search16 :class="`${carbonPrefix}--toolbar-action__icon`" />
@@ -65,7 +64,6 @@
                 ref="search"
                 v-model="searchValue"
                 @input="onSearch"
-                @blur="checkSearchFocus"
                 @keydown.esc.prevent="checkSearchExpand(false)"
               />
               <button
@@ -271,8 +269,18 @@ export default {
     this.$on('cv:sort', (srcComponent, value) => this.onSort(srcComponent, value));
   },
   mounted() {
+    if (this.$refs.searchContainer) {
+      this.$refs.magnifier.addEventListener('blur', this.checkSearchFocus);
+      this.$refs.search.addEventListener('blur', this.checkSearchFocus);
+    }
     this.updateRowsSelected();
     this.checkSlots();
+  },
+  beforeDestroy() {
+    if (this.$refs.searchContainer) {
+      this.$refs.magnifier.removeEventListener('blur', this.checkSearchFocus);
+      this.$refs.search.removeEventListener('blur', this.checkSearchFocus);
+    }
   },
   updated() {
     this.checkSlots();


### PR DESCRIPTION
Closes #1088

Removes the listeners from the original component definition, and adds the `blur` listeners to the `magnifier` and `search` components in the `mounted` function. At the end, in the `beforeDestroy` function, it removes the listeners to prevent the issue described in #1088 . It also checks if the `searchContainer` component exists, to prevent the same, undefined error happening.

#### Changelog

M       packages/core/src/components/cv-data-table/cv-data-table.vue
