### PR TITLE
fix: sb vue2 & vue3 paths

### DIFF
--- a/storybook/_storybook/views/sv-template-view/sv-versions.vue
+++ b/storybook/_storybook/views/sv-template-view/sv-versions.vue
@@ -15,7 +15,7 @@
     <div class="versions__info">
       <div class="bx--row">
         <div class="bx--no-gutter-md--left bx--col-md-4 bx--col-lg-4">
-          <a class="versions__card" href="/carbon-components-vue/vue3/">
+          <a class="versions__card" :href="vue3Url">
             <div class="bx--aspect-ratio bx--aspect-ratio--2x1">
               <div class="bx--aspect-ratio--object">
                 <div class="versions__card-content">
@@ -41,7 +41,7 @@
           </a>
         </div>
         <div class="bx--no-gutter-md--left bx--col-md-4 bx--col-lg-4">
-          <a class="versions__card" href="/?path=/story/welcome--default">
+          <a class="versions__card" :href="vue2Url">
             <div class="bx--aspect-ratio bx--aspect-ratio--2x1">
               <div class="bx--aspect-ratio--object">
                 <div class="versions__card-content">
@@ -103,12 +103,19 @@
 <script>
 export default {
   name: 'SvVersions',
-};
-</script>
-
-<script>
-export default {
-  name: 'SvVersions',
+  computed: {
+    prefix() {
+      const currentLocation = window.location;
+      if (currentLocation.pathname.includes('/carbon-components-vue/')) return '/carbon-components-vue';
+      return '';
+    },
+    vue3Url() {
+      return `${this.prefix}/vue3/`;
+    },
+    vue2Url() {
+      return `${this.prefix}/?path=/story/welcome--default`;
+    },
+  },
 };
 </script>
 

--- a/storybook/_storybook/views/sv-template-view/sv-welcome.vue
+++ b/storybook/_storybook/views/sv-template-view/sv-welcome.vue
@@ -58,7 +58,7 @@
           </a>
         </div>
         <div class="bx--no-gutter-md--left bx--col-md-4 bx--col-lg-4">
-          <a class="welcome__card" href="/?path=/story/versions--default">
+          <a class="welcome__card" :href="vue2Url">
             <div class="bx--aspect-ratio bx--aspect-ratio--2x1">
               <div class="bx--aspect-ratio--object">
                 <div class="welcome__card-content">
@@ -83,7 +83,7 @@
           </a>
         </div>
         <div class="bx--no-gutter-md--left bx--col-md-4 bx--col-lg-4">
-          <a class="welcome__card" href="/carbon-components-vue/vue3/">
+          <a class="welcome__card" :href="vue3Url">
             <div class="bx--aspect-ratio bx--aspect-ratio--2x1">
               <div class="bx--aspect-ratio--object">
                 <div class="welcome__card-content">
@@ -157,7 +157,7 @@
             <a
               target="blank"
               href="https://github.com/carbon-design-system/carbon-components-vue/issues/new/choose"
-              style="text-decoration: underline;"
+              style="text-decoration: underline"
               >GitHub.</a
             >
           </p>
@@ -213,6 +213,17 @@ export default {
         day: 'numeric',
         year: 'numeric',
       });
+    },
+    prefix() {
+      const currentLocation = window.location;
+      if (currentLocation.pathname.includes('/carbon-components-vue/')) return '/carbon-components-vue';
+      return '';
+    },
+    vue3Url() {
+      return `${this.prefix}/vue3/`;
+    },
+    vue2Url() {
+      return `${this.prefix}/?path=/story/versions--default`;
     },
   },
 };


### PR DESCRIPTION
## What did you do?


Changed the links in the vue3 vue2 storybooks to properly point to the vue2/vue3 versions. 

## Why did you do it?

The combined storybook build and deployed worked great. The links:
- vue2 is here https://vue.carbondesignsystem.com/?path=/story/welcome--default
- vue3 is here https://vue.carbondesignsystem.com/vue3/?path=/story/carbon--welcome

However the links in the storkbooks to vue3 are broken. ☹️ 

The current link to vue3 is `https://vue.carbondesignsystem.com/carbon-components-vue/vue3/`
Notice the extra **carbon-components-vue** in the path. This is because when testing with GitHub pages, the repo name is part of the path but when accessed via the custom domain, its not there. 

I added a compute property to calculate the vue2 & vue3 URLs based on if `carbon-components-vue` is in the URL path or not. When building and testing locally it is not there and so the path to vue3 is just "/vue3". When building an testing in my own repo the "carbon-components-vue" is part of the path and so the path to vue3 is "/carbon-components-vue/vue3/"
https://davidnixon.github.io/carbon-components-vue/?path=/story/welcome--default
https://davidnixon.github.io/carbon-components-vue/vue3/?path=/story/carbon--welcome

## How have you tested it?

Locally and in my own GitHub pages deploy.

## Were docs updated if needed?

- [x] N/A
