### PR TITLE
fix: address a11y issue raised in

### DIFF
--- a/packages/core/src/components/cv-tabs/cv-tabs.vue
+++ b/packages/core/src/components/cv-tabs/cv-tabs.vue
@@ -44,8 +44,6 @@
             },
           ]"
           role="presentation"
-          :aria-selected="selectedId == tab.uid ? 'true' : 'false'"
-          :aria-disabled="disabledTabs.indexOf(tab.uid) !== -1"
         >
           <button
             :class="`${carbonPrefix}--tabs--scrollable__nav-link`"


### PR DESCRIPTION
Closes #1286 #1319 #1255

## What did you do?

The A11y issue identified in #1255 has a number of solutions. This adopts or rather completes a previous attempt at the Carbon solution of moving the aria-... attributes down to a button contained in the tab.

## Why did you do it?

To address a11y issue.

## How have you tested it?

Storybook & ran tests.

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
