### PR TITLE
fix(cv-data-table): accessibility violation - batch action cancel button

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,21 +5,32 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [2.45.1](https://github.com/carbon-design-system/carbon-components-vue/compare/@carbon/vue@2.45.0...@carbon/vue@2.45.1) (2023-01-24)
 
+
 ### Bug Fixes
 
-- set aria role seperator on modal before/after content ([#1409](https://github.com/carbon-design-system/carbon-components-vue/issues/1409)) ([21b3756](https://github.com/carbon-design-system/carbon-components-vue/commit/21b375650de2e020ff96c5e3810e3393bbd318a8))
+* set aria role seperator on modal before/after content ([#1409](https://github.com/carbon-design-system/carbon-components-vue/issues/1409)) ([21b3756](https://github.com/carbon-design-system/carbon-components-vue/commit/21b375650de2e020ff96c5e3810e3393bbd318a8))
+
+
+
+
 
 # [2.45.0](https://github.com/carbon-design-system/carbon-components-vue/compare/@carbon/vue@2.44.2...@carbon/vue@2.45.0) (2023-01-10)
 
+
 ### Bug Fixes
 
-- **combo box:** set filter correctly for inital value ([f43a0b9](https://github.com/carbon-design-system/carbon-components-vue/commit/f43a0b97b73b988c8bdcb39ecc677d9b7ab024c2))
-- **cv-data-table:** fix searchbox role ([51f0ebb](https://github.com/carbon-design-system/carbon-components-vue/commit/51f0ebb763f2e2b5a8de77c3f8c5b32e789bbb7b))
-- tag close button should have type button ([fa57623](https://github.com/carbon-design-system/carbon-components-vue/commit/fa57623e173088d06cc23994d6aac3c842fb91a7))
+* **combo box:** set filter correctly for inital value ([f43a0b9](https://github.com/carbon-design-system/carbon-components-vue/commit/f43a0b97b73b988c8bdcb39ecc677d9b7ab024c2))
+* **cv-data-table:** fix searchbox role ([51f0ebb](https://github.com/carbon-design-system/carbon-components-vue/commit/51f0ebb763f2e2b5a8de77c3f8c5b32e789bbb7b))
+* tag close button should have type button ([fa57623](https://github.com/carbon-design-system/carbon-components-vue/commit/fa57623e173088d06cc23994d6aac3c842fb91a7))
+
 
 ### Features
 
-- update carbon versions ([05ba3e4](https://github.com/carbon-design-system/carbon-components-vue/commit/05ba3e487ac975b04b7de1a10d8b3363add6756d))
+* update carbon versions ([05ba3e4](https://github.com/carbon-design-system/carbon-components-vue/commit/05ba3e487ac975b04b7de1a10d8b3363add6756d))
+
+
+
+
 
 ## [2.44.2](https://github.com/carbon-design-system/carbon-components-vue/compare/@carbon/vue@2.44.1...@carbon/vue@2.44.2) (2022-12-02)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,32 +5,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [2.45.1](https://github.com/carbon-design-system/carbon-components-vue/compare/@carbon/vue@2.45.0...@carbon/vue@2.45.1) (2023-01-24)
 
-
 ### Bug Fixes
 
-* set aria role seperator on modal before/after content ([#1409](https://github.com/carbon-design-system/carbon-components-vue/issues/1409)) ([21b3756](https://github.com/carbon-design-system/carbon-components-vue/commit/21b375650de2e020ff96c5e3810e3393bbd318a8))
-
-
-
-
+- set aria role seperator on modal before/after content ([#1409](https://github.com/carbon-design-system/carbon-components-vue/issues/1409)) ([21b3756](https://github.com/carbon-design-system/carbon-components-vue/commit/21b375650de2e020ff96c5e3810e3393bbd318a8))
 
 # [2.45.0](https://github.com/carbon-design-system/carbon-components-vue/compare/@carbon/vue@2.44.2...@carbon/vue@2.45.0) (2023-01-10)
 
-
 ### Bug Fixes
 
-* **combo box:** set filter correctly for inital value ([f43a0b9](https://github.com/carbon-design-system/carbon-components-vue/commit/f43a0b97b73b988c8bdcb39ecc677d9b7ab024c2))
-* **cv-data-table:** fix searchbox role ([51f0ebb](https://github.com/carbon-design-system/carbon-components-vue/commit/51f0ebb763f2e2b5a8de77c3f8c5b32e789bbb7b))
-* tag close button should have type button ([fa57623](https://github.com/carbon-design-system/carbon-components-vue/commit/fa57623e173088d06cc23994d6aac3c842fb91a7))
-
+- **combo box:** set filter correctly for inital value ([f43a0b9](https://github.com/carbon-design-system/carbon-components-vue/commit/f43a0b97b73b988c8bdcb39ecc677d9b7ab024c2))
+- **cv-data-table:** fix searchbox role ([51f0ebb](https://github.com/carbon-design-system/carbon-components-vue/commit/51f0ebb763f2e2b5a8de77c3f8c5b32e789bbb7b))
+- tag close button should have type button ([fa57623](https://github.com/carbon-design-system/carbon-components-vue/commit/fa57623e173088d06cc23994d6aac3c842fb91a7))
 
 ### Features
 
-* update carbon versions ([05ba3e4](https://github.com/carbon-design-system/carbon-components-vue/commit/05ba3e487ac975b04b7de1a10d8b3363add6756d))
-
-
-
-
+- update carbon versions ([05ba3e4](https://github.com/carbon-design-system/carbon-components-vue/commit/05ba3e487ac975b04b7de1a10d8b3363add6756d))
 
 ## [2.44.2](https://github.com/carbon-design-system/carbon-components-vue/compare/@carbon/vue@2.44.1...@carbon/vue@2.44.2) (2022-12-02)
 

--- a/packages/core/src/components/cv-data-table/cv-data-table.vue
+++ b/packages/core/src/components/cv-data-table/cv-data-table.vue
@@ -17,9 +17,14 @@
         >
           <div :class="`${carbonPrefix}--action-list`">
             <slot name="batch-actions" />
-            <cv-button :class="`${carbonPrefix}--batch-summary__cancel`" size="small" @click="deselect">{{
-              batchCancelLabel
-            }}</cv-button>
+            <cv-button
+              :tabindex="batchActive ? '0' : '-1'"
+              :class="`${carbonPrefix}--batch-summary__cancel`"
+              size="small"
+              @click="deselect"
+            >
+              {{ batchCancelLabel }}
+            </cv-button>
           </div>
           <div :class="`${carbonPrefix}--batch-summary`">
             <p :class="`${carbonPrefix}--batch-summary__para`">
@@ -216,7 +221,7 @@ export default {
     expandAllAriaLabel: { type: String, default: 'Expand all rows' },
     selectAllAriaLabel: { type: String, default: 'Select all rows' },
     autoWidth: Boolean,
-    batchCancelLabel: { type: String, default: 'cancel' },
+    batchCancelLabel: { type: String, default: 'Cancel' },
     borderless: Boolean,
     overflowMenu: { type: [Boolean, Array], default: () => [] },
     pagination: {


### PR DESCRIPTION
Contributes to #

This PR fixes the accessibility violation 
Element "button" should not be focusable within the subtree of an element with an 'aria-hidden' attribute with value 'true'

## What did you do?

inspired by the react carbon lib
i check if the batch actions are not active, set the tabindex on the cancel button to -1 

## Why did you do it?

## How have you tested it?

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
