### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ As a community project contributions are not only welcome, but essential for the
 
 [CHANGELOG.md](./packages/core/CHANGELOG.md)
 
-## Gettting started
+## Getting started
 
 [Usage and getting started instructions](./packages/core/README.md#getting-started) for @carbon/vue.
 


### PR DESCRIPTION
fix: small typo 

Contributes to #
headline on Readme "Gettting" to "Getting" started

## What did you do?
fixed the typo

## Why did you do it?
I happened to see it

## How have you tested it?
Should not be necessary

## Were docs updated if needed?

- [ x] N/A
- [ ] No
- [ ] Yes
