### PR TITLE
fix: change the aria role of the list element

### DIFF
--- a/packages/core/src/components/cv-tabs/cv-tabs.vue
+++ b/packages/core/src/components/cv-tabs/cv-tabs.vue
@@ -43,7 +43,7 @@
               [`${carbonPrefix}--tabs--scrollable__nav-item--selected`]: selectedId == tab.uid,
             },
           ]"
-          role="presentation"
+          role="tab"
           :aria-selected="selectedId == tab.uid ? 'true' : 'false'"
           :aria-disabled="disabledTabs.indexOf(tab.uid) !== -1"
         >


### PR DESCRIPTION
Fixes #1255

## What did you do?
Change the role of the `<li>` element from `presentation` to `tab`.

## Why did you do it?
This would be consistent with the Carbon React components and fix the accessibility issue documented by #1255.

## How have you tested it?
Not yet well enough. Thus creating this as a draft PR so it doesn't get forgotten over the holidays.

## Were docs updated if needed?

- [X] N/A
- [ ] No
- [ ] Yes
