### PR TITLE
fix: li and button role issues

### DIFF
--- a/packages/core/src/components/cv-tabs/cv-tabs.vue
+++ b/packages/core/src/components/cv-tabs/cv-tabs.vue
@@ -43,16 +43,15 @@
               [`${carbonPrefix}--tabs--scrollable__nav-item--selected`]: selectedId == tab.uid,
             },
           ]"
-          role="presentation"
+          role="tab"
           :aria-selected="selectedId == tab.uid ? 'true' : 'false'"
           :aria-disabled="disabledTabs.indexOf(tab.uid) !== -1"
         >
           <button
             :class="`${carbonPrefix}--tabs--scrollable__nav-link`"
-            role="tab"
+            role="button"
             :aria-controls="tab.uid"
             :aria-disabled="disabledTabs.indexOf(tab.uid) !== -1"
-            :aria-selected="selectedId == tab.uid"
             :id="`${tab.uid}-link`"
             @click="onTabClick(tab.uid)"
             ref="link"


### PR DESCRIPTION
The roles on LI and Button are wrong.

UL has role=tablist, LI should have role=tab and button should have role=button. 

## Were docs updated if needed?

- [ ] N/A
- [ x] No
- [ ] Yes
