### PR TITLE
feat: add hide close to toast

### DIFF
--- a/packages/core/__tests__/__snapshots__/cv-toast-notification.test.js.snap
+++ b/packages/core/__tests__/__snapshots__/cv-toast-notification.test.js.snap
@@ -1,5 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CvToastNotification should not render close button when hideCloseButton is true 1`] = `
+<div data-notification="" role="alert" class="cv-notifiation bx--toast-notification bx--toast-notification--error" actionlabel="test action label">
+  <anonymous-stub class="bx--toast-notification__icon"></anonymous-stub>
+  <div class="bx--toast-notification__details">
+    <h3 class="bx--toast-notification__title"></h3>
+    <p class="bx--toast-notification__subtitle"></p>
+    <p class="bx--toast-notification__caption"></p>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`CvToastNotification should not render close button when hideCloseButton is true 2`] = `
+<div data-notification="" aria-live="polite" class="cv-notifiation bx--toast-notification bx--toast-notification--info" actionlabel="test action label">
+  <anonymous-stub class="bx--toast-notification__icon"></anonymous-stub>
+  <div class="bx--toast-notification__details">
+    <h3 class="bx--toast-notification__title"></h3>
+    <p class="bx--toast-notification__subtitle"></p>
+    <p class="bx--toast-notification__caption"></p>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`CvToastNotification should not render close button when hideCloseButton is true 3`] = `
+<div data-notification="" role="alert" class="cv-notifiation bx--toast-notification bx--toast-notification--warning" actionlabel="test action label">
+  <anonymous-stub class="bx--toast-notification__icon"></anonymous-stub>
+  <div class="bx--toast-notification__details">
+    <h3 class="bx--toast-notification__title"></h3>
+    <p class="bx--toast-notification__subtitle"></p>
+    <p class="bx--toast-notification__caption"></p>
+  </div>
+  <!---->
+</div>
+`;
+
+exports[`CvToastNotification should not render close button when hideCloseButton is true 4`] = `
+<div data-notification="" aria-live="polite" class="cv-notifiation bx--toast-notification bx--toast-notification--success" actionlabel="test action label">
+  <anonymous-stub class="bx--toast-notification__icon"></anonymous-stub>
+  <div class="bx--toast-notification__details">
+    <h3 class="bx--toast-notification__title"></h3>
+    <p class="bx--toast-notification__subtitle"></p>
+    <p class="bx--toast-notification__caption"></p>
+  </div>
+  <!---->
+</div>
+`;
+
 exports[`CvToastNotification should render correctly 1`] = `
 <div data-notification="" role="alert" class="cv-notifiation bx--toast-notification bx--toast-notification--error">
   <anonymous-stub class="bx--toast-notification__icon"></anonymous-stub>

--- a/packages/core/__tests__/cv-toast-notification.test.js
+++ b/packages/core/__tests__/cv-toast-notification.test.js
@@ -13,7 +13,7 @@ describe('CvToastNotification', () => {
   // ***************
   // PROP CHECKS
   // ***************
-  testComponent.propsAreType(CvToastNotification, ['lowContrast'], Boolean);
+  testComponent.propsAreType(CvToastNotification, ['lowContrast', 'hideCloseButton'], Boolean);
   testComponent.propsAreType(CvToastNotification, ['caption', 'closeAriaLabel', 'kind'], String);
   testComponent.propsHaveDefault(CvToastNotification, ['closeAriaLabel', 'kind']);
 
@@ -50,6 +50,15 @@ describe('CvToastNotification', () => {
 
   it('should render correctly when low contrast is used', async () => {
     const propsData = { caption: 'TEST', lowContrast: true, kind: '' };
+    for (const kind of kinds) {
+      propsData.kind = kind;
+      const wrapper = await shallow(CvToastNotification, { propsData });
+      expect(wrapper.html()).toMatchSnapshot();
+    }
+  });
+
+  it('should not render close button when hideCloseButton is true', async () => {
+    const propsData = { lowContrast: false, kind: '', actionLabel: 'test action label', hideCloseButton: true };
     for (const kind of kinds) {
       propsData.kind = kind;
       const wrapper = await shallow(CvToastNotification, { propsData });

--- a/packages/core/src/components/cv-inline-notification/cv-inline-notification-notes.md
+++ b/packages/core/src/components/cv-inline-notification/cv-inline-notification-notes.md
@@ -23,6 +23,7 @@ http://www.carbondesignsystem.com/components/notification/code
 - actionLabel: optional action button label, without it no action button is displayed.
 - closeAriaLabel: { type: String, default: 'Clear filter' },
 - lowContrast: Boolean to use a lower contrast version of the notification
+- hideCloseButton: Boolean removes close button
 
 ## Events
 

--- a/packages/core/src/components/cv-toast-notification/cv-toast-notification-notes.md
+++ b/packages/core/src/components/cv-toast-notification/cv-toast-notification-notes.md
@@ -24,6 +24,7 @@ http://www.carbondesignsystem.com/components/notification/code
 - caption: 'caption' inputs as an `v-html` so any markup is rendered.
 - closeAriaLabel: { type: String, default: 'Clear filter' },
 - lowContrast: Boolean to use a lower contrast version of the notification
+- hideCloseButton: Boolean removes close button
 
 ## Events
 

--- a/packages/core/src/components/cv-toast-notification/cv-toast-notification.vue
+++ b/packages/core/src/components/cv-toast-notification/cv-toast-notification.vue
@@ -17,6 +17,7 @@
       <p :class="`${carbonPrefix}--toast-notification__caption`" v-html="caption"></p>
     </div>
     <button
+      v-if="!hideCloseButton"
       :aria-label="closeAriaLabel"
       type="button"
       data-notification-btn
@@ -43,6 +44,7 @@ export default {
   props: {
     caption: String,
     closeAriaLabel: { type: String, default: 'Dismiss notification' },
+    hideCloseButton: Boolean,
     kind: {
       type: String,
       default: 'info',

--- a/storybook/stories/cv-toast-notification-story.js
+++ b/storybook/stories/cv-toast-notification-story.js
@@ -48,6 +48,12 @@ const preKnobs = {
     config: ['Low contrast', false],
     prop: 'low-contrast',
   },
+  hideCloseButton: {
+    group: 'attr',
+    type: boolean,
+    config: ['Hide close button', false],
+    prop: 'hide-close-button',
+  },
 };
 
 const variants = [


### PR DESCRIPTION
## What did you do?

Add hideCloseButton to toast notification

## Why did you do it?

Missing feature 

## How have you tested it?

Test and storybook

## Were docs updated if needed?

- [ ] N/A
- [ ] No
- [x] Yes
