### PR TITLE
fix: cv-fileuploader - doc updates, disabled & initialStateUploading props and bug fixes

### DIFF
--- a/src/components/CvFileUploader/CvFileUploader.stories.mdx
+++ b/src/components/CvFileUploader/CvFileUploader.stories.mdx
@@ -48,7 +48,7 @@ const skeletonTemplate = `
   </div>
 `;
 
-export const args = {
+export const argTypes = {
   // attributes
   multiple: {
     type: 'boolean',
@@ -236,7 +236,7 @@ Migration notes:
       helperText: 'Select the files you want to upload',
       removable: true,
     }}
-    argTypes={args}
+    argTypes={argTypes}
   >
     {Template.bind({})}
   </Story>
@@ -267,9 +267,9 @@ Migration notes:
       dropTargetLabel: 'Add file',
     }}
     argTypes={{
-      ...args,
+      ...argTypes,
       kind: {
-        ...args.kind,
+        ...argTypes.kind,
         control: 'none',
       },
     }}
@@ -301,9 +301,9 @@ Migration notes:
       removable: true,
     }}
     argTypes={{
-      ...args,
+      ...argTypes,
       kind: {
-        ...args.kind,
+        ...argTypes.kind,
         control: 'none',
       },
     }}

--- a/src/components/CvFileUploader/CvFileUploader.stories.mdx
+++ b/src/components/CvFileUploader/CvFileUploader.stories.mdx
@@ -107,6 +107,14 @@ export const argTypes = {
     },
     description: 'Reset file list when files are added',
   },
+  disabled: {
+    type: 'boolean',
+    table: {
+      type: { summary: 'boolean' },
+      category: 'props',
+    },
+    description: 'Disables input',
+  },
   dropTargetLabel: {
     type: 'string',
     table: {

--- a/src/components/CvFileUploader/CvFileUploader.stories.mdx
+++ b/src/components/CvFileUploader/CvFileUploader.stories.mdx
@@ -123,6 +123,14 @@ export const argTypes = {
     },
     description: 'Helper text positioned below label',
   },
+  initialStateUploading: {
+    type: 'boolean',
+    table: {
+      type: { summary: 'boolean' },
+      category: 'props',
+    },
+    description: 'Set "UPLOADING" state to new files',
+  },
   kind: {
     type: 'string',
     control: 'select',

--- a/src/components/CvFileUploader/CvFileUploader.stories.mdx
+++ b/src/components/CvFileUploader/CvFileUploader.stories.mdx
@@ -264,6 +264,7 @@ Migration notes:
       helperText: 'Select the files you want to upload',
       kind: KINDS.BUTTON,
       removable: true,
+      dropTargetLabel: 'Add file',
     }}
     argTypes={{
       ...args,

--- a/src/components/CvFileUploader/CvFileUploader.stories.mdx
+++ b/src/components/CvFileUploader/CvFileUploader.stories.mdx
@@ -61,6 +61,7 @@ export const args = {
   // props
   accept: {
     type: 'string',
+    defaultValue: '.jpg,.png',
     table: {
       type: { summary: 'string' },
       category: 'props',

--- a/src/components/CvFileUploader/CvFileUploader.vue
+++ b/src/components/CvFileUploader/CvFileUploader.vue
@@ -303,16 +303,18 @@ function setInvalidMessage(index, message) {
   internalFiles.value[index].invalidMessage = message;
 }
 
+function setState(index, state) {
+  if ([STATES.COMPLETE, STATES.UPLOADING, STATES.NONE].includes(state)) {
+    internalFiles.value[index].state = state;
+  }
+}
+
 // exposing methods
 defineExpose({
   clear,
   remove,
   setInvalidMessage,
-  setState(index, state) {
-    if ([STATES.COMPLETE, STATES.UPLOADING, STATES.NONE].includes(state)) {
-      internalFiles.value[index].state = state;
-    }
-  },
+  setState,
 });
 </script>
 

--- a/src/components/CvFileUploader/CvFileUploader.vue
+++ b/src/components/CvFileUploader/CvFileUploader.vue
@@ -1,11 +1,28 @@
 <template>
   <cv-form-item class="cv-file-uploader">
-    <p :class="`${carbonPrefix}--file--label`">{{ label }}</p>
-    <p :class="`${carbonPrefix}--label-description`">{{ helperText }}</p>
+    <p
+      :class="[
+        `${carbonPrefix}--file--label`,
+        { [`${carbonPrefix}--file--label--disabled`]: disabled },
+      ]"
+    >
+      {{ label }}
+    </p>
+    <p
+      :class="[
+        `${carbonPrefix}--label-description`,
+        { [`${carbonPrefix}--label-description--disabled`]: disabled },
+      ]"
+    >
+      {{ helperText }}
+    </p>
     <div v-if="kind === 'button'" :class="`${carbonPrefix}--file`" data-file>
       <label
         :for="cvId"
-        :class="buttonClasses"
+        :class="[
+          buttonClasses,
+          { [`${carbonPrefix}--btn--disabled`]: disabled },
+        ]"
         tabindex="0"
         @keydown.enter.prevent="onKeyHit"
         @keydown.space.prevent="onKeyHit"
@@ -17,6 +34,7 @@
         ref="fileInput"
         :class="`${carbonPrefix}--file-input`"
         :accept="accept"
+        :disabled="disabled"
         type="file"
         v-bind="$attrs"
         data-file-uploader
@@ -34,8 +52,10 @@
             `${carbonPrefix}--file-browse-btn`,
             `${carbonPrefix}--file__drop-container`,
             {
-              [`${carbonPrefix}--file__drop-container--drag-over`]: allowDrop,
+              [`${carbonPrefix}--file__drop-container--drag-over`]:
+                allowDrop && !disabled,
             },
+            { [`${carbonPrefix}--file-browse-btn--disabled`]: disabled },
           ]"
           @dragover="onDragEvent"
           @dragleave="onDragEvent"
@@ -50,6 +70,7 @@
           ref="fileInput"
           :class="`${carbonPrefix}--file-input`"
           :accept="accept"
+          :disabled="disabled"
           type="file"
           v-bind="$attrs"
           tabindex="-1"
@@ -107,6 +128,7 @@ const props = defineProps({
   },
   buttonSize: commonCvButtonProps.size,
   clearOnReselect: Boolean,
+  disabled: Boolean,
   dropTargetLabel: String,
   helperText: String,
   initialStateUploading: Boolean,
@@ -217,6 +239,11 @@ function onChange(ev) {
 }
 
 function onDragEvent(evt) {
+  if (props.disabled) {
+    evt.preventDefault();
+    return;
+  }
+
   if (Array.prototype.indexOf.call(evt.dataTransfer.types, 'Files') === -1) {
     return;
   }

--- a/src/components/CvFileUploader/CvFileUploader.vue
+++ b/src/components/CvFileUploader/CvFileUploader.vue
@@ -179,7 +179,7 @@ function addFiles(files) {
     const newFile = createInternalFile(internalFile?.file || file);
 
     if (internalFile) {
-      internalFile.state = newFile.initialState;
+      internalFile.state = newFile.state;
       internalFile.invalidMessageTitle = newFile.invalidMessageTitle;
       internalFile.invalidMessage = newFile.invalidMessage;
     } else {

--- a/src/components/CvFileUploader/CvFileUploader.vue
+++ b/src/components/CvFileUploader/CvFileUploader.vue
@@ -299,17 +299,19 @@ function remove(index) {
   onItemRemove(index);
 }
 
+function setInvalidMessage(index, message) {
+  internalFiles.value[index].invalidMessage = message;
+}
+
 // exposing methods
 defineExpose({
   clear,
   remove,
+  setInvalidMessage,
   setState(index, state) {
     if ([STATES.COMPLETE, STATES.UPLOADING, STATES.NONE].includes(state)) {
       internalFiles.value[index].state = state;
     }
-  },
-  setInvalidMessage(index, message) {
-    internalFiles.value[index].invalidMessage = message;
   },
 });
 </script>

--- a/src/components/CvFileUploader/CvFileUploader.vue
+++ b/src/components/CvFileUploader/CvFileUploader.vue
@@ -290,15 +290,18 @@ onMounted(() => {
 });
 
 // exposed methods
+function clear() {
+  internalFiles.value = [];
+  emit('update:modelValue', internalFiles.value);
+}
+
+// exposing methods
 defineExpose({
+  clear,
   setState(index, state) {
     if ([STATES.COMPLETE, STATES.UPLOADING, STATES.NONE].includes(state)) {
       internalFiles.value[index].state = state;
     }
-  },
-  clear() {
-    internalFiles.value = [];
-    emit('update:modelValue', internalFiles.value);
   },
   setInvalidMessage(index, message) {
     internalFiles.value[index].invalidMessage = message;

--- a/src/components/CvFileUploader/CvFileUploader.vue
+++ b/src/components/CvFileUploader/CvFileUploader.vue
@@ -295,9 +295,14 @@ function clear() {
   emit('update:modelValue', internalFiles.value);
 }
 
+function remove(index) {
+  onItemRemove(index);
+}
+
 // exposing methods
 defineExpose({
   clear,
+  remove,
   setState(index, state) {
     if ([STATES.COMPLETE, STATES.UPLOADING, STATES.NONE].includes(state)) {
       internalFiles.value[index].state = state;
@@ -306,7 +311,6 @@ defineExpose({
   setInvalidMessage(index, message) {
     internalFiles.value[index].invalidMessage = message;
   },
-  remove: onItemRemove,
 });
 </script>
 

--- a/src/components/CvFileUploader/CvFileUploader.vue
+++ b/src/components/CvFileUploader/CvFileUploader.vue
@@ -277,7 +277,7 @@ function onDragEvent(evt) {
 
 function onItemRemove(index) {
   internalFiles.value.splice(index, 1);
-  emit('update:modelValue', this.internalFiles);
+  emit('update:modelValue', internalFiles.value);
 }
 
 function onKeyHit() {
@@ -298,7 +298,7 @@ defineExpose({
   },
   clear() {
     internalFiles.value = [];
-    emit('update:modelValue', internalFiles);
+    emit('update:modelValue', internalFiles.value);
   },
   setInvalidMessage(index, message) {
     internalFiles.value[index].invalidMessage = message;

--- a/src/components/CvFileUploader/CvFileUploader.vue
+++ b/src/components/CvFileUploader/CvFileUploader.vue
@@ -109,6 +109,7 @@ const props = defineProps({
   clearOnReselect: Boolean,
   dropTargetLabel: String,
   helperText: String,
+  initialStateUploading: Boolean,
   kind: {
     type: String,
     default: KINDS.DRAG_TARGET,

--- a/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
+++ b/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
@@ -742,5 +742,33 @@ describe('CvFileUploader', () => {
         );
       });
     });
+
+    describe('setInvalidMessage', () => {
+      it('should set "ERROR" as invalid message of the first file when calling setInvalidMessage function with 0 and "ERROR"', async () => {
+        const wrapper = await shallowMount(CvFileUploader, {
+          props: {
+            modelValue: [
+              createFileItem(
+                new File(['content1'], 'dummy-file1.txt', {
+                  type: 'text/plain',
+                })
+              ),
+              createFileItem(
+                new File(['content2'], 'dummy-file2.txt', {
+                  type: 'text/plain',
+                })
+              ),
+            ],
+            'onUpdate:modelValue': e => wrapper.setProps({ modelValue: e }),
+          },
+        });
+
+        wrapper.vm.setInvalidMessage(0, 'ERROR');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.props('modelValue').length).toBe(2);
+        expect(wrapper.props('modelValue')[0].invalidMessage).toBe('ERROR');
+      });
+    });
   });
 });

--- a/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
+++ b/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
@@ -1,5 +1,5 @@
 import { render, fireEvent } from '@testing-library/vue';
-import { KINDS } from '../const';
+import { KINDS, STATES } from '../const';
 import { carbonPrefix } from '../../../global/settings';
 import { buttonKinds, buttonSizes } from '../../CvButton/consts';
 import CvFileUploader from '..';
@@ -325,6 +325,62 @@ describe('CvFileUploader', () => {
       expect(slotContent).toBeDefined;
     }
   );
+
+  it(`sets "${STATES.UPLOADING}" state to new files when initialStateUploading is true`, async () => {
+    const dummyFile = new File([''], 'dummy-file.jpeg', {
+      type: 'image/jpeg',
+    });
+    const dummyId = 'dummy-id';
+    const { container, emitted } = render(CvFileUploader, {
+      props: {
+        initialStateUploading: true,
+        id: dummyId,
+      },
+    });
+
+    const fileInput = container.querySelector(`#${dummyId}`);
+    await fireEvent.change(fileInput, { target: { files: [dummyFile] } });
+
+    const emitResult = emitted('update:modelValue').at(0);
+    expect(emitResult[0][0].state).toBe(STATES.UPLOADING);
+  });
+
+  it(`sets "${STATES.NONE}" state to new files when initialStateUploading is false`, async () => {
+    const dummyFile = new File([''], 'dummy-file.jpeg', {
+      type: 'image/jpeg',
+    });
+    const dummyId = 'dummy-id';
+    const { container, emitted } = render(CvFileUploader, {
+      props: {
+        initialStateUploading: false,
+        id: dummyId,
+      },
+    });
+
+    const fileInput = container.querySelector(`#${dummyId}`);
+    await fireEvent.change(fileInput, { target: { files: [dummyFile] } });
+
+    const emitResult = emitted('update:modelValue').at(0);
+    expect(emitResult[0][0].state).toBe(STATES.NONE);
+  });
+
+  it(`sets "${STATES.NONE}" state to new files when initialStateUploading is not set`, async () => {
+    const dummyFile = new File([''], 'dummy-file.jpeg', {
+      type: 'image/jpeg',
+    });
+    const dummyId = 'dummy-id';
+    const { container, emitted } = render(CvFileUploader, {
+      props: {
+        id: dummyId,
+      },
+    });
+
+    const fileInput = container.querySelector(`#${dummyId}`);
+    await fireEvent.change(fileInput, { target: { files: [dummyFile] } });
+
+    const emitResult = emitted('update:modelValue').at(0);
+    expect(emitResult[0][0].state).toBe(STATES.NONE);
+  });
 
   describe('Drop target label', () => {
     it.each(inputKinds)(

--- a/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
+++ b/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
@@ -770,5 +770,131 @@ describe('CvFileUploader', () => {
         expect(wrapper.props('modelValue')[0].invalidMessage).toBe('ERROR');
       });
     });
+
+    describe('setState', () => {
+      it(`should set second file status to 'none' state when calling setState function with 1 and ${STATES.NONE}`, async () => {
+        const wrapper = await shallowMount(CvFileUploader, {
+          props: {
+            modelValue: [
+              createFileItem(
+                new File(['content1'], 'dummy-file1.txt', {
+                  type: 'text/plain',
+                }),
+                '',
+                '',
+                STATES.UPLOADING
+              ),
+              createFileItem(
+                new File(['content2'], 'dummy-file2.txt', {
+                  type: 'text/plain',
+                }),
+                '',
+                '',
+                STATES.COMPLETE
+              ),
+            ],
+            'onUpdate:modelValue': e => wrapper.setProps({ modelValue: e }),
+          },
+        });
+
+        wrapper.vm.setState(1, STATES.NONE);
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.props('modelValue')[1].state).toBe(STATES.NONE);
+      });
+
+      it(`should set first file status to 'uploading' state when calling setState function with 0 and ${STATES.UPLOADING}`, async () => {
+        const wrapper = await shallowMount(CvFileUploader, {
+          props: {
+            modelValue: [
+              createFileItem(
+                new File(['content1'], 'dummy-file1.txt', {
+                  type: 'text/plain',
+                }),
+                '',
+                '',
+                STATES.COMPLETE
+              ),
+              createFileItem(
+                new File(['content2'], 'dummy-file2.txt', {
+                  type: 'text/plain',
+                }),
+                '',
+                '',
+                STATES.COMPLETE
+              ),
+            ],
+            'onUpdate:modelValue': e => wrapper.setProps({ modelValue: e }),
+          },
+        });
+
+        wrapper.vm.setState(0, STATES.UPLOADING);
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.props('modelValue')[0].state).toBe(STATES.UPLOADING);
+      });
+
+      it(`should set second file status to 'complete' state when calling setState function with 1 and ${STATES.COMPLETE}`, async () => {
+        const wrapper = await shallowMount(CvFileUploader, {
+          props: {
+            modelValue: [
+              createFileItem(
+                new File(['content1'], 'dummy-file1.txt', {
+                  type: 'text/plain',
+                }),
+                '',
+                '',
+                STATES.UPLOADING
+              ),
+              createFileItem(
+                new File(['content2'], 'dummy-file2.txt', {
+                  type: 'text/plain',
+                }),
+                '',
+                '',
+                STATES.UPLOADING
+              ),
+            ],
+            'onUpdate:modelValue': e => wrapper.setProps({ modelValue: e }),
+          },
+        });
+
+        wrapper.vm.setState(1, STATES.COMPLETE);
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.props('modelValue')[1].state).toBe(STATES.COMPLETE);
+      });
+
+      it(`should not set first file status to 'random', when calling setState function with 0 and 'random', as 'random' is not a valid state`, async () => {
+        const wrapper = await shallowMount(CvFileUploader, {
+          props: {
+            modelValue: [
+              createFileItem(
+                new File(['content1'], 'dummy-file1.txt', {
+                  type: 'text/plain',
+                }),
+                '',
+                '',
+                STATES.NONE
+              ),
+              createFileItem(
+                new File(['content2'], 'dummy-file2.txt', {
+                  type: 'text/plain',
+                }),
+                '',
+                '',
+                STATES.NONE
+              ),
+            ],
+            'onUpdate:modelValue': e => wrapper.setProps({ modelValue: e }),
+          },
+        });
+
+        wrapper.vm.setState(0, 'random');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.props('modelValue')[0].state).toBe(STATES.NONE);
+      });
+    });
   });
 });

--- a/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
+++ b/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
@@ -712,5 +712,35 @@ describe('CvFileUploader', () => {
         expect(wrapper.props('modelValue')).toEqual([]);
       });
     });
+
+    describe('remove', () => {
+      it('should remove the second item of files when remove function is called with 1', async () => {
+        const wrapper = await shallowMount(CvFileUploader, {
+          props: {
+            modelValue: [
+              createFileItem(
+                new File(['content1'], 'dummy-file1.txt', {
+                  type: 'text/plain',
+                })
+              ),
+              createFileItem(
+                new File(['content2'], 'dummy-file2.txt', {
+                  type: 'text/plain',
+                })
+              ),
+            ],
+            'onUpdate:modelValue': e => wrapper.setProps({ modelValue: e }),
+          },
+        });
+
+        wrapper.vm.remove(1);
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.props('modelValue').length).toBe(1);
+        expect(wrapper.props('modelValue')[0].file.name).toBe(
+          'dummy-file1.txt'
+        );
+      });
+    });
   });
 });

--- a/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
+++ b/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
@@ -382,6 +382,32 @@ describe('CvFileUploader', () => {
     expect(emitResult[0][0].state).toBe(STATES.NONE);
   });
 
+  it(`sets "${STATES.UPLOADING}" state to files when initialStateUploading is set and uploaded file already exists`, async () => {
+    const dummyFile = new File([''], 'dummy-file.jpeg', {
+      type: 'image/jpeg',
+    });
+    const dummyId = 'dummy-id';
+    const { container, emitted, rerender } = render(CvFileUploader, {
+      props: {
+        initialStateUploading: true,
+        id: dummyId,
+      },
+    });
+
+    const fileInput = container.querySelector(`#${dummyId}`);
+    await fireEvent.change(fileInput, { target: { files: [dummyFile] } });
+
+    await rerender({ initialStateUploading: false });
+    await fireEvent.change(fileInput, { target: { files: [dummyFile] } });
+
+    await rerender({ initialStateUploading: true });
+    await fireEvent.change(fileInput, { target: { files: [dummyFile] } });
+
+    expect(emitted('update:modelValue').at(2)[0][0].state).toBe(
+      STATES.UPLOADING
+    );
+  });
+
   describe('Drop target label', () => {
     it.each(inputKinds)(
       'renders drop target label when dropTargetLabel is passed (kind: %s)',

--- a/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
+++ b/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
@@ -6,7 +6,7 @@ import { carbonPrefix } from '../../../global/settings';
 import { buttonKinds, buttonSizes } from '../../CvButton/consts';
 import CvFileUploader from '..';
 
-const inputKinds = [KINDS.DRAG_TARGET];
+const inputKinds = [KINDS.DRAG_TARGET, KINDS.BUTTON];
 const createFileItem = (
   file,
   invalidMessage = '',

--- a/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
+++ b/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
@@ -1,11 +1,23 @@
 import { render, fireEvent } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
+import { shallowMount } from '@vue/test-utils';
 import { KINDS, STATES } from '../const';
 import { carbonPrefix } from '../../../global/settings';
 import { buttonKinds, buttonSizes } from '../../CvButton/consts';
 import CvFileUploader from '..';
 
 const inputKinds = [KINDS.DRAG_TARGET];
+const createFileItem = (
+  file,
+  invalidMessage = '',
+  invalidMessageTitle = '',
+  state = ''
+) => ({
+  file,
+  invalidMessage,
+  invalidMessageTitle,
+  state,
+});
 
 describe('CvFileUploader', () => {
   it('renders label', async () => {
@@ -671,5 +683,34 @@ describe('CvFileUploader', () => {
         expect(wrapper).not.toBeNull();
       }
     );
+  });
+
+  describe('Exposed methods', () => {
+    describe('clear', () => {
+      it('should clear files when clear function is called', async () => {
+        const wrapper = await shallowMount(CvFileUploader, {
+          props: {
+            modelValue: [
+              createFileItem(
+                new File(['content1'], 'dummy-file1.txt', {
+                  type: 'text/plain',
+                })
+              ),
+              createFileItem(
+                new File(['content2'], 'dummy-file2.txt', {
+                  type: 'text/plain',
+                })
+              ),
+            ],
+            'onUpdate:modelValue': e => wrapper.setProps({ modelValue: e }),
+          },
+        });
+
+        wrapper.vm.clear();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.props('modelValue')).toEqual([]);
+      });
+    });
   });
 });

--- a/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
+++ b/src/components/CvFileUploader/__tests__/CvFileUploader.spec.js
@@ -1,4 +1,5 @@
 import { render, fireEvent } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 import { KINDS, STATES } from '../const';
 import { carbonPrefix } from '../../../global/settings';
 import { buttonKinds, buttonSizes } from '../../CvButton/consts';
@@ -406,6 +407,117 @@ describe('CvFileUploader', () => {
     expect(emitted('update:modelValue').at(2)[0][0].state).toBe(
       STATES.UPLOADING
     );
+  });
+
+  describe('Disabled state', () => {
+    it('renders label in disabled state', async () => {
+      const dummyLabel = 'Dummy File Input';
+      const { findByText } = render(CvFileUploader, {
+        props: {
+          label: dummyLabel,
+          disabled: true,
+        },
+      });
+
+      const label = await findByText(dummyLabel);
+      expect(
+        label.classList.contains(`${carbonPrefix}--file--label--disabled`)
+      ).toBeTruthy();
+    });
+
+    it('renders helper text in disable state', async () => {
+      const dummyHelperText = 'Dummy Helper Text';
+      const { findByText } = render(CvFileUploader, {
+        props: {
+          helperText: dummyHelperText,
+          disabled: true,
+        },
+      });
+
+      const element = await findByText(dummyHelperText);
+      expect(
+        element.classList.contains(
+          `${carbonPrefix}--label-description--disabled`
+        )
+      ).toBeTruthy();
+    });
+
+    it('renders "button" in disabled state', async () => {
+      const dummyId = 'dummy-id';
+      const { container } = render(CvFileUploader, {
+        props: {
+          kind: KINDS.BUTTON,
+          id: dummyId,
+          disabled: true,
+        },
+      });
+
+      const fileInput = container.querySelector(`#${dummyId}`);
+      const label = container.querySelector('label');
+
+      expect(fileInput.getAttribute('disabled')).not.toBeNull();
+      expect(
+        label.classList.contains(`${carbonPrefix}--btn--disabled`)
+      ).toBeTruthy();
+    });
+
+    it('does not emit changes on click when button is disabled', async () => {
+      const dummyFile = new File(['file content'], 'dummy-file.txt', {
+        type: 'text/plain',
+      });
+      const dummyId = 'dummy-id';
+      const { container, emitted } = render(CvFileUploader, {
+        props: {
+          kind: KINDS.BUTTON,
+          id: dummyId,
+          disabled: true,
+        },
+      });
+
+      const fileInput = container.querySelector(`#${dummyId}`);
+      await userEvent.upload(fileInput, dummyFile);
+
+      expect(emitted('update:modelValue')).toBeUndefined();
+    });
+
+    it('renders "drag & drop" in disabled state', async () => {
+      const dummyId = 'dummy-id';
+      const { container } = render(CvFileUploader, {
+        props: {
+          kind: KINDS.DRAG_TARGET,
+          id: dummyId,
+          disabled: true,
+        },
+      });
+
+      const fileInput = container.querySelector(`#${dummyId}`);
+      const wrapper = container.querySelector(
+        `div.${carbonPrefix}--file-browse-btn`
+      );
+
+      expect(fileInput.getAttribute('disabled')).not.toBeNull();
+      expect(
+        wrapper.classList.contains(`${carbonPrefix}--file-browse-btn--disabled`)
+      ).toBeTruthy();
+    });
+
+    it("does not emit changes when drag & drop's input is disabled", async () => {
+      const dummyFile = new File(['file content'], 'dummy-file.txt', {
+        type: 'text/plain',
+      });
+      const dummyId = 'dummy-id';
+      const { container, emitted } = render(CvFileUploader, {
+        props: {
+          id: dummyId,
+          disabled: true,
+        },
+      });
+
+      const fileInput = container.querySelector(`#${dummyId}`);
+      await userEvent.upload(fileInput, dummyFile);
+
+      expect(emitted('update:modelValue')).toBeUndefined();
+    });
   });
 
   describe('Drop target label', () => {


### PR DESCRIPTION
Contributes to #1519 

## What did you do?
- Define `.jpg, .png` as initial values for `accept` at file uploader storybook
- Define `Add file` as button label at file uploader storybook
- Setup `initialStateUploading` as prop. Although used on code, it was set at the props definition (`defineProps`)
- Fix a bug were state was not correctly set on reuploaded files
- Setup `disabled` prop
- Adjust value emitted on `onItemRemove` to comply with vue3 setup mode
- Fix invalid value emitted exposed method `clear`
- Add tests to exposed methods
- Add missing 'button' kind to `inputKinds` array at spec

## Why did you do it?
#1520 is taking a more than expected due to limitations on storybook controls feature. As a few bugs were found and a missing feature, `disabled`, was created, a separate PR will split some of the responsibility and allow them to be review ready soon.

## How have you tested it?
Yes, through storybook and new automated tests

## Were docs updated if needed?

- [X] Yes
