### PR TITLE
feat: cv-toast-notification add more slots

### DIFF
--- a/src/components/CvNotification/CvToastNotification.stories.js
+++ b/src/components/CvNotification/CvToastNotification.stories.js
@@ -58,10 +58,56 @@ export default {
     lowContrast: {
       control: { type: 'boolean' },
     },
+    // slots
+    default: {
+      table: {
+        type: { summary: 'string | html | Component' },
+        category: 'slots',
+      },
+      description: 'Slot for additional custom content.',
+    },
+    'title ': {
+      table: {
+        type: { summary: 'string | html | Component' },
+        category: 'slots',
+      },
+      description: 'Title slot for more custom content.',
+    },
+    subtitle: {
+      table: {
+        type: { summary: 'string | html | Component' },
+        category: 'slots',
+      },
+      description: 'Subtitle slot for more custom content.',
+    },
+    'caption ': {
+      table: {
+        type: { summary: 'string | html | Component' },
+        category: 'slots',
+      },
+      description: 'Caption slot for more custom content.',
+    },
   },
 };
 
-const template = `<cv-toast-notification v-bind="args" @close="onClose" />`;
+const template = `
+<cv-toast-notification v-bind="args" @close="onClose" >
+  <template v-if="args.titleSlot" #title>
+    <strong style="color: orange; font-size: 1.25rem;">Custom</strong> <span style="color: yellow;">title</span>
+  </template>
+
+  <template v-if="args.subtitleSlot" #subtitle>
+    Some <strong style="color: orange; font-size: 1.25rem;">custom</strong> <span style="color: yellow;">subtitle</span>
+  </template>
+
+  <template v-if="args.captionSlot" #caption>
+    Some <span style="color: green;">custom</span> <strong style="color: orange; font-size: 0.75rem;">caption</strong>
+  </template>
+
+  <template v-if="args.defaultSlot">
+    Default slot content.
+  </template>
+</cv-toast-notification>`;
 const Template = args => {
   return {
     components: { CvToastNotification },
@@ -105,4 +151,28 @@ WarningAlt.args = {
 export const Error = Template.bind({});
 Error.args = {
   kind: CvNotificationConsts.notificationKinds[5],
+};
+
+export const SlotDefault = Template.bind({});
+SlotDefault.args = {
+  kind: CvNotificationConsts.notificationKinds[4],
+  defaultSlot: true,
+};
+
+export const SlotTitle = Template.bind({});
+SlotTitle.args = {
+  kind: CvNotificationConsts.notificationKinds[0],
+  titleSlot: true,
+};
+
+export const SlotSubtitle = Template.bind({});
+SlotSubtitle.args = {
+  kind: CvNotificationConsts.notificationKinds[3],
+  subtitleSlot: true,
+};
+
+export const SlotCaption = Template.bind({});
+SlotCaption.args = {
+  kind: CvNotificationConsts.notificationKinds[1],
+  captionSlot: true,
 };

--- a/src/components/CvNotification/CvToastNotification.vue
+++ b/src/components/CvNotification/CvToastNotification.vue
@@ -13,12 +13,14 @@
       :class="`${carbonPrefix}--toast-notification__icon`"
     />
     <div :class="`${carbonPrefix}--toast-notification__details`">
-      <h3 :class="`${carbonPrefix}--toast-notification__title`">{{ title }}</h3>
+      <h3 :class="`${carbonPrefix}--toast-notification__title`">
+        <slot name="title">{{ title }}</slot>
+      </h3>
       <div :class="`${carbonPrefix}--toast-notification__subtitle`">
-        {{ subTitle }}
+        <slot name="subtitle">{{ subTitle }}</slot>
       </div>
       <div :class="`${carbonPrefix}--toast-notification__caption`">
-        {{ caption }}
+        <slot name="caption">{{ caption }}</slot>
       </div>
       <slot />
     </div>
@@ -28,7 +30,7 @@
       :class="`${carbonPrefix}--toast-notification__close-button`"
       @click="$emit('close')"
     >
-      <close20 :class="`${carbonPrefix}--inline-notification__close-icon`" />
+      <close20 :class="`${carbonPrefix}--toast-notification__close-icon`" />
     </button>
   </div>
 </template>

--- a/src/components/CvNotification/__tests__/CvToastNotification.spec.js
+++ b/src/components/CvNotification/__tests__/CvToastNotification.spec.js
@@ -1,7 +1,7 @@
 /**
  * NOTE: This test needs to be converted to use the new library `@testing-library/vue`. See CvCheckbox test for example.
  */
-import { mount } from '@vue/test-utils';
+import { mount, shallowMount } from '@vue/test-utils';
 import { carbonPrefix } from '../../../global/settings';
 
 import { CvToastNotification, CvNotificationConsts } from '..';
@@ -93,5 +93,25 @@ describe('CvToastNotification', () => {
     await closeButton.trigger('click');
 
     expect(wrapper.emitted().close).toBeTruthy();
+  });
+
+  test.each([
+    ['default', `${carbonPrefix}--toast-notification__details`],
+    ['title', `${carbonPrefix}--toast-notification__title`],
+    ['subtitle', `${carbonPrefix}--toast-notification__subtitle`],
+    ['caption', `${carbonPrefix}--toast-notification__caption`],
+  ])('Renders %s slot content', async (slotName, immediateParentClass) => {
+    const SlotTestId = slotName;
+    const wrapper = shallowMount(CvToastNotification, {
+      slots: {
+        [slotName]: `<div test-id="${SlotTestId}">Test</div>`,
+      },
+    });
+
+    const defaultSlotContent = wrapper.find(
+      `.${immediateParentClass} > [test-id=${SlotTestId}]`
+    );
+
+    expect(defaultSlotContent.exists()).toBe(true);
   });
 });


### PR DESCRIPTION
Contributes to #1514

## What did you do?
Added more slots to CvToastNotification
btw. fixed toast notification close button class name

## Why did you do it?
To give more granular control over component content

## How have you tested it?
added test suits to spec.js

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
