### PR TITLE
ci(storybook): deploy to github pages

### DIFF
--- a/.github/workflows/deploy-vue-storybook.yml
+++ b/.github/workflows/deploy-vue-storybook.yml
@@ -1,4 +1,4 @@
-name: Deploy Vue storybook to IBM Cloud
+name: Deploy Vue storybook to IBM Cloud and GitHub Pages
 
 on:
   workflow_dispatch:
@@ -7,10 +7,20 @@ on:
   #     # Matches tags that have the shape `vX.Y.Z`. Reference:
   #     # https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requesttagsbranches
   #     - 'v[0-9]+.[0-9]+.[0-9]+'
-
   #     # Ignore tags that use a preid after `vX.Y.Z`, for example: vX.Y.Z-alpha.0
   #     # https://help.github.com/en/articles/workflow-syntax-for-github-actions#example-using-positive-and-negative-patterns
   #     - '!v[0-9]+.[0-9]+.[0-9]+-*'
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -45,3 +55,21 @@ jobs:
           ibmcloud cf blue-green-deploy carbon-storybook-vue \
             -f storybook/manifest.yml \
             --delete-old-apps
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'storybook/storybook-static'
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
Contributes to https://github.com/carbon-design-system/carbon/issues/12171 and https://github.com/carbon-design-system/carbon-components-vue/issues/1364

## What did you do?

Add new steps to the deployment workflow to deploy the storybook to GitHub Pages. The existing IBM Cloud deploy was not modified.

## Why did you do it?

This is the first step towards removing the IBM Cloud deploy due to the upcoming sunset of Cloudfoundry. Instead of publishing the storybook to Carbon's IBM Cloud account, storybooks will be published to github pages.

Once this is merged in, I'll move `vue.carbondesignsystem.com` to point to the github pages deployment, then issue another PR to remove the IBM cloud deploy. This will ensure no downtime on the storybook.

## How have you tested it?

We just did this same update in the main Carbon repo and [it's working](https://github.com/carbon-design-system/carbon/actions/runs/3987227574). 

The only change here is the path to the storybook.

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
