### PR TITLE
docs: index vue tutorial

### DIFF
--- a/packages/core/src/carbon.yml
+++ b/packages/core/src/carbon.yml
@@ -2,10 +2,27 @@
 library:
   id: carbon-components-vue
   name: Carbon Vue
-  description: Vue implementation of Carbon Components.
+  description: Build user interfaces with Carbon's core components.
   externalDocsUrl: https://vue.carbondesignsystem.com/?path=/story/welcome
   inherits: carbon-styles
   packageJsonPath: /../package.json
+  navData:
+    - title: Tutorial
+      items:
+        - title: Overview
+          path: 'https://github.com/carbon-design-system/carbon-website/blob/carbon-platform/src/pages/developing/vue-tutorial/overview.mdx'
+        - title: Step 1
+          path: 'https://github.com/carbon-design-system/carbon-website/blob/carbon-platform/src/pages/developing/vue-tutorial/step-1.mdx'
+        - title: Step 2
+          path: 'https://github.com/carbon-design-system/carbon-website/blob/carbon-platform/src/pages/developing/vue-tutorial/step-2.mdx'
+        - title: Step 3
+          path: 'https://github.com/carbon-design-system/carbon-website/blob/carbon-platform/src/pages/developing/vue-tutorial/step-3.mdx'
+        - title: Step 4
+          path: 'https://github.com/carbon-design-system/carbon-website/blob/carbon-platform/src/pages/developing/vue-tutorial/step-4.mdx'
+        - title: Step 5
+          path: 'https://github.com/carbon-design-system/carbon-website/blob/carbon-platform/src/pages/developing/vue-tutorial/step-5.mdx'
+        - title: Wrapping up
+          path: 'https://github.com/carbon-design-system/carbon-website/blob/main/src/pages/developing/vue-tutorial/wrapping-up.mdx'
 assets:
   accordion:
     status: stable


### PR DESCRIPTION
## What did you do?

- Updated Carbon Vue library description per design spec: https://airtable.com/shrdwElZNyJdGtZkS/tblE2Y75BfY0Z0T2O/viwiUj1cNATMWrkSy/rechGMBkWisSw0prL
- Indexed the Vue tutorial to be part of the library

## Why did you do it?

So next version of Carbon website can have Carbon Vue content.

## How have you tested it?

Updated library description:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1691245/186967949-ad0c65e6-6f59-4c24-9481-bc2a148188b8.png">

The tutorial pages render:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1691245/186968194-f94d75c8-8a82-4939-a78f-97aa1b4e9e6f.png">

Step 5 will render when https://github.com/carbon-design-system/carbon-platform/issues/1182 is fixed.

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
