### PR TITLE
feat: adding hideCloseButton prop to cv-inline-notification

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-inline-notification.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-inline-notification.test.js.snap
@@ -1,5 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CvInlineNotification should not render close button when hideCloseButton is true 1`] = `
+<div data-notification="" role="alert" class="cv-inline-notification bx--inline-notification bx--inline-notification--error">
+  <div class="bx--inline-notification__details">
+    <anonymous-stub class="bx--inline-notification__icon"></anonymous-stub>
+    <div class="bx--inline-notification__text-wrapper">
+      <p class="bx--inline-notification__title"></p>
+      <p class="bx--inline-notification__subtitle"></p>
+    </div>
+  </div> <button type="button" class="bx--inline-notification__action-button bx--btn bx--btn--sm bx--btn--ghost">
+    test action label
+  </button>
+  <!---->
+</div>
+`;
+
+exports[`CvInlineNotification should not render close button when hideCloseButton is true 2`] = `
+<div data-notification="" aria-live="polite" class="cv-inline-notification bx--inline-notification bx--inline-notification--info">
+  <div class="bx--inline-notification__details">
+    <anonymous-stub class="bx--inline-notification__icon"></anonymous-stub>
+    <div class="bx--inline-notification__text-wrapper">
+      <p class="bx--inline-notification__title"></p>
+      <p class="bx--inline-notification__subtitle"></p>
+    </div>
+  </div> <button type="button" class="bx--inline-notification__action-button bx--btn bx--btn--sm bx--btn--ghost">
+    test action label
+  </button>
+  <!---->
+</div>
+`;
+
+exports[`CvInlineNotification should not render close button when hideCloseButton is true 3`] = `
+<div data-notification="" role="alert" class="cv-inline-notification bx--inline-notification bx--inline-notification--warning">
+  <div class="bx--inline-notification__details">
+    <anonymous-stub class="bx--inline-notification__icon"></anonymous-stub>
+    <div class="bx--inline-notification__text-wrapper">
+      <p class="bx--inline-notification__title"></p>
+      <p class="bx--inline-notification__subtitle"></p>
+    </div>
+  </div> <button type="button" class="bx--inline-notification__action-button bx--btn bx--btn--sm bx--btn--ghost">
+    test action label
+  </button>
+  <!---->
+</div>
+`;
+
+exports[`CvInlineNotification should not render close button when hideCloseButton is true 4`] = `
+<div data-notification="" aria-live="polite" class="cv-inline-notification bx--inline-notification bx--inline-notification--success">
+  <div class="bx--inline-notification__details">
+    <anonymous-stub class="bx--inline-notification__icon"></anonymous-stub>
+    <div class="bx--inline-notification__text-wrapper">
+      <p class="bx--inline-notification__title"></p>
+      <p class="bx--inline-notification__subtitle"></p>
+    </div>
+  </div> <button type="button" class="bx--inline-notification__action-button bx--btn bx--btn--sm bx--btn--ghost">
+    test action label
+  </button>
+  <!---->
+</div>
+`;
+
 exports[`CvInlineNotification should render correctly 1`] = `
 <div data-notification="" role="alert" class="cv-inline-notification bx--inline-notification bx--inline-notification--error">
   <div class="bx--inline-notification__details">

--- a/packages/core/__tests__/cv-inline-notification.test.js
+++ b/packages/core/__tests__/cv-inline-notification.test.js
@@ -13,7 +13,7 @@ describe('CvInlineNotification', () => {
   // ***************
   // PROP CHECKS
   // ***************
-  testComponent.propsAreType(CvInlineNotification, ['lowContrast'], Boolean);
+  testComponent.propsAreType(CvInlineNotification, ['lowContrast', 'hideCloseButton'], Boolean);
   testComponent.propsAreType(CvInlineNotification, ['actionLabel', 'closeAriaLabel', 'kind'], String);
   testComponent.propsHaveDefault(CvInlineNotification, ['closeAriaLabel', 'kind', 'actionLabel']);
 
@@ -49,6 +49,15 @@ describe('CvInlineNotification', () => {
 
   it('should render correctly when low contrast is used', async () => {
     const propsData = { lowContrast: true, kind: '', actionLabel: 'test action label' };
+    for (const kind of kinds) {
+      propsData.kind = kind;
+      const wrapper = await shallow(CvInlineNotification, { propsData });
+      expect(wrapper.html()).toMatchSnapshot();
+    }
+  });
+
+  it('should not render close button when hideCloseButton is true', async () => {
+    const propsData = { lowContrast: false, kind: '', actionLabel: 'test action label', hideCloseButton: true };
     for (const kind of kinds) {
       propsData.kind = kind;
       const wrapper = await shallow(CvInlineNotification, { propsData });

--- a/packages/core/src/components/cv-inline-notification/cv-inline-notification.vue
+++ b/packages/core/src/components/cv-inline-notification/cv-inline-notification.vue
@@ -34,6 +34,7 @@
       {{ actionLabel }}
     </button>
     <button
+      v-if="!hideCloseButton"
       type="button"
       :aria-label="closeAriaLabel"
       data-notification-btn
@@ -66,6 +67,7 @@ export default {
       validator: val => ['error', 'info', 'warning', 'success'].includes(val),
     },
     lowContrast: Boolean,
+    hideCloseButton: Boolean,
   },
   computed: {
     icon() {

--- a/storybook/stories/cv-inline-notification-story.js
+++ b/storybook/stories/cv-inline-notification-story.js
@@ -51,6 +51,12 @@ const preKnobs = {
     config: ['Low contrast', false],
     prop: 'low-contrast',
   },
+  hideCloseButton: {
+    group: 'attr',
+    type: boolean,
+    config: ['Hide close button', false],
+    prop: 'hide-close-button',
+  },
 };
 
 const variants = [


### PR DESCRIPTION
Closes #1210

## What did you do?
- Added **hideCloseButton** prop to the **Inline Notification** component
- Added snapshot tests for the case of this prop being true
- Updated storybook page

## Why did you do it?
- This prop was missing from the component
- There was an open issue about it 

## How have you tested it?
- Checked if the storybook was updated and toggled the property on and off to check if the results were as expected
- Wrote a snapshot test passing the new prop as true

## Were docs updated if needed?

- [ ] N/A
- [ ] No
- [X] Yes
