### PR TITLE
fix: set immediate to true of expanded watch prop from side nav menu

### DIFF
--- a/src/components/CvUIShell/CvSideNavMenu.vue
+++ b/src/components/CvUIShell/CvSideNavMenu.vue
@@ -79,6 +79,7 @@ watch(
   () => props.expanded,
   value => {
     data.isExpanded = value;
-  }
+  },
+  { immediate: true }
 );
 </script>


### PR DESCRIPTION
Contributes to #

## What did you do?
Basically I set the prop `immediate` to `true` of `expanded` watch

## Why did you do it?
By default, the prop `immediate` is `false` and when we try to set to `true` it's ignored
```vue
<CvSideNavMenu :title="title" :expanded="true">
...
</CvSideNavMenu>
``` 

## How have you tested it?
I forked the repo and make the changes. Then I tested in my app and it worked.

## Were docs updated if needed?

- [x] N/A
- [X] No
- [x] Yes
