### PR TITLE
test(cv-link): add tests for a11y

### DIFF
--- a/src/components/CvLink/CvLink.vue
+++ b/src/components/CvLink/CvLink.vue
@@ -14,7 +14,12 @@
     ]"
   >
     <slot></slot>
-    <CvSvg v-if="icon" :class="`${carbonPrefix}--link__icon`" :svg="icon" />
+    <CvSvg
+      v-if="icon"
+      :class="`${carbonPrefix}--link__icon`"
+      :svg="icon"
+      alt=""
+    />
   </component>
 </template>
 

--- a/src/components/CvLink/__tests__/CvLink.accessibility.spec.js
+++ b/src/components/CvLink/__tests__/CvLink.accessibility.spec.js
@@ -1,0 +1,34 @@
+import { CvLink } from '..';
+import { render } from '@testing-library/vue';
+
+describe('CvLink - accessibility', () => {
+  it('CvLink - basic', async () => {
+    const main = document.createElement('main');
+    const result = render(CvLink, {
+      container: document.body.appendChild(main),
+      slots: { default: 'test link' },
+    });
+    await expect(result.container).toBeAccessible('cv-link');
+  }, 10000);
+
+  it('CvLink - disabled', async () => {
+    const main = document.createElement('main');
+    const result = render(CvLink, {
+      container: document.body.appendChild(main),
+      slots: { default: 'test link' },
+      props: { disabled: true },
+    });
+
+    await expect(result.container).toBeAccessible('cv-link');
+  }, 10000);
+
+  it('CvLink - with icon', async () => {
+    const main = document.createElement('main');
+    const result = render(CvLink, {
+      container: document.body.appendChild(main),
+      slots: { default: 'test link' },
+      props: { icon: 'Bee20' },
+    });
+    await expect(result.container).toBeAccessible('cv-link');
+  }, 10000);
+});


### PR DESCRIPTION
Contributes to #1538 

## What did you do?
Add a11y test for `CvLink`

## Why did you do it?
Adding 3 test cases, for simple link, one in disabled state and the other one with an icon

## How have you tested it?
Using testing library, the icon one is failing because needs a label, but I'm not sure how to proceed

### Notes
I have an idea of naming convention for accessibility tests, maybe we can use the abbreviation, `[Component].a11y.spec.js`?

Thank you in advance
