### PR TITLE
fix(cv-datatable): batch action scroll on select/unselect

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,32 +5,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [2.45.1](https://github.com/carbon-design-system/carbon-components-vue/compare/@carbon/vue@2.45.0...@carbon/vue@2.45.1) (2023-01-24)
 
-
 ### Bug Fixes
 
-* set aria role seperator on modal before/after content ([#1409](https://github.com/carbon-design-system/carbon-components-vue/issues/1409)) ([21b3756](https://github.com/carbon-design-system/carbon-components-vue/commit/21b375650de2e020ff96c5e3810e3393bbd318a8))
-
-
-
-
+- set aria role seperator on modal before/after content ([#1409](https://github.com/carbon-design-system/carbon-components-vue/issues/1409)) ([21b3756](https://github.com/carbon-design-system/carbon-components-vue/commit/21b375650de2e020ff96c5e3810e3393bbd318a8))
 
 # [2.45.0](https://github.com/carbon-design-system/carbon-components-vue/compare/@carbon/vue@2.44.2...@carbon/vue@2.45.0) (2023-01-10)
 
-
 ### Bug Fixes
 
-* **combo box:** set filter correctly for inital value ([f43a0b9](https://github.com/carbon-design-system/carbon-components-vue/commit/f43a0b97b73b988c8bdcb39ecc677d9b7ab024c2))
-* **cv-data-table:** fix searchbox role ([51f0ebb](https://github.com/carbon-design-system/carbon-components-vue/commit/51f0ebb763f2e2b5a8de77c3f8c5b32e789bbb7b))
-* tag close button should have type button ([fa57623](https://github.com/carbon-design-system/carbon-components-vue/commit/fa57623e173088d06cc23994d6aac3c842fb91a7))
-
+- **combo box:** set filter correctly for inital value ([f43a0b9](https://github.com/carbon-design-system/carbon-components-vue/commit/f43a0b97b73b988c8bdcb39ecc677d9b7ab024c2))
+- **cv-data-table:** fix searchbox role ([51f0ebb](https://github.com/carbon-design-system/carbon-components-vue/commit/51f0ebb763f2e2b5a8de77c3f8c5b32e789bbb7b))
+- tag close button should have type button ([fa57623](https://github.com/carbon-design-system/carbon-components-vue/commit/fa57623e173088d06cc23994d6aac3c842fb91a7))
 
 ### Features
 
-* update carbon versions ([05ba3e4](https://github.com/carbon-design-system/carbon-components-vue/commit/05ba3e487ac975b04b7de1a10d8b3363add6756d))
-
-
-
-
+- update carbon versions ([05ba3e4](https://github.com/carbon-design-system/carbon-components-vue/commit/05ba3e487ac975b04b7de1a10d8b3363add6756d))
 
 ## [2.44.2](https://github.com/carbon-design-system/carbon-components-vue/compare/@carbon/vue@2.44.1...@carbon/vue@2.44.2) (2022-12-02)
 

--- a/packages/core/src/components/cv-checkbox/cv-checkbox.vue
+++ b/packages/core/src/components/cv-checkbox/cv-checkbox.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="cv-checkbox" :class="[`${carbonPrefix}--checkbox-wrapper`, { [`${carbonPrefix}--form-item`]: formItem }]">
+  <div
+    style="{position: relative}"
+    class="cv-checkbox"
+    :class="[`${carbonPrefix}--checkbox-wrapper`, { [`${carbonPrefix}--form-item`]: formItem }]"
+  >
     <input
       ref="input"
       v-bind="$attrs"


### PR DESCRIPTION
Contributes to #

https://vue.carbondesignsystem.com/?path=/story/components-cvdatatable--infinite-pagination

This PR fixes a bug in the datatable component.

Using the batch actions in the datatable,
if you scroll past the top of the table and select/unselect a row, you will be teleported back to the top,

this behavior is because the checkbox input has an absolute position, and the nearest container with a relative position is the outer container for the table

## What did you do?

added a style to the container of the checkbox, to make its position relative

## Why did you do it?

to limit the checkbox input which has an absolute position from moving away to the closer relative container,

## How have you tested it?

## Were docs updated if needed?

- [ ] N/A
- [ ] No
- [ ] Yes
