### PR TITLE
fix(cv-button): fix CvButton stories, where buttons are blank (label …

### DIFF
--- a/src/components/CvButton/CvButton.stories.js
+++ b/src/components/CvButton/CvButton.stories.js
@@ -87,7 +87,7 @@ Secondary.parameters = storyParametersObject(
 
 export const Field = Template.bind({});
 Field.args = {
-  'slotArgs.default': 'Field size',
+  default: 'Field size',
   size: 'field',
 };
 Field.parameters = storyParametersObject(
@@ -98,7 +98,7 @@ Field.parameters = storyParametersObject(
 
 export const Small = Template.bind({});
 Small.args = {
-  'slotArgs.default': 'sm',
+  default: 'sm',
   size: 'sm',
 };
 Small.parameters = storyParametersObject(
@@ -109,7 +109,7 @@ Small.parameters = storyParametersObject(
 
 export const Large = Template.bind({});
 Large.args = {
-  'slotArgs.default': 'Large size',
+  default: 'Large size',
   size: 'lg',
 };
 Large.parameters = storyParametersObject(


### PR DESCRIPTION
…is not shown)

Contributes to RFC from PR #1470

## What did you do?
Fixed stories with buttons without labels

## Why did you do it?
requested in PR #1470

## How have you tested it?
Visually in Storybook
![image](https://github.com/carbon-design-system/carbon-components-vue/assets/20342514/4734d06b-34c4-47b8-ae27-81954a9c3d8a)


## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
