### PR TITLE
feat: add show/hide events to cv-interactive-tooltip

### DIFF
--- a/packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
@@ -105,6 +105,13 @@ export default {
         this.position();
       }
     },
+    dataVisible() {
+      if (this.dataVisible) {
+        this.$emit('show-tooltip');
+      } else {
+        this.$emit('hide-tooltip');
+      }
+    },
   },
   methods: {
     positionListen(on) {

--- a/packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
+++ b/packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
@@ -107,9 +107,9 @@ export default {
     },
     dataVisible() {
       if (this.dataVisible) {
-        this.$emit('show-tooltip');
+        this.$emit('tooltip-shown');
       } else {
-        this.$emit('hide-tooltip');
+        this.$emit('tooltip-hidden');
       }
     },
   },

--- a/packages/core/src/components/cv-tooltip/cv-tooltip-notes.md
+++ b/packages/core/src/components/cv-tooltip/cv-tooltip-notes.md
@@ -29,6 +29,11 @@ http://www.carbondesignsystem.com/components/tooltip/code
 - alignment: start, center or end.
 - direction: 'top', 'left', 'right', 'bottom'
 
+### Events
+
+- show-tooltip
+- hide-tooltip
+
 ## slots
 
 - label - hover does not display tooltip.

--- a/packages/core/src/components/cv-tooltip/cv-tooltip-notes.md
+++ b/packages/core/src/components/cv-tooltip/cv-tooltip-notes.md
@@ -31,8 +31,8 @@ http://www.carbondesignsystem.com/components/tooltip/code
 
 ### Events
 
-- show-tooltip
-- hide-tooltip
+- tooltip-shown
+- tooltip-hidden
 
 ## slots
 

--- a/storybook/stories/cv-tooltip-story.js
+++ b/storybook/stories/cv-tooltip-story.js
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/vue';
 import { text, select, boolean } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 
 import SvTemplateView from '../_storybook/views/sv-template-view/sv-template-view';
 // import consts from '../_storybook/utils/consts';
@@ -75,9 +76,18 @@ let preKnobs = {
     config: ['visible', false], // consts.CONFIG], // fails when used with number in storybook 4.1.4
     prop: 'visible',
   },
+  events: {
+    group: 'attr',
+    value: `v-on:show-tooltip="actionTooltipShow"
+  v-on:hide-tooltip="actionTooltipHide"`,
+  },
 };
 
-const variants = [{ name: 'default' }, { name: 'minimal', includes: ['content', 'definition', 'term', 'tip'] }];
+const variants = [
+  { name: 'default', excludes: ['events'] },
+  { name: 'minimal', includes: ['content', 'definition', 'term', 'tip'] },
+  { name: 'events', includes: ['content', 'visible', 'events'] },
+];
 
 let storySet = knobsHelper.getStorySet(variants, preKnobs);
 
@@ -114,6 +124,8 @@ for (const story of storySet) {
         template: templateViewString,
         props: settings.props,
         methods: {
+          actionTooltipShow: action('CV Tooltip - show'),
+          actionTooltipHide: action('CV Tooltip - hide'),
           doStart() {
             this.$refs.templateView.$slots.component[0].componentInstance.show();
           },

--- a/storybook/stories/cv-tooltip-story.js
+++ b/storybook/stories/cv-tooltip-story.js
@@ -78,8 +78,8 @@ let preKnobs = {
   },
   events: {
     group: 'attr',
-    value: `v-on:show-tooltip="actionTooltipShow"
-  v-on:hide-tooltip="actionTooltipHide"`,
+    value: `@tooltip-shown="actionShown"
+  @tooltip-hidden="actionHidden"`,
   },
 };
 
@@ -124,8 +124,8 @@ for (const story of storySet) {
         template: templateViewString,
         props: settings.props,
         methods: {
-          actionTooltipShow: action('CV Tooltip - show'),
-          actionTooltipHide: action('CV Tooltip - hide'),
+          actionShown: action('CV Tooltip - shown'),
+          actionHidden: action('CV Tooltip - hidden'),
           doStart() {
             this.$refs.templateView.$slots.component[0].componentInstance.show();
           },


### PR DESCRIPTION

We had a use case in our app to animate a part of the page when the tooltip is shown and when the tooltip is hidden. There is not an easy way to do this without events emitted from the tooltip so I forked the component to use it in our app.

![ToolTipEvent](https://user-images.githubusercontent.com/7536103/102389553-441d7d80-3fa1-11eb-8f1d-5462f265a3de.gif)


#### Changelog

M       packages/core/src/components/cv-tooltip/cv-interactive-tooltip.vue
M       packages/core/src/components/cv-tooltip/cv-tooltip-notes.md

