### PR TITLE
fix: change title and change @3 to @v3

### DIFF
--- a/.github/workflows/release-vNext.yml
+++ b/.github/workflows/release-vNext.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release vNext
 
 on:
   workflow_dispatch:
@@ -23,7 +23,7 @@ jobs:
           git config user.email github-actions@github.com
 
       - name: Use Node.js 18.x
-        uses: actions/setup-node@3 # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3 # https://github.com/actions/setup-node
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
## What did you do?

Change title of release workflow for vNext and change typo in `actions/setup-node@v3`

## Why did you do it?

https://github.com/carbon-design-system/carbon-components-vue/actions/runs/4515376724/jobs/7952598848

## Were docs updated if needed?

- [x] N/A
