### PR TITLE
docs: cv-file-uploader docs enhancements

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -7,6 +7,8 @@
 
 import { addons } from '@storybook/addons';
 import theme from './theme';
+import React from 'react';
+import { Form } from '@storybook/components';
 
 addons.setConfig({
   theme,
@@ -16,3 +18,24 @@ addons.setConfig({
 // conditional panels, or other things that get in the way of our workflow
 localStorage.removeItem('@storybook/ui/store');
 localStorage.removeItem('storybook-layout');
+
+/**
+ * This is a **workaround** due to the lack of a 'button' control in storybook.
+ * It relies on postinstall.js defining `window["STORYBOOK_CUSTOM_CONTROLS"]`
+ * as a fallback object, at @storybook/components module, when storybook looks
+ * for a control type.
+ */
+window['STORYBOOK_CUSTOM_CONTROLS'] = {
+  button({ argType, value, onChange }) {
+    return React.createElement(
+      Form.Button,
+      {
+        onClick() {
+          value = typeof value === 'number' ? value : 0;
+          onChange(value + 1);
+        },
+      },
+      argType.buttonLabel || argType.name
+    );
+  },
+};

--- a/.storybook/postinstall.js
+++ b/.storybook/postinstall.js
@@ -1,0 +1,38 @@
+const { resolve } = require('path');
+const { readFileSync, writeFileSync } = require('fs');
+
+/**
+ * This is a fragile **workaround** to customize new storybook controls.
+ *
+ * Currently, storybook lack the option to create customizable controls, as an option for
+ * knobs. This hack allow us to define our own control types, that should be defined at
+ * `window["STORYBOOK_CUSTOM_CONTROLS"]`, created at manager.js.
+ *
+ * This solution, along with the button control defined at manager.js, was found in a discussion
+ * about a new button control type:
+ * https://github.com/storybookjs/storybook/issues/11971#issuecomment-1240831460
+ */
+
+addCustomControls();
+
+function addCustomControls() {
+  const file = resolve(
+    'node_modules',
+    '@storybook',
+    'components',
+    'dist',
+    'esm',
+    'index-681e4b07.js'
+  );
+  replaceInFile(
+    file,
+    'var Control=Controls[control.type]||NoControl',
+    'var Control=(Object.assign({}, Controls, (window["STORYBOOK_CUSTOM_CONTROLS"] || {})))[control.type]||NoControl'
+  );
+}
+
+function replaceInFile(file, search, value) {
+  let content = readFileSync(file, 'utf-8');
+  content = content.replace(search, value);
+  writeFileSync(file, content, 'utf-8');
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "types": "src/index.d.ts",
   "web-types": "dist/web-types.json",
   "scripts": {
-    "postinstall": "node prepare.js",
+    "postinstall": "node prepare.js && node .storybook/postinstall.js",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
     "build": "vue-cli-service build --target lib --name carbon-vue-3 ./src/index.js --no-clean",

--- a/src/components/CvFileUploader/CvFileUploader.stories.mdx
+++ b/src/components/CvFileUploader/CvFileUploader.stories.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Canvas, Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import { sbCompPrefix } from '../../global/storybook-utils';
 import { CvFileUploader, CvFileUploaderSkeleton } from '.';
 import { KINDS, STATES } from './const';
@@ -299,6 +299,8 @@ Migration notes:
     {Template.bind({})}
   </Story>
 </Canvas>
+
+<ArgsTable story="Default" />
 
 # CvFileUploader Button
 

--- a/src/components/CvFileUploader/CvFileUploader.stories.mdx
+++ b/src/components/CvFileUploader/CvFileUploader.stories.mdx
@@ -19,6 +19,13 @@ export const Template = args => ({
     const fileUploader = ref(null);
     const files = ref(storage.files);
     // exposed methods handlers
+    function clear() {
+      if (args.clear && args.clear > storage.clearCount) {
+        storage.clearCount = args.clear;
+        fileUploader.value.clear();
+        action('cv-file-uploader clear')()
+      }
+    }
     function setInvalidMessage(index) {
       if (files.value[index].invalidMessage !== args.setInvalidMessage) {
         fileUploader.value.setInvalidMessage(index, args.setInvalidMessage);
@@ -45,6 +52,7 @@ export const Template = args => ({
       changeFiles();
     }, { deep: true });
     onMounted(() => {
+      clear();
       changeFiles();
     });
     return {
@@ -61,6 +69,7 @@ export const Template = args => ({
 });
 const storage = {
   files: [],
+  clearCount: 0,
 };
 const setStateOptionMap = {
   [`Set files status to: None`]: STATES.NONE,
@@ -219,7 +228,8 @@ export const argTypes = {
   },
   // exposed methods
   clear: {
-    control: 'none',
+    control: 'button',
+    buttonLabel: 'Clear',
     type: 'function',
     table: {
       type: { summary: '() => void' },

--- a/src/components/CvFileUploader/CvFileUploader.stories.mdx
+++ b/src/components/CvFileUploader/CvFileUploader.stories.mdx
@@ -26,6 +26,14 @@ export const Template = args => ({
         action('cv-file-uploader clear')()
       }
     }
+    function remove() {
+      if (args.remove && args.remove > storage.removeCount && files.value.length > 0) {
+        const randomIndex = Math.floor(Math.random() * files.value.length);
+        storage.removeCount = args.remove;
+        fileUploader.value.remove(randomIndex);
+        action('cv-file-uploader remove')(randomIndex)
+      }
+    }
     function setInvalidMessage(index) {
       if (files.value[index].invalidMessage !== args.setInvalidMessage) {
         fileUploader.value.setInvalidMessage(index, args.setInvalidMessage);
@@ -53,6 +61,7 @@ export const Template = args => ({
     }, { deep: true });
     onMounted(() => {
       clear();
+      remove();
       changeFiles();
     });
     return {
@@ -70,6 +79,7 @@ export const Template = args => ({
 const storage = {
   files: [],
   clearCount: 0,
+  removeCount: 0,
 };
 const setStateOptionMap = {
   [`Set files status to: None`]: STATES.NONE,
@@ -238,7 +248,8 @@ export const argTypes = {
     description: 'Clear file list',
   },
   remove: {
-    control: 'none',
+    control: 'button',
+    buttonLabel: 'Remove a random file',
     type: 'function',
     table: {
       type: { summary: '(index: number) => void' },

--- a/src/components/CvFileUploader/CvFileUploader.stories.mdx
+++ b/src/components/CvFileUploader/CvFileUploader.stories.mdx
@@ -274,7 +274,7 @@ export const argTypes = {
       type: { summary: '(index: number, state: string) => void' },
       category: 'exposed methods',
     },
-    description: 'Update the "state" field of a file. State must be `""`, `complete` or `loading`',
+    description: 'Update the "state" field of a file. State must be `""`, `complete` or `uploading`',
   },
   // slots
   'drop-target': {

--- a/src/components/CvFileUploader/CvFileUploader.stories.mdx
+++ b/src/components/CvFileUploader/CvFileUploader.stories.mdx
@@ -1,9 +1,9 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
 import { sbCompPrefix } from '../../global/storybook-utils';
 import { CvFileUploader, CvFileUploaderSkeleton } from '.';
-import { KINDS } from './const';
+import { KINDS, STATES } from './const';
 import { action } from '@storybook/addon-actions';
-import { nextTick, ref, watch } from 'vue';
+import { nextTick, ref, watch, onMounted } from 'vue';
 import { Add16 } from '@carbon/icons-vue';
 import { buttonKinds, buttonSizes } from '../CvButton/consts';
 
@@ -16,11 +16,39 @@ export const Template = args => ({
     Add16
   },
   setup() {
+    const fileUploader = ref(null);
     const files = ref(storage.files);
+    // exposed methods handlers
+    function setInvalidMessage(index) {
+      if (files.value[index].invalidMessage !== args.setInvalidMessage) {
+        fileUploader.value.setInvalidMessage(index, args.setInvalidMessage);
+        action('cv-file-uploader setInvalidMessage')(index, args.setInvalidMessage);
+      }
+    }
+    function setState(index) {
+      const newState = setStateOptionMap[args.setState];
+      if (files.value[index].state !== newState) {
+        fileUploader.value.setState(index, newState);
+        action('cv-file-uploader setState')(index, newState);
+      }
+    }
+    // exposed methods setState & setInvalidMessage handler
+    function changeFiles() {
+      const callbacks = [
+        typeof args.setState === 'string' ? setState : null,
+        typeof args.setInvalidMessage === 'string' ? setInvalidMessage : null,
+      ];
+      files.value.forEach((_, index) => callbacks.forEach(callback => callback && callback(index)));
+    }
     watch(() => files.value, (newValue) => {
       storage.files = newValue;
+      changeFiles();
     }, { deep: true });
+    onMounted(() => {
+      changeFiles();
+    });
     return {
+      fileUploader,
       files,
       slotContent: args.slot,
       args: {
@@ -34,9 +62,14 @@ export const Template = args => ({
 const storage = {
   files: [],
 };
+const setStateOptionMap = {
+  [`Set files status to: None`]: STATES.NONE,
+  [`Set files status to: Complete (${STATES.COMPLETE})`]: STATES.COMPLETE,
+  [`Set files status to: Uploading (${STATES.UPLOADING})`]: STATES.UPLOADING,
+};
 const defaultTemplate = `
   <div style="display: inline-flex; align-items: flex-start;">
-    <cv-file-uploader v-bind="args" v-model="files" />
+    <cv-file-uploader v-bind="args" ref="fileUploader" v-model="files" />
   </div>
 `;
 const slotTemplate = `
@@ -203,23 +236,24 @@ export const argTypes = {
     },
     description: 'Removes an individual file',
   },
-  setState: {
-    control: 'none',
-    type: 'function',
-    table: {
-      type: { summary: '(index: number, state: string) => void' },
-      category: 'exposed methods',
-    },
-    description: 'Update the "state" field of a file. State must be `""`, `complete` or `loading`',
-  },
   setInvalidMessage: {
-    control: 'none',
+    control: 'text',
     type: 'function',
     table: {
       type: { summary: '(index: number, invalidMessage: string) => void' },
       category: 'exposed methods',
     },
     description: 'Update the "invalidMessage" field of a file.',
+  },
+  setState: {
+    control: 'select',
+    options: Object.keys(setStateOptionMap),
+    type: 'function',
+    table: {
+      type: { summary: '(index: number, state: string) => void' },
+      category: 'exposed methods',
+    },
+    description: 'Update the "state" field of a file. State must be `""`, `complete` or `loading`',
   },
   // slots
   'drop-target': {

--- a/src/components/CvFileUploader/CvFileUploader.stories.mdx
+++ b/src/components/CvFileUploader/CvFileUploader.stories.mdx
@@ -3,7 +3,7 @@ import { sbCompPrefix } from '../../global/storybook-utils';
 import { CvFileUploader, CvFileUploaderSkeleton } from '.';
 import { KINDS } from './const';
 import { action } from '@storybook/addon-actions';
-import { nextTick, ref } from 'vue';
+import { nextTick, ref, watch } from 'vue';
 import { Add16 } from '@carbon/icons-vue';
 import { buttonKinds, buttonSizes } from '../CvButton/consts';
 
@@ -16,7 +16,12 @@ export const Template = args => ({
     Add16
   },
   setup() {
+    const files = ref(storage.files);
+    watch(() => files.value, (newValue) => {
+      storage.files = newValue;
+    }, { deep: true });
     return {
+      files,
       slotContent: args.slot,
       args: {
         ...args,
@@ -26,9 +31,12 @@ export const Template = args => ({
   },
   template: args.template,
 });
+const storage = {
+  files: [],
+};
 const defaultTemplate = `
   <div style="display: inline-flex; align-items: flex-start;">
-    <cv-file-uploader v-bind="args" />
+    <cv-file-uploader v-bind="args" v-model="files" />
   </div>
 `;
 const slotTemplate = `

--- a/src/components/CvFileUploader/CvFileUploaderItem.vue
+++ b/src/components/CvFileUploader/CvFileUploaderItem.vue
@@ -9,8 +9,12 @@
       {{ item.file?.name }}
     </p>
     <span :class="`${carbonPrefix}--file__state-container`">
+      <WarningFilled16
+        v-if="isInvalid"
+        :class="`${carbonPrefix}--file--invalid`"
+      />
       <div
-        v-if="item.state === 'uploading'"
+        v-if="!isInvalid && item.state === 'uploading'"
         :class="`${carbonPrefix}--inline-loading__animation`"
       >
         <div
@@ -37,15 +41,12 @@
         </div>
       </div>
       <CheckmarkFilled16
-        v-if="item.state === 'complete'"
+        v-else-if="!isInvalid && item.state === 'complete'"
         :class="`${carbonPrefix}--file-complete`"
       />
-      <WarningFilled16
-        v-if="isInvalid"
-        :class="`${carbonPrefix}--file--invalid`"
-      />
+      <!-- "edit" state at react -->
       <button
-        v-if="removable"
+        v-else-if="removable"
         type="button"
         :class="`${carbonPrefix}--file-close`"
         :alt="removeAriaLabel"

--- a/src/components/CvFileUploader/__tests__/CvFileUploaderItem.spec.js
+++ b/src/components/CvFileUploader/__tests__/CvFileUploaderItem.spec.js
@@ -160,4 +160,61 @@ describe('CvFileUploaderItem', () => {
     );
     expect(removableButton).toBeDefined();
   });
+
+  it('favors invalid state representation instead of complete state', async () => {
+    const { container } = render(CvFileUploaderItem, {
+      props: {
+        item: {},
+        state: STATES.COMPLETE,
+        invalidMessage: 'random invalid message',
+      },
+    });
+
+    const warningIcon = await container.querySelector(
+      `.${carbonPrefix}--file--invalid`
+    );
+    const completeIcon = await container.querySelector(
+      `.${carbonPrefix}--file-complete`
+    );
+    expect(warningIcon).toBeDefined();
+    expect(completeIcon).toBeNull();
+  });
+
+  it('favors invalid state representation instead of uploading state', async () => {
+    const { container } = render(CvFileUploaderItem, {
+      props: {
+        item: {},
+        state: STATES.UPLOADING,
+        invalidMessage: 'random invalid message',
+      },
+    });
+
+    const warningIcon = await container.querySelector(
+      `.${carbonPrefix}--file--invalid`
+    );
+    const completeIcon = await container.querySelector(
+      `.${carbonPrefix}--inline-loading__animation`
+    );
+    expect(warningIcon).toBeDefined();
+    expect(completeIcon).toBeNull();
+  });
+
+  it('displays removable button when removable is true and file is also in invalid state', async () => {
+    const { container } = render(CvFileUploaderItem, {
+      props: {
+        item: {},
+        removable: true,
+        invalidMessage: 'random invalid message',
+      },
+    });
+
+    const warningIcon = await container.querySelector(
+      `.${carbonPrefix}--file--invalid`
+    );
+    const removableButton = await container.querySelector(
+      `button.${carbonPrefix}--file-close`
+    );
+    expect(warningIcon).toBeDefined();
+    expect(removableButton).toBeDefined();
+  });
 });


### PR DESCRIPTION
Contributes to #1519 

## What did you do?
- ~~Set '.jpg, .png' as initial values for `accept` prop, so users can check invalid state right away~~ (#1529)
- ~~Update button story label to better translate its state~~ (#1529)
- (WIP) allow user to play with the exposed methods

##  Why did you do it?
- Improve user experience / align the current documentation w/ react's

## How have you tested it?

## Were docs updated if needed?

- [X] Yes
