### PR TITLE
fix(cv-combo-box): accessibility violations

### DIFF
--- a/packages/core/src/components/cv-combo-box/cv-combo-box.vue
+++ b/packages/core/src/components/cv-combo-box/cv-combo-box.vue
@@ -8,7 +8,6 @@
     >
 
     <div
-      role="listbox"
       tabindex="-1"
       class=""
       :class="[
@@ -30,9 +29,7 @@
     >
       <WarningFilled16 v-if="isInvalid" :class="[`${carbonPrefix}--list-box__invalid-icon`]" />
       <div
-        role="button"
         aria-haspopup="true"
-        :aria-expanded="open ? 'true' : 'false'"
         :aria-owns="uid"
         :aria-controls="uid"
         :class="[`${carbonPrefix}--list-box__field`]"


### PR DESCRIPTION
Contributes to #

## What did you do?

Fix accessibility violation: nested-interactive
caused by using a listbox role on a div with two buttons

this fix inspired by the same component in the react carbon lib
https://react.carbondesignsystem.com/?path=/story/components-combobox--default

## Why did you do it?

## How have you tested it?

## Were docs updated if needed?

- [ ] N/A
- [ ] No
- [ ] Yes
