### PR TITLE
fix: role menuitem into li

### DIFF
--- a/packages/core/src/components/cv-dropdown/cv-dropdown-item.vue
+++ b/packages/core/src/components/cv-dropdown/cv-dropdown-item.vue
@@ -17,6 +17,7 @@
       `cv-dropdown-item ${carbonPrefix}--dropdown-item`,
       { [`${carbonPrefix}--dropdown--selected`]: internalSelected },
     ]"
+    role="menuitem"
   >
     <a
       :aria-checked="internalSelected"


### PR DESCRIPTION
Contributes to [#1343](https://github.com/carbon-design-system/carbon-components-vue/issues/1343)

## What did you do?
Added a role into li.

## Why did you do it?
 In IBM Equal Access Accessibility Checker appears a violation about this element do not have a role.

## How have you tested it?
 In IBM Equal Access Accessibility Checker (as the image attached, the 4.1.2 error do not appears anymore)

## Were docs updated if needed?

- [ ] N/A
- [x ] No
- [ ] Yes
<img width="1031" alt="Captura de Tela 2022-07-18 às 13 07 55" src="https://user-images.githubusercontent.com/25625728/179554569-37838727-33fc-4c7f-83b8-ac151a8ba7f6.png">

