### PR TITLE
feat: cv-text-area-skeleton ported from React to Vue3

### DIFF
--- a/src/components/CvTextArea/CvTextArea.stories.js
+++ b/src/components/CvTextArea/CvTextArea.stories.js
@@ -2,12 +2,12 @@ import {
   sbCompPrefix,
   storyParametersObject,
 } from '../../global/storybook-utils';
-
+import { StorybookGroupConst } from './StorybookGroupConst';
 import CvTextArea from '.';
 import { ref } from 'vue';
 
 export default {
-  title: `${sbCompPrefix}/CvTextArea`,
+  title: `${sbCompPrefix}/${StorybookGroupConst}/CvTextArea`,
   component: CvTextArea,
   argTypes: {
     // attrs

--- a/src/components/CvTextArea/CvTextAreaSkeleton.stories.js
+++ b/src/components/CvTextArea/CvTextAreaSkeleton.stories.js
@@ -11,9 +11,8 @@ export default {
 };
 
 const template = `<cv-text-area-skeleton></cv-text-area-skeleton>`;
-const Template = (args, { argTypes }) => {
+const Template = args => {
   return {
-    props: Object.keys(argTypes),
     components: { CvTextAreaSkeleton },
     template,
     setup() {

--- a/src/components/CvTextArea/CvTextAreaSkeleton.stories.js
+++ b/src/components/CvTextArea/CvTextAreaSkeleton.stories.js
@@ -1,0 +1,30 @@
+import {
+  sbCompPrefix,
+  storyParametersObject,
+} from '../../global/storybook-utils';
+import { StorybookGroupConst } from './StorybookGroupConst';
+import { CvTextAreaSkeleton } from './';
+
+export default {
+  title: `${sbCompPrefix}/${StorybookGroupConst}/CvTextAreaSkeleton`,
+  component: CvTextAreaSkeleton,
+};
+
+const template = `<cv-text-area-skeleton></cv-text-area-skeleton>`;
+const Template = (args, { argTypes }) => {
+  return {
+    props: Object.keys(argTypes),
+    components: { CvTextAreaSkeleton },
+    template,
+    setup() {
+      return { args };
+    },
+  };
+};
+
+export const Default = Template.bind({});
+Default.parameters = storyParametersObject(
+  Default.parameters,
+  template,
+  Default.args
+);

--- a/src/components/CvTextArea/CvTextAreaSkeleton.vue
+++ b/src/components/CvTextArea/CvTextAreaSkeleton.vue
@@ -1,0 +1,10 @@
+<template>
+  <div :class="`${carbonPrefix}--form-item`">
+    <label :class="`${carbonPrefix}--label ${carbonPrefix}--skeleton`" />
+    <div :class="`${carbonPrefix}--text-area ${carbonPrefix}--skeleton`" />
+  </div>
+</template>
+
+<script setup>
+import { carbonPrefix } from '../../global/settings';
+</script>

--- a/src/components/CvTextArea/StorybookGroupConst.js
+++ b/src/components/CvTextArea/StorybookGroupConst.js
@@ -1,0 +1,1 @@
+export const StorybookGroupConst = 'CvTextArea';

--- a/src/components/CvTextArea/__tests__/CvTextAreaSkeleton.spec.js
+++ b/src/components/CvTextArea/__tests__/CvTextAreaSkeleton.spec.js
@@ -1,0 +1,21 @@
+import { shallowMount } from '@vue/test-utils';
+import { carbonPrefix } from '../../../global/settings';
+import { CvTextAreaSkeleton } from '../';
+
+describe('CvTextAreaSkeleton', () => {
+  it('should match snapshot', async () => {
+    const wrapper = await shallowMount(CvTextAreaSkeleton);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it('renders text area skeleton', () => {
+    const wrapper = shallowMount(CvTextAreaSkeleton);
+
+    const skeletonLabel = wrapper.find(`.${carbonPrefix}--label`);
+    const skeletonInput = wrapper.find(`.${carbonPrefix}--text-area`);
+    const expectedSkeletonClass = `${carbonPrefix}--skeleton`;
+
+    expect(skeletonLabel.classes()).toContain(expectedSkeletonClass);
+    expect(skeletonInput.classes()).toContain(expectedSkeletonClass);
+  });
+});

--- a/src/components/CvTextArea/__tests__/__snapshots__/CvTextAreaSkeleton.spec.js.snap
+++ b/src/components/CvTextArea/__tests__/__snapshots__/CvTextAreaSkeleton.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CvTextAreaSkeleton should match snapshot 1`] = `
+<div class="bx--form-item"><label class="bx--label bx--skeleton"></label>
+  <div class="bx--text-area bx--skeleton"></div>
+</div>
+`;

--- a/src/components/CvTextArea/index.js
+++ b/src/components/CvTextArea/index.js
@@ -1,4 +1,5 @@
 import CvTextArea from './CvTextArea.vue';
+import CvTextAreaSkeleton from './CvTextAreaSkeleton';
 
-export { CvTextArea };
+export { CvTextArea, CvTextAreaSkeleton };
 export default CvTextArea;


### PR DESCRIPTION
Contributes to #1516

## What did you do?
Ported CvTextAreaSkeleton from React to Vue3

## How have you tested it?
added spec.js

## Were docs updated if needed?

- [ ] N/A
- [ ] No
- [x] Yes
