### PR TITLE
feat: switch to vue 3

### DIFF
--- a/.github/ISSUE_TEMPLATE/improve-component.md
+++ b/.github/ISSUE_TEMPLATE/improve-component.md
@@ -1,0 +1,19 @@
+---
+name: "\U0001F36A Vue 3 - improve component"
+about: Claim work on Vue 3 component
+title: Improving [cv-some-component]
+labels: 'V3 - Vue 3'
+assignees: ''
+---
+
+**Please read** [code of conduct](../CODE_OF_CONDUCT.md) and [contributing](../CONTRIBUTING.md) guides.
+
+Improving [cv-some-component]
+
+Plans:
+
+- add slot for ...
+- update accessibility in ...
+- update story to ...
+
+You may want to reference the [Carbon 10 React components](https://v7-react.carbondesignsystem.com/?path=/story/getting-started--welcome)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,14 @@
-name: CI vNext
+name: CI
 
 on:
   workflow_dispatch:
   pull_request:
     branches:
+      - main
+      - vNext
+  push:
+    branches:
+      - main
       - vNext
 
 jobs:
@@ -11,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -58,6 +64,3 @@ jobs:
 
       - name: Run component tests
         run: yarn test
-
-      - name: Accessability tests
-        run: yarn a11test

--- a/.github/workflows/deploy-vue-storybook.yml
+++ b/.github/workflows/deploy-vue-storybook.yml
@@ -33,25 +33,30 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16.x'
-      - name: Install dependencies from our offline mirror
-        run: yarn install --offline
-      - name: Build Vue 2 storybook
+
+      - name: Install Vue 3 dependencies
         run: |
-          yarn build:storybook --quiet
-      - name: Switch to Vue 3 branch
-        uses: actions/checkout@v3
-        with:
-          ref: vNext
-          clean: false
-          path: vNext
-      - name: Install vNext dependencies
-        run: |
-          cd ${GITHUB_WORKSPACE}/vNext/storybook
+          cd ${GITHUB_WORKSPACE}/storybook
           yarn install
       - name: Build Vue 3 storybook
         run: |
-          cd ${GITHUB_WORKSPACE}/vNext/storybook
-          yarn build-storybook --quiet --output-dir ${GITHUB_WORKSPACE}/storybook/storybook-static/vue3
+          cd ${GITHUB_WORKSPACE}/storybook
+          yarn build-storybook --quiet --output-dir ${GITHUB_WORKSPACE}/storybook/storybook-static/
+
+      - name: Switch to Vue 2 branch
+        uses: actions/checkout@v3
+        with:
+          ref: vue2
+          clean: false
+          path: vue2
+      - name: Install vue2 dependencies
+        run: |
+          cd ${GITHUB_WORKSPACE}/vue2
+          yarn install --offline
+      - name: Build Vue 2 storybook
+        run: |
+          yarn build:storybook --quiet --output-dir ${GITHUB_WORKSPACE}/storybook/storybook-static/vue2
+
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact

--- a/.github/workflows/release-vNext.yml
+++ b/.github/workflows/release-vNext.yml
@@ -40,4 +40,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: yarn lerna publish prepatch --dist-tag next --yes
+        run: yarn lerna publish patch --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Vue2
 
 on:
   workflow_dispatch:
@@ -15,6 +15,7 @@ jobs:
         with:
           fetch-depth: 0 # https://github.com/actions/checkout/issues/217
           token: ${{ secrets.GH_TOKEN_LERNA }} # https://github.com/lerna/lerna/issues/1957
+          ref: vue2
 
       # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
       - run: |
@@ -37,7 +38,7 @@ jobs:
         run: yarn ci-check
 
       # Dry run - `yarn lerna version --no-git-tag-version --no-push --yes`
-      # With dist tag - `run: yarn lerna publish --create-release github --yes --dist-tag next`
+      # With dist tag - `run: yarn lerna publish --create-release github --yes --dist-tag next`
       - name: Publish
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}

--- a/.storybook/Welcome/sv-welcome.vue
+++ b/.storybook/Welcome/sv-welcome.vue
@@ -28,7 +28,7 @@
                 <div class="welcome__card-content">
                   <h5>Go to</h5>
                   <h4>the source repository</h4>
-                  <div>(currently Vue3 is on the vNext branch)</div>
+                  <div>(Vue 2 components are on the vue2 branch)</div>
                   <div class="welcome__card-image">
                     <svg
                       focusable="false"
@@ -72,15 +72,16 @@
         </div>
         <div class="bx--no-gutter-md--left bx--col-md-4 bx--col-lg-4"></div>
         <div class="bx--no-gutter-md--left bx--col-md-4 bx--col-lg-4">
-          <a class="welcome__card" href="https://vue.carbondesignsystem.com/">
+          <a
+            class="welcome__card"
+            href="https://vue.carbondesignsystem.com/vue2/"
+          >
             <div class="bx--aspect-ratio bx--aspect-ratio--2x1">
               <div class="bx--aspect-ratio--object">
                 <div class="welcome__card-content">
                   <h5>Take a look at our</h5>
                   <h4>Vue 2 version</h4>
-                  <div>
-                    (currently Vue 2 is the only production-ready version)
-                  </div>
+                  <div>(currently Vue 2 version is nearing end-of-life)</div>
                   <div class="welcome__card-image">
                     <svg
                       xmlns="http://www.w3.org/2000/svg"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @carbon/vue-3
 
-<p align="center">
+<p>
   <a href="https://github.com/carbon-design-system/carbon/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="Carbon is released under the Apache-2.0 license" />
   </a>
@@ -12,6 +12,9 @@
   </a>
   <a href="https://github.com/carbon-design-system/carbon/blob/master/.github/CONTRIBUTING.md">
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome" />
+  </a>
+  <a href="https://discord.gg/J7JEUEkTRX">
+      <img src="https://img.shields.io/discord/689212587170201628?color=5865F2" alt="Chat with us on Discord">
   </a>
 </p>
 
@@ -25,6 +28,46 @@ The [library](http://vue.carbondesignsystem.com/) provides front-end developers 
 ## Community Contributions Needed
 
 As a community project contributions are not only welcome, but essential for the maintenance and growth of this project.
+
+## Install
+
+```shell
+npm add @carbon/vue
+```
+
+or
+
+```shell
+$ yarn add @carbon/vue
+```
+
+### Add to Vue project
+
+`src/main.js`
+
+```js
+import CarbonVue3 from '@carbon/vue';
+import App from './App.vue';
+const app = createApp(App);
+app.use(CarbonVue3);
+app.mount('#app');
+```
+
+See [Hello Carbon Vue](https://github.com/IBM/hello-carbon-vue3) for an example Vue project with Carbon.
+
+### Add to Nuxt project
+
+`plugins/carbon-vue.js`
+
+```js
+import CarbonVue from '@carbon/vue'
+
+export default defineNuxtPlugin((nuxtApp) => {
+    nuxtApp.vueApp.use(CarbonVue)
+}
+```
+
+See [Hello Carbon Nuxt](#add-to-nuxt-project) **coming soon**
 
 ### Vue 3
 
@@ -49,11 +92,7 @@ More work is needed especially around accessibility. If you want to improve Vue 
 
 ### Changelog
 
-[CHANGELOG.md](./packages/core/CHANGELOG.md)
-
-## Getting started
-
-[Usage and getting started instructions](./packages/core/README.md#getting-started) for @carbon/vue.
+[CHANGELOG.md](./CHANGELOG.md)
 
 ### List of available components
 

--- a/README.md
+++ b/README.md
@@ -26,25 +26,25 @@ The [library](http://vue.carbondesignsystem.com/) provides front-end developers 
 
 As a community project contributions are not only welcome, but essential for the maintenance and growth of this project.
 
-### Vue 3 Guidance
+### Vue 3
 
-We are actively working on components for Vue 3 and would love to get your help with this. If you want to contribute follow this guidance:
+- Vue 2 support will end on Dec 31, 2023. Learn [more](https://vuejs.org/guide/introduction.html).
+- Upgrading from Vue 2? Check out the [Migration Guide](https://v3-migration.vuejs.org/).
+- Vue 2 components can be found on the `vue2` [branch](https://github.com/carbon-design-system/carbon-components-vue/tree/vue2)
 
-1. Fork this repo and checkout the `vNext` branch
-2. Look to see which components have not yet been implemented. You can do this by comparing the components listed in the [Carbon React storybook](https://react.carbondesignsystem.com/?path=/story/getting-started-welcome--welcome) with the components in the `src/components` directory.
-3. When you find a component that interests you, look in the open issue list to see if someone else might already be working on it. Look for issues with a "V3 - Vue3" label. A "dibs" issue will have that label and a title of "[component name] work in progress" so for example "**CvDatePicker work in progress**".
-4. If no one else is already working on it, create an issue and label it as above.
+Vue 3 components for Carbon 10 have reached parity with the Vue 2 components.
+More work is needed especially around accessibility. If you want to improve Vue 3 components follow these guidelines.
+
+1. Fork this repo and checkout the `main` branch
+2. Look to see which components are currently being improved. You can do this by looking in the [issues list](https://github.com/carbon-design-system/carbon-components-vue/issues).
+3. If you want to improve a component, look in the open issue list to see if someone else might already be working on it. Look for issues with a "V3 - Vue3" label and the name of the component. For example "**CvDatePicker - improving accessibility**".
+4. If no one else is already working on it, create an issue using the "🍪 Vue 3 - improve component" and label it as above.
    - Work on the component and create a PR when you are ready.
    - Components are expected to be implemented as [single file components](https://vuejs.org/guide/scaling-up/sfc.html) using the Vue [composition api](https://vuejs.org/guide/extras/composition-api-faq.html). See `CvCheckbox` as an example. The Vue 2 components use the options API.
-   - You should reference the existing Vue 2 component while developing the code. The existing components often have the community enhancements that need to be maintained.
-   - You should reference the DOM in the React components storybook and be sure to include any accessibility improvements that might be there.
-   - You should provide a story and test case for the component. For example:
-     ```
-     src/components/CvCheckbox/CvCheckbox.stories.js
-     src/components/CvCheckbox/CvCheckbox.vue
-     src/components/CvCheckbox/__tests__/CvCheckbox.spec.js
-     src/components/CvCheckbox/index.js
-     ```
+   - You should reference the DOM in the React components storybook and be sure to include any accessibility
+     improvements that might be there.
+   - You should update the story and test cases for the component if applicable. Sometimes the story might need updating
+     almost always the test cases for the component will need updates.
    - If you have question tag @davidnixon in your issue and let me know how I can help.
 
 ### Changelog


### PR DESCRIPTION
Prepare to switch vNext to be main branch
- update Vue 3  issue template
- update CI to remove vNext reference
- update story book build to move Vue 3 to main page and Vue 2 to /vue2 page
- update release action to have Vue 2 in the name. (Likely this will not get used but I want to keep it around a while.)
- update vue 3 release action to remove "alpha" and the "next" dist tag. This will make Vue 3 the default install for `npm add @carbon/vue`
- update the vNext README to show this is the main branch