### PR TITLE
fix: update vNext README.md file to include storybook instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,22 @@ If you just want to build an individual package you can limit the scope:
 `yarn build --scope storybook`
 
 To start the storybook in a local server use `yarn start`.
+
+## How to run the storybook
+
+:bulb: **In this case, it's best to run using `npm`!**
+
+Just follow the steps listed below and you will be able to run the storybook.
+
+1. After the checkout to the `vNext` branch, in order to install the dependencies run the command `npm i` on the root;
+2. Now, run the command `cd storybook` to enter the storybook folder, then again run the command `npm i` to install the dependencies inside the storybook folder;
+3. Finally, run the command `npm run serve` inside the storybook folder.
+
+In other words, these are the commands you're going to use in order of execution:
+
+```
+npm i
+cd storybook
+npm i
+npm run serve
+```

--- a/README.md
+++ b/README.md
@@ -86,6 +86,5 @@ In other words, these are the commands you're going to use in order of execution
 ```
 yarn install
 cd storybook
-yarn install
 yarn serve
 ```

--- a/README.md
+++ b/README.md
@@ -75,19 +75,17 @@ To start the storybook in a local server use `yarn start`.
 
 ## How to run the storybook
 
-:bulb: **In this case, it's best to run using `npm`!**
-
 Just follow the steps listed below and you will be able to run the storybook.
 
-1. After the checkout to the `vNext` branch, in order to install the dependencies run the command `npm i` on the root;
-2. Now, run the command `cd storybook` to enter the storybook folder, then again run the command `npm i` to install the dependencies inside the storybook folder;
-3. Finally, run the command `npm run serve` inside the storybook folder.
+1. After the checkout to the `vNext` branch, in order to install the dependencies run the command `yarn install` on the root;
+2. Now, run the command `cd storybook` to enter the storybook folder, then again run the command `yarn install` to install the dependencies inside the storybook folder;
+3. Finally, run the command `yarn serve` inside the storybook folder.
 
 In other words, these are the commands you're going to use in order of execution:
 
 ```
-npm i
+yarn install
 cd storybook
-npm i
-npm run serve
+yarn install
+yarn serve
 ```


### PR DESCRIPTION
Contributes to `vNext` README.md file

## What did you do?
Update of the README.md file, adding the instructions on how to run the storybook.

## Why did you do it?
Because these instructions can help new contributors test their components.

## How have you tested it?
By watching the README.md file in my fork.

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes