### PR TITLE
chore: tidy button story slotArgs

### DIFF
--- a/packages/v3/src/components/CvButton/CvButton.stories.js
+++ b/packages/v3/src/components/CvButton/CvButton.stories.js
@@ -32,6 +32,7 @@ export default {
   component: CvButton,
   argTypes: {
     ...storybookControlsFromProps(commonCvButtonProps),
+    default: { control: { type: 'text' } },
     icon: { control: { type: 'select', options: Object.keys(icons) } },
     kind: {
       control: { type: 'select', options: buttonKinds },
@@ -49,7 +50,7 @@ export default {
 
 const template = `<cv-button @click="onClick" v-bind="args">{{slotArgs.default}}</cv-button>`;
 const Template = (argsIn, { argTypes }) => {
-  let { args, slotArgs } = splitSlotArgs(argsIn);
+  let { args, slotArgs } = splitSlotArgs(argsIn, ['default']);
   args = { ...args, icon: icons[args.icon] };
 
   return {
@@ -65,7 +66,7 @@ const Template = (argsIn, { argTypes }) => {
 export const Primary = Template.bind({});
 Primary.args = {
   kind: 'primary',
-  'slotArgs.default': 'Primary',
+  default: 'Primary',
 };
 Primary.parameters = storyParametersObject(
   Primary.parameters,
@@ -76,7 +77,7 @@ Primary.parameters = storyParametersObject(
 export const Secondary = Template.bind({});
 Secondary.args = {
   kind: 'secondary',
-  'slotArgs.default': 'Secondary',
+  default: 'Secondary',
 };
 Secondary.parameters = storyParametersObject(
   Secondary.parameters,

--- a/packages/v3/src/global/storybook-utils/__tests__/split-slot-args.spec.js
+++ b/packages/v3/src/global/storybook-utils/__tests__/split-slot-args.spec.js
@@ -10,12 +10,15 @@ describe('splitSlotArgs', () => {
 
   it('shold split args and slot args', () => {
     expect(
-      splitSlotArgs({
-        abc: 'abc',
-        def: 'def',
-        'slotArgs.ghi': 'ghi',
-        'slotArgs.jkl': 'jkl',
-      })
+      splitSlotArgs(
+        {
+          abc: 'abc',
+          def: 'def',
+          ghi: 'ghi',
+          jkl: 'jkl',
+        },
+        ['ghi', 'jkl']
+      )
     ).toEqual({
       args: {
         abc: 'abc',

--- a/packages/v3/src/global/storybook-utils/split-slot-args.js
+++ b/packages/v3/src/global/storybook-utils/split-slot-args.js
@@ -1,10 +1,10 @@
-export const splitSlotArgs = (argsIn = {}) => {
+export const splitSlotArgs = (argsIn = {}, slotArgKeys) => {
   const keys = Object.keys(argsIn);
   const slotArgs = {};
   const args = {};
   keys.forEach(key => {
-    if (key.startsWith('slotArgs.')) {
-      slotArgs[key.substr(9)] = argsIn[key];
+    if (slotArgKeys.includes(key)) {
+      slotArgs[key] = argsIn[key];
     } else {
       args[key] = argsIn[key];
     }


### PR DESCRIPTION
Undoes the use of slotArgs prefix in favour of extracting specific args as slots.


#### Changelog

Checked storybook still worked and split-slot-args tests still passed.
