### PR TITLE
feat: using native Crypto API to generate UUIDs

### DIFF
--- a/packages/core/src/mixins/uid-mixin.js
+++ b/packages/core/src/mixins/uid-mixin.js
@@ -1,12 +1,6 @@
 const idGen = {
   newId() {
-    // as it is funny gen IDs using b - https://gist.github.com/jed/982883
-    const b = a =>
-      a
-        ? (a ^ ((Math.random() * 16) >> (a / 4))).toString(16)
-        : ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, b);
-
-    return `uid-${b()}`;
+    return `uid-${ crypto.randomUUID() }`;
   },
 };
 


### PR DESCRIPTION

## What did you do?

Replaced an obscure UUID generation function with a native method from the Crypto API (available everywhere). 

About the Crypto API and its availability: https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID

## Why did you do it? 

Using the native API was about 50% faster, and it's all done in a single line of code, calling the Crypto API.
The current version is somewhat obscure. 

The in-browser benchmark can run here: https://jsbench.me/a9lcjwwi2p/2


## How have you tested it?

Function output was unaltered with the change. Both versions output `uid-${ a_random_uuid }`

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
