### PR TITLE
Add missing classes for invalid password input

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-text-input.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-text-input.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CvTextInput should render correctly 1`] = `
-<div class="cv-text-input bx--form-item"><label for="1" class="bx--label">test label</label>
+<div class="cv-text-input bx--form-item bx--text-input-wrapper"><label for="1" class="bx--label">test label</label>
   <div class="bx--text-input__field-wrapper">
     <!----> <input id="1" type="text" class="bx--text-input">
     <!---->
@@ -12,7 +12,7 @@ exports[`CvTextInput should render correctly 1`] = `
 `;
 
 exports[`CvTextInput should render correctly when helper text is provided 1`] = `
-<div class="cv-text-input bx--form-item"><label for="1" class="bx--label">test label</label>
+<div class="cv-text-input bx--form-item bx--text-input-wrapper"><label for="1" class="bx--label">test label</label>
   <div class="bx--text-input__field-wrapper">
     <!----> <input id="1" type="text" class="bx--text-input">
     <!---->
@@ -23,7 +23,7 @@ exports[`CvTextInput should render correctly when helper text is provided 1`] = 
 `;
 
 exports[`CvTextInput should render correctly when helper text slot is provided 1`] = `
-<div class="cv-text-input bx--form-item"><label for="1" class="bx--label">test label</label>
+<div class="cv-text-input bx--form-item bx--text-input-wrapper"><label for="1" class="bx--label">test label</label>
   <div class="bx--text-input__field-wrapper">
     <!----> <input id="1" type="text" class="bx--text-input">
     <!---->
@@ -36,7 +36,7 @@ exports[`CvTextInput should render correctly when helper text slot is provided 1
 `;
 
 exports[`CvTextInput should render correctly when invalid message is provided 1`] = `
-<div class="cv-text-input bx--form-item"><label for="1" class="bx--label">test label</label>
+<div class="cv-text-input bx--form-item bx--text-input-wrapper"><label for="1" class="bx--label">test label</label>
   <div class="bx--text-input__field-wrapper" data-invalid="true">
     <warningfilled16-stub class="bx--text-input__invalid-icon"></warningfilled16-stub> <input id="1" type="text" class="bx--text-input bx--text-input--invalid">
     <!---->
@@ -47,7 +47,7 @@ exports[`CvTextInput should render correctly when invalid message is provided 1`
 `;
 
 exports[`CvTextInput should render correctly when invalid message slot is provided 1`] = `
-<div class="cv-text-input bx--form-item"><label for="1" class="bx--label">test label</label>
+<div class="cv-text-input bx--form-item bx--text-input-wrapper"><label for="1" class="bx--label">test label</label>
   <div class="bx--text-input__field-wrapper" data-invalid="true">
     <warningfilled16-stub class="bx--text-input__invalid-icon"></warningfilled16-stub> <input id="1" type="text" class="bx--text-input bx--text-input--invalid">
     <!---->
@@ -60,7 +60,7 @@ exports[`CvTextInput should render correctly when invalid message slot is provid
 `;
 
 exports[`CvTextInput should render correctly when light theme is used 1`] = `
-<div class="cv-text-input bx--form-item"><label for="1" class="bx--label">test label</label>
+<div class="cv-text-input bx--form-item bx--text-input-wrapper"><label for="1" class="bx--label">test label</label>
   <div class="bx--text-input__field-wrapper">
     <!----> <input id="1" type="text" class="bx--text-input bx--text-input--light">
     <!---->
@@ -71,7 +71,7 @@ exports[`CvTextInput should render correctly when light theme is used 1`] = `
 `;
 
 exports[`CvTextInput should render correctly when type is password and is not visible 1`] = `
-<div class="cv-text-input bx--form-item"><label for="1" class="bx--label">test label</label>
+<div class="cv-text-input bx--form-item bx--text-input-wrapper bx--password-input-wrapper"><label for="1" class="bx--label">test label</label>
   <div class="bx--text-input__field-wrapper">
     <!----> <input id="1" data-toggle-password-visibility="true" type="password" class="bx--text-input"> <button type="button" class="bx--text-input--password__visibility__toggle bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"><span class="bx--assistive-text">Show password</span>
       <view16-stub class="bx--icon-visibility-off"></view16-stub>
@@ -82,7 +82,7 @@ exports[`CvTextInput should render correctly when type is password and is not vi
 `;
 
 exports[`CvTextInput should render correctly when type is password and is visible 1`] = `
-<div class="cv-text-input bx--form-item"><label for="1" class="bx--label">test label</label>
+<div class="cv-text-input bx--form-item bx--text-input-wrapper bx--password-input-wrapper"><label for="1" class="bx--label">test label</label>
   <div class="bx--text-input__field-wrapper">
     <!----> <input id="1" data-toggle-password-visibility="true" type="password" class="bx--text-input"> <button type="button" class="bx--text-input--password__visibility__toggle bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"><span class="bx--assistive-text">Show password</span>
       <view16-stub class="bx--icon-visibility-off"></view16-stub>

--- a/packages/core/src/components/cv-text-input/cv-text-input.vue
+++ b/packages/core/src/components/cv-text-input/cv-text-input.vue
@@ -1,5 +1,12 @@
 <template>
-  <div :class="`cv-text-input ${carbonPrefix}--form-item`">
+  <div
+    :class="[
+      `cv-text-input`,
+      `${carbonPrefix}--form-item`,
+      `${carbonPrefix}--text-input-wrapper`,
+      { [`${carbonPrefix}--password-input-wrapper`]: isPassword },
+    ]"
+  >
     <label
       :for="uid"
       :class="[


### PR DESCRIPTION
Contributes to `CvTextInput`

## What did you do?

There's a bug when a `CvTextInput` of type `password` has a invalid state. The "show password" button and the invalid indicator overlap eachother:
![as is](https://user-images.githubusercontent.com/15495980/117166752-0b8a0f00-ad9d-11eb-9767-d182a5263667.png)
(I took this screenshot from [https://vue.carbondesignsystem.com/?path=/story/components-cvtextinput--default](https://vue.carbondesignsystem.com/?path=/story/components-cvtextinput--default) today.

I added the missing classes so the buttons don't overlap: 
![Without floriankapaun's fix](https://user-images.githubusercontent.com/15495980/117167353-90752880-ad9d-11eb-81ab-b7085a7d85c8.png)

As you can see, there's still a spacing problem on the last button. This issue will be solved with the changes introduced by PR #1179. Here's a screenshot with both changes incorporated:
![With floriankapaun's fix](https://user-images.githubusercontent.com/15495980/117167587-c3b7b780-ad9d-11eb-800d-49f9925b765c.png)

## Why did you do it?

I found this bug while working on a project. I managed to fix it on my own, so I took the opportunity to contribute to this project.

## How have you tested it?


After I updated the snapshot files for `CvTextInput` to include the classes I added, I've ran `yarn test`  and got 8 failed tests. All of which are related to `CvCheckbox` and `CvToggle`, but they are also failing on the project's main branch. So I don't think my changes are breaking anything.

## Were docs updated if needed?

- [X] N/A
- [ ] No
- [ ] Yes


This is my first contribution to an open source project. Please let me know if I need to change anything or do any additional steps.