### PR TITLE
Bugfix: Add missing Classes to CvTextInput (Password Visibility Toggle)

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-text-input.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-text-input.test.js.snap
@@ -73,7 +73,7 @@ exports[`CvTextInput should render correctly when light theme is used 1`] = `
 exports[`CvTextInput should render correctly when type is password and is not visible 1`] = `
 <div class="cv-text-input bx--form-item"><label for="1" class="bx--label">test label</label>
   <div class="bx--text-input__field-wrapper">
-    <!----> <input id="1" data-toggle-password-visibility="true" type="password" class="bx--text-input"> <button type="button" class="bx--text-input--password__visibility__toggle bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"><span class="bx--assistive-text">Show password</span>
+    <!----> <input id="1" data-toggle-password-visibility="true" type="password" class="bx--text-input bx--password-input"> <button type="button" class="bx--btn bx--text-input--password__visibility__toggle bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"><span class="bx--assistive-text">Show password</span>
       <view16-stub class="bx--icon-visibility-off"></view16-stub>
     </button></div>
   <!---->
@@ -84,7 +84,7 @@ exports[`CvTextInput should render correctly when type is password and is not vi
 exports[`CvTextInput should render correctly when type is password and is visible 1`] = `
 <div class="cv-text-input bx--form-item"><label for="1" class="bx--label">test label</label>
   <div class="bx--text-input__field-wrapper">
-    <!----> <input id="1" data-toggle-password-visibility="true" type="password" class="bx--text-input"> <button type="button" class="bx--text-input--password__visibility__toggle bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"><span class="bx--assistive-text">Show password</span>
+    <!----> <input id="1" data-toggle-password-visibility="true" type="password" class="bx--text-input bx--password-input"> <button type="button" class="bx--btn bx--text-input--password__visibility__toggle bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"><span class="bx--assistive-text">Show password</span>
       <view16-stub class="bx--icon-visibility-off"></view16-stub>
     </button></div>
   <!---->

--- a/packages/core/src/components/cv-text-input/cv-text-input.vue
+++ b/packages/core/src/components/cv-text-input/cv-text-input.vue
@@ -19,6 +19,7 @@
           {
             [`${carbonPrefix}--text-input--light`]: isLight,
             [`${carbonPrefix}--text-input--invalid`]: isInvalid,
+            [`${carbonPrefix}--password-input`]: isPassword,
           },
         ]"
         v-bind="$attrs"
@@ -31,6 +32,7 @@
       <button
         v-if="isPassword"
         :class="[
+          `${carbonPrefix}--btn`,
           `${carbonPrefix}--text-input--password__visibility__toggle`,
           `${carbonPrefix}--tooltip__trigger`,
           `${carbonPrefix}--tooltip--a11y`,


### PR DESCRIPTION
Contributes to `CvTextInput`

## What did you do?

I conditionally added classes that are apparently needed for the password visibility toggle

## Why did you do it?

When working with VueCarbonComponents I noticed that the password visibility toggle was missing some styles. When comparing the Vue Component with its corresponding React Component I noticed that those classes were missing although the styles were already included.

<img width="553" alt="Bildschirmfoto 2021-05-03 um 16 36 23" src="https://user-images.githubusercontent.com/55788142/116892568-3dca2e00-ac30-11eb-9cb6-b973b90af835.png">

## How have you tested it?

I ran the command included in package.json (`yarn test`). I don't know if this is sufficient, but I couldn't find any information on the correct procedure. Updated the Snapshot as well.

## Were docs updated if needed?

- [X] No, no update needed
