### PR TITLE
Fix `primary` button click event

### DIFF
--- a/packages/core/src/components/cv-modal/cv-modal.vue
+++ b/packages/core/src/components/cv-modal/cv-modal.vue
@@ -279,7 +279,7 @@ export default {
       this.onFooterButtonClick('primary-click', ev);
     },
     onSecondaryClick(ev) {
-      this.onFooterButtonClick('primary-click', ev);
+      this.onFooterButtonClick('secondary-click', ev);
     },
     onOtherBtnClick(ev) {
       this.onFooterButtonClick('other-btn-click', ev);

--- a/packages/core/src/components/cv-modal/cv-modal.vue
+++ b/packages/core/src/components/cv-modal/cv-modal.vue
@@ -71,7 +71,7 @@
           :disabled="primaryButtonDisabled"
           type="button"
           :kind="primaryKind"
-          @click="() => onPrimaryClick"
+          @click="onPrimaryClick"
           v-if="hasPrimary"
           ref="primary"
         >


### PR DESCRIPTION
Contributes to #1201 

## What did you do?

Remove the outer arrow function to call the click handler upon a button click.

## Why did you do it?

To allow the component to properly emit the primary button click.

## How have you tested it?

N/A

## Were docs updated if needed?

- [X] N/A
- [ ] No
- [ ] Yes
