### PR TITLE
fix(file-uploader): mark files with invalid types/formats

### DIFF
--- a/packages/core/__tests__/cv-file-uploader.test.js
+++ b/packages/core/__tests__/cv-file-uploader.test.js
@@ -1,0 +1,87 @@
+import { testComponent, awaitNextTick } from './_helpers';
+import { CvFileUploader } from '@/components/cv-file-uploader';
+
+const { shallowMount: shallow, trigger, setProps } = awaitNextTick;
+
+describe('CvFileUploader', () => {
+  // ***************
+  // FUNCTIONAL TESTS
+  // ***************
+
+  it('should accept all file formats if no accept is specified', async () => {
+    const wrapper = await shallow(CvFileUploader);
+
+    const dropEvent = {
+      dataTransfer: {
+        types: ['Files'],
+        files: [{ name: 'foo.jpg', type: 'image/jpg' }],
+      },
+      type: 'drop',
+      preventDefault: jest.fn(),
+    };
+    wrapper.find('[data-file-drop-container]').trigger('drop', dropEvent);
+    expect(wrapper.emitted().change[0][0]).toEqual([
+      {
+        file: {
+          name: 'foo.jpg',
+          type: 'image/jpg',
+        },
+        invalidMessage: '',
+        invalidMessageTitle: '',
+        state: '',
+      },
+    ]);
+  });
+
+  it('should emit when a file is dragged', async () => {
+    const propsData = { accept: '.jpg,.png' };
+    const wrapper = await shallow(CvFileUploader, { propsData });
+
+    const dropEvent = {
+      dataTransfer: {
+        types: ['Files'],
+        files: [{ name: 'foo.jpg', type: 'image/jpg' }],
+      },
+      type: 'drop',
+      preventDefault: jest.fn(),
+    };
+    wrapper.find('[data-file-drop-container]').trigger('drop', dropEvent);
+    expect(wrapper.emitted().change[0][0]).toEqual([
+      {
+        file: {
+          name: 'foo.jpg',
+          type: 'image/jpg',
+        },
+        invalidMessage: '',
+        invalidMessageTitle: '',
+        state: '',
+      },
+    ]);
+  });
+
+  it('should not accept wrong file formats', async () => {
+    const propsData = { accept: '.jpg,.png' };
+    const wrapper = await shallow(CvFileUploader, { propsData });
+
+    const dropEvent = {
+      dataTransfer: {
+        types: ['Files'],
+        files: [{ name: 'foo.mp4', type: 'video/mp4' }],
+      },
+      type: 'drop',
+      preventDefault: jest.fn(),
+    };
+    wrapper.find('[data-file-drop-container]').trigger('drop', dropEvent);
+    expect(wrapper.emitted().change[0][0]).toEqual([
+      {
+        file: {
+          name: 'foo.mp4',
+          type: 'video/mp4',
+        },
+        invalidMessage: '"foo.mp4" does not have a valid file type.',
+        invalidMessageTitle: 'Invalid file type',
+        state: '',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Fix #1223 

## What did you do?

- made the accept attr a prop
- checked if dropped files have the same mime type or extensions as the informed in the accept prop
- added special case for jpeg files

## Why did you do it?
because there was a comment there saying it should be implemented and an issue for it.
I inspired my code in the [carbon-react implementation](https://github.com/carbon-design-system/carbon/blob/0dfde60e30a3e1238d49b66950362fd39a2c7ca7/packages/react/src/components/FileUploader/FileUploaderDropContainer.js#L65)

## How have you tested it?
I created unit tests and tested with the local storybook

## Were docs updated if needed?

- [ ] N/A
- [x] No
- [ ] Yes
