### PR TITLE
fix(combo box): set filter correctly for initial value

### DIFF
--- a/packages/core/src/components/cv-combo-box/cv-combo-box.vue
+++ b/packages/core/src/components/cv-combo-box/cv-combo-box.vue
@@ -182,7 +182,7 @@ export default {
     this.updateOptions();
   },
   mounted() {
-    this.filter = this.value;
+    this.internalUpdateValue(this.value);
     this.highlighted = this.value ? this.value : this.highlight; // override highlight with value if provided
     this.checkSlots();
   },

--- a/storybook/stories/cv-combo-box-story.js
+++ b/storybook/stories/cv-combo-box-story.js
@@ -179,6 +179,7 @@ for (const story of storySet) {
     story.name,
     () => {
       const settings = story.knobs();
+      const defaultValue = story.name === 'vModel' ? 'val-mango' : '';
 
       const templateString = `<cv-combo-box ${settings.group.attr}
   :options="options">${settings.group.slots}
@@ -224,7 +225,7 @@ for (const story of storySet) {
         props: settings.props,
         data() {
           return {
-            value: '',
+            value: defaultValue,
             options: fruits,
             highlight: '',
           };


### PR DESCRIPTION
Contributes to #1194

## What did you do?

Set initial value for combo box filter

## Why did you do it?

![combo-initial-value](https://user-images.githubusercontent.com/7536103/159394448-b6d9d1b2-df75-46ba-810c-11f453397be7.gif)

## How have you tested it?

Added a initial value to the combo box vModal story 

## Were docs updated if needed?

- [ ] N/A
- [ ] No
- [ ] Yes
