### PR TITLE
fix: use check slot pattern in side nav

### DIFF
--- a/packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue
@@ -36,11 +36,19 @@ export default {
   },
   data() {
     return {
-      hasNavIcon: this.$slots['nav-icon'],
+      hasNavIcon: false,
     };
   },
+  mounted() {
+    this.checkSlots();
+  },
   updated() {
-    this.hasNavIcon = !!this.$slots['nav-icon'];
+    this.checkSlots();
+  },
+  methods: {
+    checkSlots() {
+      this.hasNavIcon = !!this.$slots['nav-icon'];
+    },
   },
 };
 </script>


### PR DESCRIPTION
Contribues to  #1091 

Use the checkSlots pattern in side nav for icons

#### Changelog

modified:   packages/core/src/components/cv-ui-shell/cv-side-nav-link.vue