### PR TITLE
fix: change update to computed

### DIFF
--- a/packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
@@ -34,13 +34,10 @@ export default {
     active: Boolean,
     icon: Object,
   },
-  data() {
-    return {
-      hasNavIcon: this.$slots['nav-icon'],
-    };
-  },
-  updated() {
-    this.hasNavIcon = !!this.$slots['nav-icon'];
+  computed: {
+    hasNavIcon() {
+      return !!this.$slots['nav-icon'];
+    },
   },
 };
 </script>


### PR DESCRIPTION
Closes #

The side nav with icon does not work properly if the side nav is hidden with v-if and then later shown
https://ihzer.csb.app/
![image](https://user-images.githubusercontent.com/7536103/101405343-f3719a80-38a5-11eb-9b53-ba8edd05adf6.png)

Force an update to show icons
![image](https://user-images.githubusercontent.com/7536103/101405857-beb21300-38a6-11eb-9bcd-2d835cf7e81d.png)


#### Changelog

M       packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
