### PR TITLE
feat: add slot to gain control over tabs switching buttons

### DIFF
--- a/src/components/CvTabs/CvTabs.stories.mdx
+++ b/src/components/CvTabs/CvTabs.stories.mdx
@@ -53,7 +53,7 @@ const defaultTemplate = `
         To customise tab look, in CvTabs component use scoped slot named with tab's label.
         Example: current tab has label "<strong>House</strong>", so the code for customising tab looks like:
         <div style="background-color: lightgrey; padding: 0.5rem;">
-          &lt;template #House="tab"&gt;
+          &lt;template #tab-1="tab"&gt;
             {&nbsp;{ tab.label }&nbsp;} &lt;IbmSecurity20 /&gt;
           &lt;template&gt;
         </div>
@@ -69,7 +69,7 @@ const defaultTemplate = `
         To customise tab look, in CvTabs component use scoped slot named with tab's label.
         Example: current tab has label "<strong>Bar</strong>", so the code for customising tab looks like:
         <div style="background-color: lightgrey; padding: 0.5rem;">
-          &lt;template #Bar="tab"&gt;
+          &lt;template #tab-2="tab"&gt;
             {&nbsp;{ tab.label }&nbsp;} &lt;strong style="color: red;"&gt;(*)&lt;/strong&gt;
           &lt;template&gt;
         </div>
@@ -84,7 +84,7 @@ const defaultTemplate = `
         To customise tab look, in CvTabs component use scoped slot named with tab's label.
         Example: current tab has label "<strong>Reach</strong>", so the code for customising tab looks like:
         <div style="background-color: lightgrey; padding: 0.5rem;">
-          &lt;template #Reach="tab"&gt;
+          &lt;template #tab-3="tab"&gt;
             {&nbsp;{ tab.label }&nbsp;} &lt;strong style="color: orange;"&gt;(!)&lt;/strong&gt;
           &lt;template&gt;
         </div>
@@ -111,13 +111,13 @@ const defaultTemplate = `
         <a target='_blank' href='https://hitchhikers.fandom.com/wiki/Main_Page'>credits</a>
       </p>
     </cv-tab>
-    <template v-if="slottedTabs" #House="tab">
+    <template v-if="slottedTabs" #tab-1="tab">
       House <SampleIcon/>
     </template>
-    <template v-if="slottedTabs" #Bar="tab">
+    <template v-if="slottedTabs" #tab-2="tab">
       {{tab.label}} <strong style="color: red;">(*)</strong>
     </template>
-    <template v-if="slottedTabs" #Reach="tab">
+    <template v-if="slottedTabs" #tab-3="tab">
       {{tab.label}} <strong style="color: orange;">(!)</strong>
     </template>
 </cv-tabs>

--- a/src/components/CvTabs/CvTabs.stories.mdx
+++ b/src/components/CvTabs/CvTabs.stories.mdx
@@ -50,8 +50,8 @@ const defaultTemplate = `
   aria-label="navigation tab label">
     <cv-tab id="tab-1" label="House" :selected="selectedId === 'tab-1'" :disabled="disabledIds.includes('tab-1')">
       <p v-if="slottedTabs">
-        To customise tab look, in CvTabs component use scoped slot named with tab's label.
-        Example: current tab has label "<strong>House</strong>", so the code for customising tab looks like:
+        To customise tab look, in CvTabs component use scoped slot named with tab's id.
+        Example: current tab has id "<strong>tab-1</strong>", so the code for customising tab looks like:
         <div style="background-color: lightgrey; padding: 0.5rem;">
           &lt;template #tab-1="tab"&gt;
             {&nbsp;{ tab.label }&nbsp;} &lt;IbmSecurity20 /&gt;
@@ -66,8 +66,8 @@ const defaultTemplate = `
     </cv-tab>
     <cv-tab id="tab-2" label="Bar" :selected="selectedId === 'tab-2'" :disabled="disabledIds.includes('tab-2')">
       <p v-if="slottedTabs">
-        To customise tab look, in CvTabs component use scoped slot named with tab's label.
-        Example: current tab has label "<strong>Bar</strong>", so the code for customising tab looks like:
+        To customise tab look, in CvTabs component use scoped slot named with tab's id.
+        Example: current tab has id "<strong>tab-2</strong>", so the code for customising tab looks like:
         <div style="background-color: lightgrey; padding: 0.5rem;">
           &lt;template #tab-2="tab"&gt;
             {&nbsp;{ tab.label }&nbsp;} &lt;strong style="color: red;"&gt;(*)&lt;/strong&gt;
@@ -81,8 +81,8 @@ const defaultTemplate = `
     </cv-tab>
     <cv-tab id="tab-3" label="Reach" :selected="selectedId === 'tab-3'" :disabled="disabledIds.includes('tab-3')">
       <p v-if="slottedTabs">
-        To customise tab look, in CvTabs component use scoped slot named with tab's label.
-        Example: current tab has label "<strong>Reach</strong>", so the code for customising tab looks like:
+        To customise tab look, in CvTabs component use scoped slot named with tab's id.
+        Example: current tab has id "<strong>tab-3</strong>", so the code for customising tab looks like:
         <div style="background-color: lightgrey; padding: 0.5rem;">
           &lt;template #tab-3="tab"&gt;
             {&nbsp;{ tab.label }&nbsp;} &lt;strong style="color: orange;"&gt;(!)&lt;/strong&gt;

--- a/src/components/CvTabs/CvTabs.stories.mdx
+++ b/src/components/CvTabs/CvTabs.stories.mdx
@@ -5,6 +5,7 @@ import CvTab from './CvTab.vue';
 import CvTabsSkeleton from './CvTabsSkeleton.vue';
 import SbContainer from './_SbContainer.vue';
 import { action } from '@storybook/addon-actions';
+import { IbmSecurity20 as SampleIcon } from '@carbon/icons-vue';
 
 <Meta
   title={`${sbCompPrefix}/CvTabs`}
@@ -23,6 +24,7 @@ export const Template = args => ({
     CvTabs,
     CvTab,
     CvTabsSkeleton,
+    SampleIcon,
   },
   // The story's `args` need to be mapped into the template through the `setup()` method
   setup() {
@@ -31,6 +33,7 @@ export const Template = args => ({
       noDefaultToFirst: args.noDefaultToFirst,
       selectedId: args.selectedId,
       disabledIds: args.disabledIds,
+      slottedTabs: args.slottedTabs,
       onTabSelected: action('tab-selected'),
       onTabSelectedId: action('tab-selected-id'),
     };
@@ -46,20 +49,47 @@ const defaultTemplate = `
   @tab-selected-id="onTabSelectedId"
   aria-label="navigation tab label">
     <cv-tab id="tab-1" label="House" :selected="selectedId === 'tab-1'" :disabled="disabledIds.includes('tab-1')">
-      <p>
+      <p v-if="slottedTabs">
+        To customise tab look, in CvTabs component use scoped slot named with tab's label.
+        Example: current tab has label "<strong>House</strong>", so the code for customising tab looks like:
+        <div style="background-color: lightgrey; padding: 0.5rem;">
+          &lt;template #House="tab"&gt;
+            {&nbsp;{ tab.label }&nbsp;} &lt;IbmSecurity20 /&gt;
+          &lt;template&gt;
+        </div>
+      </p>
+      <p v-else>
         29 Arlington Avenue is a house in Islington, London. Douglas Adams shared the house for a time
         with Jonny Brock and Clare Gorst. It is mentioned in the dedication of The Hitchhiker's Guide to
         the Galaxy, which is dedicated to the "Arlingtonians for tea, sympathy, and a sofa."
       </p>
     </cv-tab>
     <cv-tab id="tab-2" label="Bar" :selected="selectedId === 'tab-2'" :disabled="disabledIds.includes('tab-2')">
-      <p>
+      <p v-if="slottedTabs">
+        To customise tab look, in CvTabs component use scoped slot named with tab's label.
+        Example: current tab has label "<strong>Bar</strong>", so the code for customising tab looks like:
+        <div style="background-color: lightgrey; padding: 0.5rem;">
+          &lt;template #Bar="tab"&gt;
+            {&nbsp;{ tab.label }&nbsp;} &lt;strong style="color: red;"&gt;(*)&lt;/strong&gt;
+          &lt;template&gt;
+        </div>
+      </p>
+      <p v-else>
         The Old Pink Dog Bar was the bar in Han Dold City that Ford Prefect was in when he discovered
         that his Guide had his full entry on Earth on it.
       </p>
     </cv-tab>
     <cv-tab id="tab-3" label="Reach" :selected="selectedId === 'tab-3'" :disabled="disabledIds.includes('tab-3')">
-      <p>
+      <p v-if="slottedTabs">
+        To customise tab look, in CvTabs component use scoped slot named with tab's label.
+        Example: current tab has label "<strong>Reach</strong>", so the code for customising tab looks like:
+        <div style="background-color: lightgrey; padding: 0.5rem;">
+          &lt;template #Reach="tab"&gt;
+            {&nbsp;{ tab.label }&nbsp;} &lt;strong style="color: orange;"&gt;(!)&lt;/strong&gt;
+          &lt;template&gt;
+        </div>
+      </p>
+      <p v-else>
         The Third Reach of the Unknown is what might be loosely described as a "place" which exists only
         under high improbability conditions and was created on the starship Heart of Gold due to the
         Infinite Improbability Drive. During Arthur Dent and Ford Prefect's first trip on board the Heart
@@ -81,6 +111,15 @@ const defaultTemplate = `
         <a target='_blank' href='https://hitchhikers.fandom.com/wiki/Main_Page'>credits</a>
       </p>
     </cv-tab>
+    <template v-if="slottedTabs" #House="tab">
+      House <SampleIcon/>
+    </template>
+    <template v-if="slottedTabs" #Bar="tab">
+      {{tab.label}} <strong style="color: red;">(*)</strong>
+    </template>
+    <template v-if="slottedTabs" #Reach="tab">
+      {{tab.label}} <strong style="color: orange;">(!)</strong>
+    </template>
 </cv-tabs>
 `;
 const skeletonTemplate = `<cv-tabs-skeleton></cv-tabs-skeleton>`;
@@ -169,6 +208,48 @@ screens, and so I suggest using a different component for mobile cases.
       template: skeletonTemplate,
     }}
     argTypes={{}}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+# Tabs slotted
+
+<Canvas>
+  <Story
+    name="tabsSlot"
+    parameters={{
+      controls: {
+        exclude: [
+          'default',
+          'template',
+          'leftOverflowIconButtonProps',
+          'rightOverflowIconButtonProps',
+          'scrollIntoView',
+          'tab-selected',
+          'tab-selected-id',
+          'slottedTabs',
+        ],
+      },
+      docs: { source: { code: defaultTemplate } },
+    }}
+    args={{
+      template: defaultTemplate,
+      selectedId: '',
+      disabledIds: [],
+      slottedTabs: true
+    }}
+    argTypes={{
+      selectedId: {
+        control: 'select',
+        default: '',
+        options: ['', 'tab-1', 'tab-2', 'tab-3', 'tab-4', 'tab-5'],
+      },
+      disabledIds: {
+        control: 'multi-select',
+        options: ['tab-1', 'tab-2', 'tab-3', 'tab-4', 'tab-5'],
+      },
+    }}
   >
     {Template.bind({})}
   </Story>

--- a/src/components/CvTabs/CvTabs.vue
+++ b/src/components/CvTabs/CvTabs.vue
@@ -76,7 +76,9 @@
             :tabindex="selectedId === tab.uid ? 0 : -1"
             type="button"
           >
-            {{ tab.label }}
+            <slot :name="tab.label" v-bind="tab">
+              {{ tab.label }}
+            </slot>
           </button>
         </li>
       </ul>

--- a/src/components/CvTabs/CvTabs.vue
+++ b/src/components/CvTabs/CvTabs.vue
@@ -76,7 +76,7 @@
             :tabindex="selectedId === tab.uid ? 0 : -1"
             type="button"
           >
-            <slot :name="tab.label" v-bind="tab">
+            <slot :name="tab.uid" v-bind="tab">
               {{ tab.label }}
             </slot>
           </button>

--- a/src/components/CvTabs/__tests__/CvTabs.spec.js
+++ b/src/components/CvTabs/__tests__/CvTabs.spec.js
@@ -4,17 +4,31 @@ import userEvent from '@testing-library/user-event';
 import CvTabs from '../CvTabs.vue';
 import CvTab from '../CvTab.vue';
 
-const Tab1Label = 'Tab 1 label';
-const Tab2Label = 'Tab 2 label';
 const ariaLabel = 'ABC-aria-label-123';
+
+const tab1 = {
+  id: 'tab-1',
+  label: 'Tab 1 label',
+  content: 'Tab 1 content',
+};
+const tab2 = {
+  id: 'tab-2',
+  label: 'Tab 2 label',
+  content: 'Tab 2 content',
+};
+const tab3 = {
+  id: 'tab-3',
+  label: 'Tab 3 label',
+  content: 'Tab 3 content',
+};
 
 const ContentTabs = {
   components: { CvTab },
   template: `
-    <cv-tab  id="tab-1" label="${Tab1Label}">Tab 1 content</cv-tab>
-    <cv-tab  id="tab-2" label="${Tab2Label}">Tab 2 content</cv-tab>
-    <cv-tab  id="tab-3" label="Tab 3 label">Tab 3 content</cv-tab>
-  `,
+      <cv-tab id="${tab1.id}" label="${tab1.label}">${tab1.content}</cv-tab>
+      <cv-tab id="${tab2.id}" label="${tab2.label}">${tab2.content}</cv-tab>
+      <cv-tab id="${tab3.id}" label="${tab3.label}">${tab3.content}</cv-tab>
+    `,
 };
 
 describe('CvTabs', () => {
@@ -95,8 +109,8 @@ describe('CvTabs', () => {
       props: {},
       slots: {
         default: ContentTabs,
-        [Tab1Label]: 'Hello <strong style="color: red;">(*)</strong>',
-        [Tab2Label]: 'Origin<strong style="color: orange;">(!)</strong>',
+        [tab1.id]: 'Hello <strong style="color: red;">(*)</strong>',
+        [tab2.id]: 'Origin<strong style="color: orange;">(!)</strong>',
       },
       attrs: {
         class: 'ABC-class-123',

--- a/src/components/CvTabs/__tests__/CvTabs.spec.js
+++ b/src/components/CvTabs/__tests__/CvTabs.spec.js
@@ -1,20 +1,24 @@
 import { render } from '@testing-library/vue';
+import { mount } from '@vue/test-utils';
 import userEvent from '@testing-library/user-event';
 import CvTabs from '../CvTabs.vue';
 import CvTab from '../CvTab.vue';
 
+const Tab1Label = 'Tab 1 label';
+const Tab2Label = 'Tab 2 label';
+const ariaLabel = 'ABC-aria-label-123';
+
 const ContentTabs = {
   components: { CvTab },
   template: `
-    <cv-tab  id="tab-1" label="Tab 1 label">Tab 1 content</cv-tab>
-    <cv-tab  id="tab-2" label="Tab 2 label">Tab 2 content</cv-tab>
+    <cv-tab  id="tab-1" label="${Tab1Label}">Tab 1 content</cv-tab>
+    <cv-tab  id="tab-2" label="${Tab2Label}">Tab 2 content</cv-tab>
     <cv-tab  id="tab-3" label="Tab 3 label">Tab 3 content</cv-tab>
   `,
 };
 
 describe('CvTabs', () => {
   it('CvTabs - test default and attrs', async () => {
-    const ariaLabel = 'ABC-aria-label-123';
     // The render method returns a collection of utilities to query your component.
     const result = render(CvTabs, {
       props: {},
@@ -59,7 +63,6 @@ describe('CvTabs', () => {
   });
 
   it('CvTabs - test all props', async () => {
-    const ariaLabel = 'ABC-aria-label-123';
     const props = {
       id: 'ABC-123',
       container: false,
@@ -85,5 +88,22 @@ describe('CvTabs', () => {
     expect(tabNav.classList.contains('bx--tabs--scrollable--container')).toBe(
       true
     );
+  });
+
+  it('CvTabs - test slotted tab buttons to match snapshot', async () => {
+    const wrapper = await mount(CvTabs, {
+      props: {},
+      slots: {
+        default: ContentTabs,
+        [Tab1Label]: 'Hello <strong style="color: red;">(*)</strong>',
+        [Tab2Label]: 'Origin<strong style="color: orange;">(!)</strong>',
+      },
+      attrs: {
+        class: 'ABC-class-123',
+        'aria-label': ariaLabel,
+      },
+    });
+
+    expect(wrapper.html()).toMatchSnapshot();
   });
 });

--- a/src/components/CvTabs/__tests__/__snapshots__/CvTabs.spec.js.snap
+++ b/src/components/CvTabs/__tests__/__snapshots__/CvTabs.spec.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CvTabs CvTabs - test slotted tab buttons to match snapshot 1`] = `
+<div class="cv-tabs ABC-class-123" style="width: 100%;" aria-label="ABC-aria-label-123">
+  <div data-tabs="" class="cv-tab bx--tabs--scrollable ABC-class-123" role="navigation" aria-label="ABC-aria-label-123"><button aria-hidden="true" aria-label="scroll left" class="bx--tab--overflow-nav-button--hidden" tabindex="-1" type="button"><svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M5 8L10 3 10.7 3.7 6.4 8 10.7 12.3 10 13z"></path>
+      </svg></button>
+    <!--v-if-->
+    <ul class="bx--tabs--scrollable__nav" role="tablist">
+      <li class="cv-tabs-button  bx--tabs--scrollable__nav-item bx--tabs__nav-item--selected bx--tabs--scrollable__nav-item--selected" role="presentation"><button class="bx--tabs--scrollable__nav-link" role="tab" aria-controls="tab-1" aria-disabled="false" aria-selected="true" id="tab-1-link" tabindex="0" type="button">Hello <strong style="color: red;">(*)</strong></button></li>
+      <li class="cv-tabs-button  bx--tabs--scrollable__nav-item" role="presentation"><button class="bx--tabs--scrollable__nav-link" role="tab" aria-controls="tab-2" aria-disabled="false" aria-selected="false" id="tab-2-link" tabindex="-1" type="button">Origin<strong style="color: orange;">(!)</strong></button></li>
+      <li class="cv-tabs-button  bx--tabs--scrollable__nav-item" role="presentation"><button class="bx--tabs--scrollable__nav-link" role="tab" aria-controls="tab-3" aria-disabled="false" aria-selected="false" id="tab-3-link" tabindex="-1" type="button">Tab 3 label</button></li>
+    </ul>
+    <!--v-if--><button aria-hidden="true" aria-label="scroll right" class="bx--tab--overflow-nav-button--hidden" tabindex="-1" type="button"><svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"></path>
+      </svg></button>
+  </div>
+  <div class="cv-tabs__panels">
+    <div class="cv-tab bx--tab-content" id="tab-1" role="tabpanel" aria-labelledby="tab-1-link" aria-hidden="false">Tab 1 content</div>
+    <div class="cv-tab bx--tab-content" id="tab-2" role="tabpanel" aria-labelledby="tab-2-link" aria-hidden="true" hidden="">Tab 2 content</div>
+    <div class="cv-tab bx--tab-content" id="tab-3" role="tabpanel" aria-labelledby="tab-3-link" aria-hidden="true" hidden="">Tab 3 content</div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Contributes to #1522

## What did you do?
Added slot to customise tab switching buttons' content

## How have you tested it?
added test for slot in CvTabs.spec.js

## Were docs updated if needed?
- [x] Yes

sample:
![image](https://github.com/carbon-design-system/carbon-components-vue/assets/20342514/9f5a8099-ea9a-4af8-9cd7-eead99544c89)
