### PR TITLE
fix: expanded not true even for child

### DIFF
--- a/packages/core/src/components/cv-ui-shell/cv-header.vue
+++ b/packages/core/src/components/cv-ui-shell/cv-header.vue
@@ -79,7 +79,16 @@ export default {
         for (let index in this.panelControllers) {
           this.panelControllers[index].panelExpanded = false;
         }
-
+        const componentChildren = document.getElementsByClassName('cv-header-panel bx--header-panel');
+        if (newValue === false) {
+          for (let index = 0; index < componentChildren.length; index++) {
+            componentChildren[index].hidden = true;
+          }
+        } else {
+          for (let index = 0; index < componentChildren.length; index++) {
+            componentChildren[index].hidden = false;
+          }
+        }
         srcComponent.panelExpanded = newValue;
         this.panels[foundIndex].panelExpanded = newValue;
       }


### PR DESCRIPTION
if the expanded is not true the children will be hidden also

Contributes to [#1343](https://github.com/carbon-design-system/carbon-components-vue/issues/1343)

## What did you do?
"Hid" the children elements when some panel is not expanded.


## Why did you do it?

For screen readers, keyboards, these elements were still visible. So, it brings some accessibility problems.

## How have you tested it?

With 'IBM Equal Access Accessibility Checker ' and screen reader

## Were docs updated if needed?

- [ ] N/A
- [ x] No
- [ ] Yes

before:
<img width="1434" alt="Captura de Tela 2022-07-19 às 13 09 15" src="https://user-images.githubusercontent.com/25625728/179808111-8d9ebda2-d710-464b-a0b0-b4dc10a6dd37.png">

after:
<img width="1037" alt="Captura de Tela 2022-07-19 às 13 07 18" src="https://user-images.githubusercontent.com/25625728/179808101-55631ff0-d134-4fc0-967a-9f8b02f9cb7a.png">
