### PR TITLE
fix: cv-data-table headers have no padding when sortable = false

### DIFF
--- a/packages/core/src/components/cv-data-table/cv-data-table-heading.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table-heading.vue
@@ -70,6 +70,10 @@ export default {
   computed: {
     internalOrder: {
       get() {
+        if (!this.sortable) {
+          return undefined;
+        }
+
         if (this.dataOrder !== 'ascending' && this.dataOrder !== 'descending') {
           return 'none';
         } else {


### PR DESCRIPTION
Contributes to #1161

## What did you do?
I fixed `CvDataTable` headers having no padding when they are not sortable, but the table has the sortable class (e.g. when only some headers are sortable).

## Why did you do it?
Fix a bug

## How have you tested it?
I reproduced the error as described in the issue using the Storybook

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
