### PR TITLE
fix: datepicker issue for mobile

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,32 +5,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [2.45.1](https://github.com/carbon-design-system/carbon-components-vue/compare/@carbon/vue@2.45.0...@carbon/vue@2.45.1) (2023-01-24)
 
-
 ### Bug Fixes
 
-* set aria role seperator on modal before/after content ([#1409](https://github.com/carbon-design-system/carbon-components-vue/issues/1409)) ([21b3756](https://github.com/carbon-design-system/carbon-components-vue/commit/21b375650de2e020ff96c5e3810e3393bbd318a8))
-
-
-
-
+- set aria role seperator on modal before/after content ([#1409](https://github.com/carbon-design-system/carbon-components-vue/issues/1409)) ([21b3756](https://github.com/carbon-design-system/carbon-components-vue/commit/21b375650de2e020ff96c5e3810e3393bbd318a8))
 
 # [2.45.0](https://github.com/carbon-design-system/carbon-components-vue/compare/@carbon/vue@2.44.2...@carbon/vue@2.45.0) (2023-01-10)
 
-
 ### Bug Fixes
 
-* **combo box:** set filter correctly for inital value ([f43a0b9](https://github.com/carbon-design-system/carbon-components-vue/commit/f43a0b97b73b988c8bdcb39ecc677d9b7ab024c2))
-* **cv-data-table:** fix searchbox role ([51f0ebb](https://github.com/carbon-design-system/carbon-components-vue/commit/51f0ebb763f2e2b5a8de77c3f8c5b32e789bbb7b))
-* tag close button should have type button ([fa57623](https://github.com/carbon-design-system/carbon-components-vue/commit/fa57623e173088d06cc23994d6aac3c842fb91a7))
-
+- **combo box:** set filter correctly for inital value ([f43a0b9](https://github.com/carbon-design-system/carbon-components-vue/commit/f43a0b97b73b988c8bdcb39ecc677d9b7ab024c2))
+- **cv-data-table:** fix searchbox role ([51f0ebb](https://github.com/carbon-design-system/carbon-components-vue/commit/51f0ebb763f2e2b5a8de77c3f8c5b32e789bbb7b))
+- tag close button should have type button ([fa57623](https://github.com/carbon-design-system/carbon-components-vue/commit/fa57623e173088d06cc23994d6aac3c842fb91a7))
 
 ### Features
 
-* update carbon versions ([05ba3e4](https://github.com/carbon-design-system/carbon-components-vue/commit/05ba3e487ac975b04b7de1a10d8b3363add6756d))
-
-
-
-
+- update carbon versions ([05ba3e4](https://github.com/carbon-design-system/carbon-components-vue/commit/05ba3e487ac975b04b7de1a10d8b3363add6756d))
 
 ## [2.44.2](https://github.com/carbon-design-system/carbon-components-vue/compare/@carbon/vue@2.44.1...@carbon/vue@2.44.2) (2022-12-02)
 

--- a/packages/core/src/components/cv-date-picker/cv-date-picker.vue
+++ b/packages/core/src/components/cv-date-picker/cv-date-picker.vue
@@ -250,6 +250,9 @@ export default {
         <rect width="16" height="16" style="fill:none" />
       </svg>`;
 
+      // issue with flatpickr package https://github.com/flatpickr/flatpickr/issues/1508
+      _options.disableMobile = true;
+
       return _options;
     },
     onChange() {


### PR DESCRIPTION
Contributes to #

## What did you do?
I created a pull request for the current date time picker component library, modifying the datetime picker to have the option disableMobile: true. This change disables the automatic detection of mobile browsers by the flatpickr library and prevents the issue of turning the date input into a native date/time/datetime input when it is not desired.

## Why did you do it?
The flatpickr library has a known issue, as reported in their GitHub repository (https://github.com/flatpickr/flatpickr/issues/1115), where the automatic detection of mobile browsers may not work as intended. This temporary fix allows users to avoid the problem until a more permanent solution is implemented by the flatpickr team.

## How have you tested it?
I tested the changes on various devices and browsers, including mobile and desktop environments, to ensure that the datetime picker now behaves as expected and does not automatically convert the date input to a native input type on mobile browsers.

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
