### PR TITLE
feat(cv-text-input-skeleton): add CvTextInputSkeleton

### DIFF
--- a/src/components/CvTextInput/CvTextInput.stories.js
+++ b/src/components/CvTextInput/CvTextInput.stories.js
@@ -3,7 +3,7 @@ import {
   storyParametersObject,
 } from '../../global/storybook-utils';
 
-import CvTextInput from '.';
+import { CvTextInput, CvTextInputSkeleton } from '.';
 import { ref } from 'vue';
 
 export default {
@@ -242,4 +242,20 @@ Password.parameters = storyParametersObject(
   Password.parameters,
   template,
   Password.args
+);
+
+const templateSkeleton = `<cv-text-input-skeleton v-bind='args'>`;
+const TemplateSkeleton = args => {
+  return {
+    components: { CvTextInputSkeleton },
+    setup: () => ({ args }),
+    template: templateSkeleton,
+  };
+};
+
+export const Skeleton = TemplateSkeleton.bind({});
+Skeleton.parameters = storyParametersObject(
+  Skeleton.parameters,
+  templateSkeleton,
+  Skeleton.args
 );

--- a/src/components/CvTextInput/CvTextInput.stories.js
+++ b/src/components/CvTextInput/CvTextInput.stories.js
@@ -254,6 +254,13 @@ const TemplateSkeleton = args => {
 };
 
 export const Skeleton = TemplateSkeleton.bind({});
+
+Skeleton.parameters = {
+  controls: {
+    include: ['hideLabel'],
+  },
+};
+
 Skeleton.parameters = storyParametersObject(
   Skeleton.parameters,
   templateSkeleton,

--- a/src/components/CvTextInput/CvTextInput.stories.js
+++ b/src/components/CvTextInput/CvTextInput.stories.js
@@ -244,7 +244,7 @@ Password.parameters = storyParametersObject(
   Password.args
 );
 
-const templateSkeleton = `<cv-text-input-skeleton v-bind='args'>`;
+const templateSkeleton = `<cv-text-input-skeleton v-bind='args'/>`;
 const TemplateSkeleton = args => {
   return {
     components: { CvTextInputSkeleton },

--- a/src/components/CvTextInput/CvTextInputSkeleton.vue
+++ b/src/components/CvTextInput/CvTextInputSkeleton.vue
@@ -1,0 +1,14 @@
+<template>
+  <div :class="[`${carbonPrefix}--form-item`]">
+    <span
+      :class="[`${carbonPrefix}--label`, `${carbonPrefix}--skeleton`]"
+    ></span>
+    <div
+      :class="[`${carbonPrefix}--text-input`, `${carbonPrefix}--skeleton`]"
+    ></div>
+  </div>
+</template>
+
+<script setup>
+import { carbonPrefix } from '../../global/settings';
+</script>

--- a/src/components/CvTextInput/CvTextInputSkeleton.vue
+++ b/src/components/CvTextInput/CvTextInputSkeleton.vue
@@ -1,8 +1,9 @@
 <template>
   <div :class="[`${carbonPrefix}--form-item`]">
-    <span
+    <label
+      v-if="!hideLabel"
       :class="[`${carbonPrefix}--label`, `${carbonPrefix}--skeleton`]"
-    ></span>
+    ></label>
     <div
       :class="[`${carbonPrefix}--text-input`, `${carbonPrefix}--skeleton`]"
     ></div>
@@ -11,4 +12,6 @@
 
 <script setup>
 import { carbonPrefix } from '../../global/settings';
+
+defineProps({ hideLabel: { type: Boolean, default: false } });
 </script>

--- a/src/components/CvTextInput/CvTextInputSkeleton.vue
+++ b/src/components/CvTextInput/CvTextInputSkeleton.vue
@@ -1,9 +1,9 @@
 <template>
   <div :class="[`${carbonPrefix}--form-item`]">
-    <label
+    <span
       v-if="!hideLabel"
       :class="[`${carbonPrefix}--label`, `${carbonPrefix}--skeleton`]"
-    ></label>
+    ></span>
     <div
       :class="[`${carbonPrefix}--text-input`, `${carbonPrefix}--skeleton`]"
     ></div>

--- a/src/components/CvTextInput/__tests__/CvTextInput.spec.js
+++ b/src/components/CvTextInput/__tests__/CvTextInput.spec.js
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
-import CvTextInput from '..';
+import { CvTextInput, CvTextInputSkeleton } from '..';
 
 describe('CvTextInput', () => {
   it("renders label when 'label' prop is passed", () => {
@@ -457,5 +457,40 @@ describe('CvTextInput', () => {
       expect(input).not.toBeNull();
       expect(button).not.toBeNull();
     });
+  });
+});
+
+describe('CvTextInputSkeleton', () => {
+  it("renders label when 'hideLabel' prop is omitted", async () => {
+    const skeleton = render(CvTextInputSkeleton);
+    const label = skeleton.container.querySelector(
+      'label.bx--label.bx--skeleton'
+    );
+    expect(label).toBeTruthy();
+  });
+  it("renders label when 'hideLabel' prop is false", async () => {
+    const skeleton = render(CvTextInputSkeleton, {
+      props: { hideLabel: false },
+    });
+    const label = skeleton.container.querySelector(
+      'label.bx--label.bx--skeleton'
+    );
+    expect(label).toBeTruthy();
+  });
+  it("does not render label when 'hideLabel' prop is true", async () => {
+    const skeleton = render(CvTextInputSkeleton, {
+      props: { hideLabel: true },
+    });
+    const label = skeleton.container.querySelector(
+      'label.bx--label.bx--skeleton'
+    );
+    expect(label).toBeFalsy();
+  });
+  it('renders div with correct class', async () => {
+    const skeleton = render(CvTextInputSkeleton);
+    const div = skeleton.container.querySelector(
+      'div.bx--text-input.bx--skeleton'
+    );
+    expect(div).toBeTruthy();
   });
 });

--- a/src/components/CvTextInput/__tests__/CvTextInput.spec.js
+++ b/src/components/CvTextInput/__tests__/CvTextInput.spec.js
@@ -493,4 +493,11 @@ describe('CvTextInputSkeleton', () => {
     );
     expect(div).toBeTruthy();
   });
+  it('is accessible', async () => {
+    const main = document.createElement('main');
+    const skeleton = render(CvTextInputSkeleton, {
+      container: document.body.appendChild(main),
+    });
+    await expect(skeleton.container).toBeAccessible('cv-text-input-skeleton');
+  }, 10000);
 });

--- a/src/components/CvTextInput/__tests__/CvTextInput.spec.js
+++ b/src/components/CvTextInput/__tests__/CvTextInput.spec.js
@@ -464,7 +464,7 @@ describe('CvTextInputSkeleton', () => {
   it("renders label when 'hideLabel' prop is omitted", async () => {
     const skeleton = render(CvTextInputSkeleton);
     const label = skeleton.container.querySelector(
-      'label.bx--label.bx--skeleton'
+      'span.bx--label.bx--skeleton'
     );
     expect(label).toBeTruthy();
   });
@@ -473,7 +473,7 @@ describe('CvTextInputSkeleton', () => {
       props: { hideLabel: false },
     });
     const label = skeleton.container.querySelector(
-      'label.bx--label.bx--skeleton'
+      'span.bx--label.bx--skeleton'
     );
     expect(label).toBeTruthy();
   });
@@ -482,7 +482,7 @@ describe('CvTextInputSkeleton', () => {
       props: { hideLabel: true },
     });
     const label = skeleton.container.querySelector(
-      'label.bx--label.bx--skeleton'
+      'span.bx--label.bx--skeleton'
     );
     expect(label).toBeFalsy();
   });

--- a/src/components/CvTextInput/index.js
+++ b/src/components/CvTextInput/index.js
@@ -1,4 +1,5 @@
 import CvTextInput from './CvTextInput.vue';
+import CvTextInputSkeleton from './CvTextInputSkeleton.vue';
 
-export { CvTextInput };
+export { CvTextInput, CvTextInputSkeleton };
 export default CvTextInput;


### PR DESCRIPTION
Contributes to #167

## What did you do?
Implemented `cv-text-input-skeleton`.

## Why did you do it?
Because Carbon Vue rocks 😄 . And it was requested on #167.

## How have you tested it?
Ran the existing unit tests and added new ones.

## Were docs updated if needed?
- [ ] N/A
- [ ] No
- [x] Yes

(I updated the storybook. Is there anything else that needs to be updated?)
