### PR TITLE
fix package.json scripts on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "1.1.1",
   "description": "A collection of components for the Carbon Design System built using Vue.js",
   "scripts": {
-    "build": "yarn build:packages; yarn build:storybook",
+    "build": "yarn build:packages && yarn build:storybook",
     "lint": "vue-cli-service lint 'packages/core/src' 'packages/core/__tests__' 'storybook/stories'",
     "build:packages": "lerna exec yarn build --no-prefix --concurrency 1",
-    "build:storybook": "yarn info @carbon/vue --json > package-info.jsonl; vue-cli-service storybook:build -c storybook/.storybook -o storybook/storybook-static",
+    "build:storybook": "yarn info @carbon/vue --json > package-info.jsonl && vue-cli-service storybook:build -c storybook/.storybook -o storybook/storybook-static",
     "ci-check": "yarn format:diff && yarn test --maxWorkers=5 && yarn build:packages && yarn build:storybook --quiet",
-    "clean": "lerna run clean; rimraf storybook/storybook-static package-info.jsonl node_modules/.cache",
+    "clean": "lerna run clean && rimraf storybook/storybook-static package-info.jsonl node_modules/.cache",
     "format": "prettier --write '**/*.{scss,css,js,md,vue}' '!**/{build,es,lib,storybook,ts,umd,.coverage}/**'",
     "format:diff": "prettier --list-different '**/*.{scss,css,js,md,vue}' '!**/{dist,storybook-static,.coverage}/**'",
     "format:staged": "prettier --write '**/*.{scss,css,js,md,vue}' '!**/{dist,storybook-static,.coverage}/**'",
@@ -17,8 +17,8 @@
     "lint:style": "vue-cli-service lint:style",
     "prepare": "lerna bootstrap",
     "prepublishOnly": "yarn build",
-    "reinstall": "echo Clearing yarn cache; yarn cache clean; echo Removing yarn offline mirror; rimraf .yarn-offline-mirror; echo Removing package folders; lerna clean --yes; rimraf node_modules; yarn install",
-    "start": "yarn info @carbon/vue --json > package-info.jsonl; vue-cli-service storybook:serve -p 9001 -c storybook/.storybook",
+    "reinstall": "echo Clearing yarn cache && yarn cache clean && echo Removing yarn offline mirror && rimraf .yarn-offline-mirror && echo Removing package folders && lerna clean --yes && rimraf node_modules && yarn install",
+    "start": "yarn info @carbon/vue --json > package-info.jsonl && vue-cli-service storybook:serve -p 9001 -c storybook/.storybook",
     "test": "vue-cli-service test:unit"
   },
   "dependencies": {


### PR DESCRIPTION
## What did you do?
This commit edits the scripts defined in `package.json`, replacing `;` by `&&`.

## Why did you do it?
The `;` separator does not work on Windows. As a Windows user, I had to manually run the scripts with multiple commands.

## How have you tested it?
I didn't change anything in the actual project code.

## Were docs updated if needed?
N/A
