### PR TITLE
feat: CvTag / CvTagSkeleton changes

### DIFF
--- a/src/components/CvTag/CvTag.stories.js
+++ b/src/components/CvTag/CvTag.stories.js
@@ -14,7 +14,7 @@ export default {
   },
 };
 
-const template = `<CvTag @remove="onRemove" v-bind="args" />`;
+const template = `<cv-tag @remove="onRemove" v-bind="args" />`;
 const Template = (args, { argTypes }) => {
   return {
     props: Object.keys(argTypes),
@@ -56,6 +56,7 @@ Filter.parameters = storyParametersObject(
 export const Skeleton = Template.bind({});
 Skeleton.args = {
   skeleton: true,
+  label: '',
 };
 Skeleton.parameters = storyParametersObject(
   Skeleton.parameters,

--- a/src/components/CvTag/CvTag.vue
+++ b/src/components/CvTag/CvTag.vue
@@ -56,6 +56,10 @@ export default {
      * skeleton used when loading
      */
     skeleton: Boolean,
+    /**
+     * tag size small
+     */
+    small: Boolean,
   },
   emits: [
     /**
@@ -70,6 +74,8 @@ export default {
 
     const tagClasses = computed(() => {
       const classes = [`${carbonPrefix}--tag`];
+
+      if (props.small) classes.push(`${carbonPrefix}--tag--sm`);
 
       if (props.skeleton) {
         classes.push(`${carbonPrefix}--skeleton`);

--- a/src/components/CvTag/CvTag.vue
+++ b/src/components/CvTag/CvTag.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="skeleton" :class="tagClasses" />
+  <div v-if="skeleton" :class="tagClasses"></div>
   <div v-else :class="tagClasses" role="listitem" :title="title">
     <span :class="`${carbonPrefix}--tag__label`">
       {{ label }}
@@ -69,14 +69,13 @@ export default {
     });
 
     const tagClasses = computed(() => {
-      const classes = [
-        `${carbonPrefix}--tag`,
-        `${carbonPrefix}--tag--${props.kind}`,
-      ];
+      const classes = [`${carbonPrefix}--tag`];
 
       if (props.skeleton) {
         classes.push(`${carbonPrefix}--skeleton`);
       } else {
+        classes.push(`${carbonPrefix}--tag--${props.kind}`);
+
         if (props.filter) {
           classes.push(`${carbonPrefix}--tag--filter`);
         }

--- a/src/components/CvTag/CvTagSkeleton.stories.js
+++ b/src/components/CvTag/CvTagSkeleton.stories.js
@@ -1,0 +1,39 @@
+import {
+  sbCompPrefix,
+  storyParametersObject,
+} from '../../global/storybook-utils';
+import CvTagSkeleton from './CvTagSkeleton.vue';
+
+export default {
+  title: `${sbCompPrefix}/CvTagSkeleton`,
+  component: CvTagSkeleton,
+};
+
+const template = `<cv-tag-skeleton v-bind="args"></cv-tag-skeleton>`;
+const Template = (args, { argTypes }) => {
+  return {
+    props: Object.keys(argTypes),
+    components: { CvTagSkeleton },
+    template,
+    setup() {
+      return { args };
+    },
+  };
+};
+
+export const Default = Template.bind({});
+Default.parameters = storyParametersObject(
+  Default.parameters,
+  template,
+  Default.args
+);
+
+export const Small = Template.bind({});
+Small.args = {
+  small: true,
+};
+Small.parameters = storyParametersObject(
+  Small.parameters,
+  template,
+  Small.args
+);

--- a/src/components/CvTag/CvTagSkeleton.vue
+++ b/src/components/CvTag/CvTagSkeleton.vue
@@ -1,0 +1,20 @@
+<template>
+  <CvTag skeleton :small="small" :label="''" />
+</template>
+
+<script>
+import CvTag from './CvTag.vue';
+
+export default {
+  name: 'CvTagSkeleton',
+  components: { CvTag },
+  props: {
+    /**
+     * tag size small
+     */
+    small: {
+      type: Boolean,
+    },
+  },
+};
+</script>

--- a/src/components/CvTag/__tests__/CvTag.spec.js
+++ b/src/components/CvTag/__tests__/CvTag.spec.js
@@ -114,4 +114,16 @@ describe('CvTag', () => {
     const removeButton = wrapper.find('button');
     expect(removeButton.exists()).toBe(false);
   });
+
+  it('CvTag - small', () => {
+    const label = 'test tag label';
+    const wrapper = shallowMount(CvTag, {
+      props: {
+        label,
+        small: true,
+      },
+    });
+    // - verify sm class on the root span
+    expect(wrapper.classes()).toContain(`${carbonPrefix}--tag--sm`);
+  });
 });

--- a/src/components/CvTag/__tests__/CvTagSkeleton.spec.js
+++ b/src/components/CvTag/__tests__/CvTagSkeleton.spec.js
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/vue';
+import { carbonPrefix } from '../../../global/settings';
+import { CvTagSkeleton } from '../';
+
+describe('CvTagSkeleton', () => {
+  it('CvTagSkeleton - default', async () => {
+    const { container } = await render(CvTagSkeleton);
+    // - verify classes on the root span
+    expect(container.querySelector(`.${carbonPrefix}--tag`)).toBeTruthy();
+    expect(container.querySelector(`.${carbonPrefix}--skeleton`)).toBeTruthy();
+  });
+
+  it('CvTagSkeleton - small', () => {
+    const { container } = render(CvTagSkeleton, {
+      props: {
+        small: true,
+      },
+    });
+
+    // - verify classes on the root span
+    expect(container.querySelector(`.${carbonPrefix}--tag`)).toBeTruthy();
+    expect(container.querySelector(`.${carbonPrefix}--skeleton`)).toBeTruthy();
+    expect(container.querySelector(`.${carbonPrefix}--tag--sm`)).toBeTruthy();
+  });
+});

--- a/src/components/CvTag/index.js
+++ b/src/components/CvTag/index.js
@@ -1,5 +1,6 @@
 import CvTag from './CvTag.vue';
 import CvTagConsts from './consts';
+import CvTagSkeleton from './CvTagSkeleton.vue';
 
-export { CvTag, CvTagConsts };
+export { CvTag, CvTagConsts, CvTagSkeleton };
 export default CvTag;


### PR DESCRIPTION
Contributes to https://github.com/carbon-design-system/carbon-components-vue/issues/1526

## What did you do?

### CvTag changes
-  Added `small` property to change component size (chosen `small` instead `size` because is the only available option for this component)

- Created end tag for skeleton div, `<div/>` is not the best option

- Reorganized initial tagClasses, we doesn't need to set `kind` classes when skeleton component is being used
- Set label on Skeleton scenario in the Storybook (fixing console warn above)
  <img width="411" alt="image" src="https://github.com/carbon-design-system/carbon-components-vue/assets/52216605/780d1713-6f9c-49ff-8bd6-22a91933c4bd">

### CvTagSkeleton
- Created CvTagSkeleton for migration purposes by having a separated component to use Skeleton (preserving Vue 2 pattern)

## How have you tested it?
- Created unit tests
- Checked Storybook behaviors and it's console

## Were docs updated if needed?

- [ ] N/A
- [ ] No
- [x] Yes
