### PR TITLE
fix: CvDataTable did not properly store/emit sort events

### DIFF
--- a/src/components/CvDataTable/CvDataTable.vue
+++ b/src/components/CvDataTable/CvDataTable.vue
@@ -611,19 +611,19 @@ function onInternalSearch() {
   emit('search', searchValue.value);
 }
 function onSort(payload) {
-  const { heading, val } = payload;
+  const { heading, value } = payload;
   const headings = store.headings(uid);
   let index;
   for (let colIndex in headings) {
     const column = headings[colIndex];
     if (column.id === heading.id) {
-      store.updateHeading(uid, { ...column, order: val });
+      store.updateHeading(uid, { ...column, order: value });
       index = colIndex;
     } else {
       store.updateHeading(uid, { ...column, order: 'none' });
     }
   }
-  emit('sort', { index, order: val, name: heading.name });
+  emit('sort', { index, order: value, name: heading.name });
 }
 
 // are all rows expanded


### PR DESCRIPTION
## What was broken?

Clicking on a sortable header in a CvDataTable (e.g. the first two columns in [the official story book](https://vue.carbondesignsystem.com/?path=/story/component-cvdatatable--default-story) didn't actually trigger the expected events:

* the sort icon for that column remained 'unsorted'
* the action always has `order: undefined`

## Why ?

The code that emits `cv:sort` when clicking on a `CvDataTableHeading` [uses the key `value`](https://github.com/carbon-design-system/carbon-components-vue/blob/43ed9bdfdb32725966e12da7ae059a39e7ef60c4/src/components/CvDataTable/CvDataTableHeading.vue#L119):

```js
function onSortClick() {
  bus?.emit('cv:sort', {
    heading: { id: cvId.value, name: props.name },
    value: nextOrder[internalOrder.value],
  });
}
```

However, the receiving code [destructs `payload` into a variable named `val`](https://github.com/carbon-design-system/carbon-components-vue/blob/43ed9bdfdb32725966e12da7ae059a39e7ef60c4/src/components/CvDataTable/CvDataTable.vue#L613C1-L615C1):
```js
function onSort(payload) {
  const { heading, val } = payload;
```

As `val` doesn't acutally exist in the payload, the variable gets initialized to `undefined`, breaking the rest of that function.

## What did you do?

Changed the code in `onSort(payload)` to use the variable named `value` instead of `val`.

## How have you tested it?

* built the storybook with the fixed code
* opened the story for CvDataTables
* clicked on the sortable header
* confirmed that the sort indicator now iterates through "ascending", "descending" and "none"
* confirmed that the emitted `onSort` action now has the proper `order`


## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
