### PR TITLE
fix: set aria role separator on modal before/after content

### DIFF
--- a/packages/core/src/components/cv-modal/cv-modal.vue
+++ b/packages/core/src/components/cv-modal/cv-modal.vue
@@ -25,7 +25,9 @@
         class="cv-modal__before-content"
         ref="beforeContent"
         tabindex="0"
-        style="position: absolute; height: 1px; width: 1px; left: -9999px;"
+        style="position: absolute; height: 1px; width: 1px; left: -9999px"
+        role="separator"
+        aria-valuenow="0"
         @focus="focusBeforeContent"
       />
       <div :class="`${carbonPrefix}--modal-header`">
@@ -82,7 +84,9 @@
         class="cv-modal__after-content"
         ref="afterContent"
         tabindex="0"
-        style="position: absolute; height: 1px; width: 1px; left: -9999px;"
+        style="position: absolute; height: 1px; width: 1px; left: -9999px"
+        role="separator"
+        aria-valuenow="1"
         @focus="focusAfterContent"
       />
     </div>


### PR DESCRIPTION
Contributes to #1408 

## What did you do?

Added `role="separator"` to the before/after modal divs. Also added required value `aria-valuenow` to both 


## How have you tested it?

Tested locally in Storybook with IBM accessibility checker

## Were docs updated if needed?

- [x] N/A
