### PR TITLE
Remove extra role="search"

### DIFF
--- a/packages/core/src/components/cv-search/cv-search.vue
+++ b/packages/core/src/components/cv-search/cv-search.vue
@@ -12,7 +12,6 @@
           'cv-search': !formItem,
         },
       ]"
-      role="search"
       ref="search"
     >
       <button


### PR DESCRIPTION
This PR fixes the accessibility check of cv-search.

The input box has a `role=search`, the `div` also has one, cause the accessibility check to fail:

![image](https://user-images.githubusercontent.com/35569780/164510793-58c06a99-3087-4e25-ad52-e5937ab28eea.png)


- [ ] N/A
- [x ] No
- [ ] Yes
