### PR TITLE
chore: combine Vue2 & Vue3 storybooks in GitHub pages

### DIFF
--- a/.github/workflows/deploy-vue-storybook.yml
+++ b/.github/workflows/deploy-vue-storybook.yml
@@ -28,11 +28,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: main
-      - name: Use Node.js 14.x
+          ref: chore-combine-storybooks
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - name: Install dependencies from our offline mirror
         run: yarn install --offline
       - name: Build Vue 2 storybook

--- a/.github/workflows/deploy-vue-storybook.yml
+++ b/.github/workflows/deploy-vue-storybook.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: chore-combine-storybooks
+          ref: main
       - name: Use Node.js 16.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/deploy-vue-storybook.yml
+++ b/.github/workflows/deploy-vue-storybook.yml
@@ -1,4 +1,4 @@
-name: Deploy Vue storybook to IBM Cloud and GitHub Pages
+name: Deploy Storybook
 
 on:
   workflow_dispatch:
@@ -23,21 +23,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: macOS-latest
+  build-storybook:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - name: Use Node.js 16.x
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v3
         with:
           node-version: '14.x'
       - name: Install dependencies from our offline mirror
         run: yarn install --offline
-      - name: Build Vue storybook
+      - name: Build Vue 2 storybook
         run: |
           yarn build:storybook --quiet
+      - name: Switch to Vue 3 branch
+        uses: actions/checkout@v3
+        with:
+          ref: vNext
+          clean: false
+          path: vNext
+      - name: Install vNext dependencies
+        run: |
+          cd ${GITHUB_WORKSPACE}/vNext/storybook
+          yarn install
+      - name: Build Vue 3 storybook
+        run: |
+          cd ${GITHUB_WORKSPACE}/vNext/storybook
+          yarn build-storybook --quiet --output-dir ${GITHUB_WORKSPACE}/storybook/storybook-static/vue3
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v3
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
@@ -49,7 +65,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-storybook
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/storybook/_storybook/views/sv-template-view/sv-versions.vue
+++ b/storybook/_storybook/views/sv-template-view/sv-versions.vue
@@ -15,7 +15,7 @@
     <div class="versions__info">
       <div class="bx--row">
         <div class="bx--no-gutter-md--left bx--col-md-4 bx--col-lg-4">
-          <a class="versions__card" href="https://carbon-components-vue-3.netlify.app/">
+          <a class="versions__card" href="/carbon-components-vue/vue3/">
             <div class="bx--aspect-ratio bx--aspect-ratio--2x1">
               <div class="bx--aspect-ratio--object">
                 <div class="versions__card-content">

--- a/storybook/_storybook/views/sv-template-view/sv-welcome.vue
+++ b/storybook/_storybook/views/sv-template-view/sv-welcome.vue
@@ -83,7 +83,7 @@
           </a>
         </div>
         <div class="bx--no-gutter-md--left bx--col-md-4 bx--col-lg-4">
-          <a class="welcome__card" href="https://carbon-components-vue-3.netlify.app/">
+          <a class="welcome__card" href="/carbon-components-vue/vue3/">
             <div class="bx--aspect-ratio bx--aspect-ratio--2x1">
               <div class="bx--aspect-ratio--object">
                 <div class="welcome__card-content">


### PR DESCRIPTION
## What did you do?

Per slack discussion, deploy both Vue 2 and Vue 3 storybook to the same GitHub pages. 
Vue2 https://vue.carbondesignsystem.com/
Vue3  https://vue.carbondesignsystem.com/vue3/
The Vue2 welcome and version pages changed to point to the new vue3 storybook.

## Why did you do it?
Make both storybooks available in the same location

## How have you tested it?
Deployed it to [my own forked repo](https://davidnixon.github.io/carbon-components-vue/?path=/story/welcome--default) 

## Were docs updated if needed?

- [x] Yes
