### PR TITLE
feat: CvLink implementation for Vue3

### DIFF
--- a/src/components/CvLink/CvLink.stories.js
+++ b/src/components/CvLink/CvLink.stories.js
@@ -5,7 +5,7 @@ import {
 } from '../../global/storybook-utils';
 
 import { CvLink } from '.';
-import { props as propsCvLink } from '../../use/cvLink';
+import { props as propsCvLink, linkSizes } from '../../use/cvLink';
 
 export default {
   title: `${sbCompPrefix}/CvLink`,
@@ -60,6 +60,26 @@ export default {
       defaultValue: false,
       description:
         'Specify whether you want the link to receive visited styles after the link has been clicked.',
+    },
+    size: {
+      type: 'string',
+      table: {
+        type: { summary: linkSizes.join(' | ') },
+        defaultValue: { summary: 'medium (md)' },
+        category: 'props',
+      },
+      options: linkSizes,
+      control: {
+        type: 'select',
+        labels: {
+          sm: 'small (sm)',
+          md: 'medium (md)',
+          lg: 'large (lg)',
+        },
+      },
+      defaultValue: 'md',
+      description:
+        'Specify the size of the Link. Currently supports either `sm`, `md` (default) or `lg` as an option.',
     },
     default: {
       type: 'string',

--- a/src/components/CvLink/CvLink.stories.js
+++ b/src/components/CvLink/CvLink.stories.js
@@ -1,0 +1,121 @@
+import {
+  sbCompPrefix,
+  storybookControlsFromProps,
+  storyParametersObject,
+} from '../../global/storybook-utils';
+
+import { CvLink } from '.';
+import { props as propsCvLink } from '../../use/cvLink';
+
+export default {
+  title: `${sbCompPrefix}/CvLink`,
+  component: CvLink,
+  argTypes: {
+    ...storybookControlsFromProps(propsCvLink),
+    disabled: {
+      type: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        category: 'props',
+      },
+      defaultValue: false,
+      description: 'Toogle anchor / router-link disable state.',
+    },
+    inline: {
+      type: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        category: 'props',
+      },
+      defaultValue: false,
+      description:
+        'Specify whether you want the inline version of this control.',
+    },
+    href: {
+      type: 'string',
+      table: {
+        type: { summary: 'string' },
+        category: 'props',
+      },
+      description: 'Provide the href attribute for the `<a>` node.',
+    },
+    to: {
+      type: 'string',
+      table: {
+        type: {
+          summary:
+            'string, object (see vue-router documentation for router-link)',
+        },
+        category: 'props',
+      },
+      description:
+        "Replace `<a>` node for vue-router's `router-link`, providing `to` property to it. Cannot be used with href.",
+    },
+    default: {
+      type: 'string',
+      table: {
+        type: { summary: 'html' },
+        category: 'slots',
+      },
+      description: 'Inner `<a>` node / router-link content.',
+    },
+  },
+};
+
+const template = `<cv-link href='#' v-bind='args'>{{ args.default }}</cv-link>`;
+const Template = args => {
+  return {
+    components: { CvLink },
+    setup: () => ({ args }),
+    template,
+  };
+};
+
+export const Default = Template.bind({});
+Default.args = { default: 'Link' };
+Default.parameters = storyParametersObject(
+  Default.parameters,
+  template,
+  Default.args
+);
+
+export const Disabled = Template.bind({});
+Disabled.args = { default: 'Disabled link', disabled: true };
+Disabled.parameters = storyParametersObject(
+  Disabled.parameters,
+  template,
+  Disabled.args
+);
+
+const inlineTemplate = `
+<p>
+  Ut facilisis semper lorem in aliquet. Aliquam accumsan ante justo, vitae
+  fringilla eros vehicula id. Ut at enim quis libero pharetra ullamcorper.
+  Maecenas feugiat sodales arcu ut porttitor. In blandit ultricies est.
+  Vivamus risus massa, cursus eu tellus sed, sagittis commodo nunc.
+  <cv-link href="#" v-bind='args'>{{ args.default }}</cv-link>,
+  finibus suscipit nunc. Phasellus ex quam, placerat quis tempus sit amet,
+  pretium nec sem. Etiam dictum scelerisque mauris, blandit ultrices erat
+  pellentesque id. Quisque venenatis purus sit amet sodales condimentum.
+  Duis at tincidunt orci. Ut velit ipsum, lacinia at ex quis, aliquet
+  rhoncus purus. Praesent et scelerisque ligula.
+</p>
+`;
+const InlineTemplate = args => {
+  return {
+    components: { CvLink },
+    setup: () => ({ args }),
+    template: inlineTemplate,
+  };
+};
+
+export const Inline = InlineTemplate.bind({});
+Inline.args = {
+  default: 'Maecenas nunc mauris, consequat quis mauris sit amet',
+  inline: true,
+};
+Inline.parameters = storyParametersObject(
+  Inline.parameters,
+  inlineTemplate,
+  Inline.args
+);

--- a/src/components/CvLink/CvLink.stories.js
+++ b/src/components/CvLink/CvLink.stories.js
@@ -5,6 +5,7 @@ import {
 } from '../../global/storybook-utils';
 
 import { CvLink } from '.';
+import { Download16 } from '@carbon/icons-vue';
 import { props as propsCvLink, linkSizes } from '../../use/cvLink';
 
 export default {
@@ -81,6 +82,15 @@ export default {
       description:
         'Specify the size of the Link. Currently supports either `sm`, `md` (default) or `lg` as an option.',
     },
+    icon: {
+      table: {
+        type: { summary: 'string | object' },
+        category: 'props',
+      },
+      control: { type: null },
+      description:
+        'Render an icon next to the link. Can be a component object or a svg string',
+    },
     default: {
       type: 'string',
       table: {
@@ -148,4 +158,12 @@ Inline.parameters = storyParametersObject(
   Inline.parameters,
   inlineTemplate,
   Inline.args
+);
+
+export const PariedWithIcon = Template.bind({});
+PariedWithIcon.args = { default: 'Download', icon: Download16 };
+PariedWithIcon.parameters = storyParametersObject(
+  PariedWithIcon.parameters,
+  template,
+  PariedWithIcon.args
 );

--- a/src/components/CvLink/CvLink.stories.js
+++ b/src/components/CvLink/CvLink.stories.js
@@ -51,6 +51,16 @@ export default {
       description:
         "Replace `<a>` node for vue-router's `router-link`, providing `to` property to it. Cannot be used with href.",
     },
+    visited: {
+      type: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        category: 'props',
+      },
+      defaultValue: false,
+      description:
+        'Specify whether you want the link to receive visited styles after the link has been clicked.',
+    },
     default: {
       type: 'string',
       table: {

--- a/src/components/CvLink/CvLink.vue
+++ b/src/components/CvLink/CvLink.vue
@@ -8,6 +8,7 @@
       {
         [`${carbonPrefix}--link--disabled`]: disabled,
         [`${carbonPrefix}--link--inline`]: inline,
+        [`${carbonPrefix}--link--visited`]: visited,
       },
     ]"
   >
@@ -25,6 +26,7 @@ import {
 
 const props = defineProps({
   inline: Boolean,
+  visited: Boolean,
   ...linkPropsDefinition,
 });
 const linkProps = useLinkProps(props);

--- a/src/components/CvLink/CvLink.vue
+++ b/src/components/CvLink/CvLink.vue
@@ -1,0 +1,32 @@
+<template>
+  <component
+    :is="tagType"
+    v-bind="linkProps"
+    class="cv-link"
+    :class="[
+      `${carbonPrefix}--link`,
+      {
+        [`${carbonPrefix}--link--disabled`]: disabled,
+        [`${carbonPrefix}--link--inline`]: inline,
+      },
+    ]"
+  >
+    <slot></slot>
+  </component>
+</template>
+
+<script setup>
+import { carbonPrefix } from '../../global/settings';
+import {
+  props as linkPropsDefinition,
+  useLinkProps,
+  useTagType,
+} from '../../use/cvLink';
+
+const props = defineProps({
+  inline: Boolean,
+  ...linkPropsDefinition,
+});
+const linkProps = useLinkProps(props);
+const tagType = useTagType(props);
+</script>

--- a/src/components/CvLink/CvLink.vue
+++ b/src/components/CvLink/CvLink.vue
@@ -9,6 +9,7 @@
         [`${carbonPrefix}--link--disabled`]: disabled,
         [`${carbonPrefix}--link--inline`]: inline,
         [`${carbonPrefix}--link--visited`]: visited,
+        [`${carbonPrefix}--link--${size}`]: size,
       },
     ]"
   >

--- a/src/components/CvLink/CvLink.vue
+++ b/src/components/CvLink/CvLink.vue
@@ -14,10 +14,12 @@
     ]"
   >
     <slot></slot>
+    <CvSvg v-if="icon" :class="`${carbonPrefix}--link__icon`" :svg="icon" />
   </component>
 </template>
 
 <script setup>
+import CvSvg from '../CvSvg/_CvSvg.vue';
 import { carbonPrefix } from '../../global/settings';
 import {
   props as linkPropsDefinition,
@@ -26,6 +28,7 @@ import {
 } from '../../use/cvLink';
 
 const props = defineProps({
+  icon: { type: [String, Object] },
   inline: Boolean,
   visited: Boolean,
   ...linkPropsDefinition,

--- a/src/components/CvLink/__tests__/CvLink.spec.js
+++ b/src/components/CvLink/__tests__/CvLink.spec.js
@@ -78,4 +78,38 @@ describe('CvLink', () => {
     const element = container.firstElementChild;
     expect(element.classList.contains('bx--link--visited')).toBe(true);
   });
+
+  it("update link size to small when 'size' is sm", () => {
+    const { container } = render(CvLink, {
+      props: { size: 'sm' },
+    });
+
+    const element = container.firstElementChild;
+    expect(element.classList.contains('bx--link--sm')).toBe(true);
+  });
+
+  it("update link size to medium when 'size' is md", () => {
+    const { container } = render(CvLink, {
+      props: { size: 'md' },
+    });
+
+    const element = container.firstElementChild;
+    expect(element.classList.contains('bx--link--md')).toBe(true);
+  });
+
+  it("update link size to large when 'size' is lg", () => {
+    const { container } = render(CvLink, {
+      props: { size: 'lg' },
+    });
+
+    const element = container.firstElementChild;
+    expect(element.classList.contains('bx--link--lg')).toBe(true);
+  });
+
+  it('sets link size to medium when no size is passed', () => {
+    const { container } = render(CvLink);
+
+    const element = container.firstElementChild;
+    expect(element.classList.contains('bx--link--md')).toBe(true);
+  });
 });

--- a/src/components/CvLink/__tests__/CvLink.spec.js
+++ b/src/components/CvLink/__tests__/CvLink.spec.js
@@ -1,4 +1,6 @@
+import { Download16 } from '@carbon/icons-vue';
 import { render } from '@testing-library/vue';
+import { markRaw } from 'vue';
 import CvLink from '..';
 
 describe('CvLink', () => {
@@ -111,5 +113,54 @@ describe('CvLink', () => {
 
     const element = container.firstElementChild;
     expect(element.classList.contains('bx--link--md')).toBe(true);
+  });
+
+  it("sets an icon, when 'icon' is set with a svg string", () => {
+    const dummyIcon = `
+      <svg height="10" width="10">
+        <circle cx="50" cy="50" r="40" fill="red" />
+      </svg>
+    `;
+    const { container } = render(CvLink, {
+      props: { icon: dummyIcon },
+    });
+
+    expect(container.querySelector('svg')).toBeDefined();
+  });
+
+  it("sets an icon, when 'icon' is set with a vue component", () => {
+    /**
+     * Without `markRaw`, vue triggers a warning at CvSvg:
+     * [Vue warn]: Vue received a Component which was made a reactive object. This can lead to
+     * unnecessary performance overhead, and should be avoided by marking the component with
+     * `markRaw` or using `shallowRef` instead of `ref`.
+     */
+    const dummyIcon = markRaw(Download16);
+    const { container } = render(CvLink, {
+      props: { icon: dummyIcon },
+    });
+
+    expect(container.querySelector('svg')).toBeDefined();
+  });
+
+  it('places icon next to link text (default slot) per carbon spec', () => {
+    const dummyLinkText = 'Link';
+    const dummyIcon = `
+      <svg height="10" width="10">
+        <circle cx="50" cy="50" r="40" fill="red" />
+      </svg>
+    `;
+    const { getByText } = render(CvLink, {
+      props: { icon: dummyIcon },
+      slots: { default: dummyLinkText },
+    });
+
+    const anchor = getByText(dummyLinkText);
+    expect(anchor.innerHTML.startsWith(`${dummyLinkText}<svg `)).toBe(true);
+  });
+
+  it("does not set icon if 'icon' is not set", () => {
+    const { container } = render(CvLink);
+    expect(container.querySelector('svg')).toBeNull();
   });
 });

--- a/src/components/CvLink/__tests__/CvLink.spec.js
+++ b/src/components/CvLink/__tests__/CvLink.spec.js
@@ -1,0 +1,72 @@
+import { render } from '@testing-library/vue';
+import CvLink from '..';
+
+describe('CvLink', () => {
+  it('renders sloted content', async () => {
+    const dummyLinkText = 'Dummy Link';
+    const { getByText } = render(CvLink, { slots: { default: dummyLinkText } });
+
+    const anchor = await getByText(dummyLinkText);
+    expect(anchor.textContent).toBe(dummyLinkText);
+  });
+
+  it("renders an anchor when neither 'href' and 'to' are defined", async () => {
+    const { container } = render(CvLink);
+
+    const anchor = container.firstElementChild;
+    expect(anchor.tagName).toBe('A');
+  });
+
+  it("renders an anchor with href attribute when 'href' prop are defined", async () => {
+    const dummyHref = 'ibm.com';
+    const { container } = render(CvLink, {
+      props: { href: dummyHref },
+    });
+
+    const anchor = container.firstElementChild;
+    expect(anchor.tagName).toBe('A');
+    expect(anchor.getAttribute('href')).toBe(dummyHref);
+  });
+
+  it("renders an anchor with href attribute when both 'href' and 'to' prop are defined", async () => {
+    const dummyHref = '/path-href';
+    const { container } = render(CvLink, {
+      props: { href: dummyHref, to: '/path-to' },
+    });
+
+    const anchor = container.firstElementChild;
+    expect(anchor.tagName).toBe('A');
+    expect(anchor.getAttribute('href')).toBe(dummyHref);
+  });
+
+  it("renders a 'router-link' when 'to' prop is passed", async () => {
+    const dummyTo = '/dummy-path';
+    const { container } = render(CvLink, {
+      props: { to: dummyTo },
+      global: { stubs: ['router-link'] },
+    });
+
+    const routerLink = container.firstChild;
+    expect(routerLink.tagName).toBe('ROUTER-LINK-STUB');
+    expect(routerLink.getAttribute('to')).toBe(dummyTo);
+  });
+
+  it("renders link in disabled state when 'disabled' is true", () => {
+    const { container } = render(CvLink, {
+      props: { disabled: true, href: '/home' },
+    });
+
+    const element = container.firstElementChild;
+    expect(element.classList.contains('bx--link--disabled')).toBe(true);
+    expect(element.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it("sets link inline carbon class when 'inline' prop is passed", () => {
+    const { container } = render(CvLink, {
+      props: { inline: true, href: '/home' },
+    });
+
+    const element = container.firstElementChild;
+    expect(element.classList.contains('bx--link--inline')).toBe(true);
+  });
+});

--- a/src/components/CvLink/__tests__/CvLink.spec.js
+++ b/src/components/CvLink/__tests__/CvLink.spec.js
@@ -69,4 +69,13 @@ describe('CvLink', () => {
     const element = container.firstElementChild;
     expect(element.classList.contains('bx--link--inline')).toBe(true);
   });
+
+  it("sets link in visited state when 'visited' is true", () => {
+    const { container } = render(CvLink, {
+      props: { visited: true },
+    });
+
+    const element = container.firstElementChild;
+    expect(element.classList.contains('bx--link--visited')).toBe(true);
+  });
 });

--- a/src/components/CvLink/index.js
+++ b/src/components/CvLink/index.js
@@ -1,0 +1,4 @@
+import CvLink from './CvLink.vue';
+
+export { CvLink };
+export default CvLink;

--- a/src/use/cvLink.js
+++ b/src/use/cvLink.js
@@ -3,10 +3,17 @@
  */
 import { computed } from 'vue';
 
+export const linkSizes = ['sm', 'md', 'lg'];
+
 export const props = {
   disabled: Boolean,
   to: { type: [String, Object] },
   href: String,
+  size: {
+    type: String,
+    validator: size => linkSizes.includes(size),
+    default: 'md',
+  },
 };
 
 export const useTagType = props => {

--- a/src/use/cvLink.js
+++ b/src/use/cvLink.js
@@ -23,6 +23,7 @@ export const useLinkProps = props => {
     if (props.disabled) {
       return {
         'aria-disabled': true,
+        role: 'link',
       };
     } else if (props.to && !props.href) {
       return { to: props.to };


### PR DESCRIPTION
Contributes to #1434 

## What did you do?
Port CvLink component to vue3, covering the same functionalities at the vue2 implementation and a small update in 'useLinkProps' to also add 'role' attribute when link is disabled.

Edit: I've also left the story more like the react one: a child story for each 'state' instead of how it's in vue2.

## How have you tested it?
Yes. Although, Since most tests assert template changes based on props received, they are not exactly following `@testing-library`'s guidelines on replicating user behavior. 

## Were docs updated if needed?

- [ ] N/A
- [ ] No
- [x] Yes
