### PR TITLE
fix: cv-date-picker range plugin  use

### DIFF
--- a/packages/core/src/components/cv-date-picker/cv-date-picker.vue
+++ b/packages/core/src/components/cv-date-picker/cv-date-picker.vue
@@ -234,7 +234,7 @@ export default {
 
       _options.plugins = [
         this.isRange
-          ? new carbonFlatpickrRangePlugin({
+          ? carbonFlatpickrRangePlugin({
               input: this.$refs.todate,
             })
           : () => {},


### PR DESCRIPTION
When swapping out the range plugin for the carbon version left a spurious 'new' which did not show one storybook. Can be seen here with v2.36.0 https://codesandbox.io/s/carbonvue-cvdatepicker-i1lyy?file=/src/App.vue

#### Changelog

m. packages/core/src/components/cv-date-picker/cv-date-picker.vue 