### PR TITLE
feat(data-table): add staticWidth prop

### DIFF
--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -94,6 +94,7 @@
             [`${carbonPrefix}--data-table--no-border `]: borderless,
             [`${carbonPrefix}--skeleton `]: skeleton,
             [`${carbonPrefix}--data-table--sort `]: isSortable,
+            [`${carbonPrefix}--data-table--static `]: staticWidth,
           },
         ]"
       >
@@ -236,6 +237,7 @@ export default {
     expandingSearch: { type: Boolean, default: true },
     skeleton: Boolean,
     hasExpandAll: Boolean,
+    staticWidth: Boolean,
   },
   model: {
     prop: 'rows-selected',


### PR DESCRIPTION
## What did you do?

I added a `staticWidth` prop to toggle the `bx--data-table--static` selector on the `table` element.

## Why did you do it?

This enables the user to render the table with a width of  "auto" instead of "100%". This feature is supported in the flagship Carbon React implementation.

## How have you tested it?

## Were docs updated if needed?

- [ ] N/A
- [ ] No
- [ ] Yes
