### PR TITLE
docs: index getting started content

### DIFF
--- a/packages/core/src/carbon.yml
+++ b/packages/core/src/carbon.yml
@@ -7,6 +7,8 @@ library:
   inherits: carbon-styles
   packageJsonPath: /../package.json
   navData:
+    - title: Get started
+      path: "https://github.com/carbon-design-system/carbon-website/blob/carbon-platform/src/pages/developing/frameworks/vue.mdx"
     - title: Tutorial
       items:
         - title: Overview


### PR DESCRIPTION
As found in https://github.com/carbon-design-system/carbon-platform/issues/907, added a "Get started" page to the Carbon Vue library with https://carbondesignsystem.com/developing/frameworks/vue content.