### PR TITLE
chore: migration coercion fixes

### DIFF
--- a/src/components/CvComboBox/CvComboBox.vue
+++ b/src/components/CvComboBox/CvComboBox.vue
@@ -59,7 +59,7 @@
           :aria-controls="cvId"
           aria-autocomplete="list"
           role="combobox"
-          :aria-disabled="disabled"
+          :aria-disabled="disabled || null"
           :aria-expanded="open ? 'true' : 'false'"
           autocomplete="off"
           :disabled="disabled"

--- a/src/components/CvDataTable/CvDataTable.vue
+++ b/src/components/CvDataTable/CvDataTable.vue
@@ -23,7 +23,7 @@
       <section v-if="hasToolbar" :class="`${carbonPrefix}--table-toolbar`">
         <div
           v-show="hasBatchActions"
-          :aria-hidden="!batchActive"
+          :aria-hidden="`${!batchActive}`"
           :class="[
             `${carbonPrefix}--batch-actions`,
             { [`${carbonPrefix}--batch-actions--active`]: batchActive },

--- a/src/components/CvDropdown/CvDropdown.stories.mdx
+++ b/src/components/CvDropdown/CvDropdown.stories.mdx
@@ -49,7 +49,7 @@ const defaultTemplate = `
 <cv-dropdown
   :light="light"
   :placeholder="placeholder"
-  :value="value"
+  :modelValue="modelValue"
   :up="up"
   :inline="inline"
   :helper-text="helperText"
@@ -71,7 +71,7 @@ const defaultTemplate = `
 const slotsTemplate = `
 <div :style="{width: '300px'}">
 <cv-dropdown
-  v-model:value="myValue"
+  v-model="myValue"
   :light="light"
   :placeholder="placeholder"
   :up="up"
@@ -101,7 +101,7 @@ const itemsTemplate = `
 <cv-dropdown
   :light="light"
   :placeholder="placeholder"
-  :value="value"
+  :modelValue="modelValue"
   :up="up"
   :inline="inline"
   :helper-text="helperText"
@@ -119,7 +119,7 @@ const itemsTemplate = `
 const vmodelTemplate = `
 <div :style="{width: '300px'}">
 <cv-dropdown
-  v-model:value="myValue"
+  v-model="myValue"
   :label="label"
   :placeholder="placeholder"
   @change="onChange">
@@ -151,10 +151,7 @@ Notes:
 
 - You can place a Dropdown inline with other content by using the inline variant
   Migration notes:
-
-- The `v-model` is different in Vue 3 than Vue 2. You can still specify the `v-model=something` to control the visibility but
-  if you specify it like this you will see a deprecation message in the log. Please use `v-model:value=something` instead.
-- Add the `size` option to match Carbon React
+- Added the `size` option to match Carbon React
 - Added the `warningMessage` option to match Carbon React
 
 <Canvas>
@@ -168,21 +165,16 @@ Notes:
           'template',
           'change',
           'update:modelValue',
-          'update:value',
           'helper-text',
           'invalid-message',
           'warning-message',
           'internal-caption',
-          'modelValue',
         ],
       },
       docs: { source: { code: defaultTemplate } },
     }}
     args={{
       template: defaultTemplate,
-      props: {
-        modelValue: undefined,
-      },
       label: 'Characters',
       placeholder: 'Choose an ally',
       helperText: 'May the force be with you',
@@ -273,7 +265,6 @@ Notes:
           'template',
           'change',
           'update:modelValue',
-          'update:value',
           'helper-text',
           'invalid-message',
           'warning-message',
@@ -316,32 +307,7 @@ Notes:
     name="v-model"
     parameters={{
       controls: {
-        exclude: [
-          'props',
-          'default',
-          'template',
-          'change',
-          'update:modelValue',
-          'update:value',
-          'helper-text',
-          'invalid-message',
-          'warning-message',
-          'internal-caption',
-          'modelValue',
-          'ariaLabel',
-          'disabled',
-          'formItem',
-          'helperText',
-          'hideSelected',
-          'inline',
-          'invalidMessage',
-          'items',
-          'label',
-          'placeholder',
-          'size',
-          'up',
-          'value',
-          'warningMessage',
+        include: [
         ],
       },
       docs: { source: { code: vmodelTemplate } },
@@ -367,32 +333,7 @@ Notes:
     name="skeleton"
     parameters={{
       controls: {
-        exclude: [
-          'props',
-          'default',
-          'template',
-          'change',
-          'update:modelValue',
-          'update:value',
-          'helper-text',
-          'invalid-message',
-          'warning-message',
-          'internal-caption',
-          'modelValue',
-          'ariaLabel',
-          'disabled',
-          'formItem',
-          'helperText',
-          'hideSelected',
-          'invalidMessage',
-          'items',
-          'label',
-          'placeholder',
-          'size',
-          'up',
-          'value',
-          'warningMessage',
-          'inline',
+        include: [
         ],
       },
       docs: { source: { code: skeletonTemplate } },

--- a/src/components/CvDropdown/CvDropdown.vue
+++ b/src/components/CvDropdown/CvDropdown.vue
@@ -229,24 +229,14 @@ const props = defineProps({
    */
   up: { type: Boolean, default: false },
   /**
-   * Render with a value already selected. Available as `v-model:value`.
-   */
-  value: { type: String, default: undefined },
-  /**
    * Provide the text that is displayed and put the control in warning state
    */
   warningMessage: { type: String, default: undefined },
   /**
-   * @deprecated - use v-model:value
+   * Render with a value already selected. Available as `v-model`.
    */
   modelValue: {
     type: String,
-    validator: val => {
-      console.warn(
-        `v-model for cv-dropdown is deprecated. Specify "v-model:value" instead [${val}]`
-      );
-      return true;
-    },
     default: undefined,
   },
 
@@ -255,7 +245,7 @@ const props = defineProps({
 });
 const uid = useCvId(props, true);
 const isLight = useIsLight(props);
-const dataValue = ref(props.value);
+const dataValue = ref(props.modelValue);
 provide('dropdown-selected', dataValue);
 const focusItem = ref(undefined);
 provide('dropdown-focus', focusItem);
@@ -287,16 +277,15 @@ const isWarning = computed(() => {
 });
 onMounted(checkSlots);
 onUpdated(checkSlots);
-const emit = defineEmits(['update:value', 'update:modelValue', 'change']);
+const emit = defineEmits(['update:modelValue', 'change']);
 watch(
-  () => props.value,
+  () => props.modelValue,
   () => {
-    dataValue.value = props.value;
+    dataValue.value = props.modelValue;
   }
 );
 watch(dataValue, () => {
   emit('change', dataValue.value);
-  emit('update:value', dataValue.value);
   emit('update:modelValue', dataValue.value);
 });
 watch(open, () => {

--- a/src/components/CvDropdown/CvDropdown.vue
+++ b/src/components/CvDropdown/CvDropdown.vue
@@ -73,7 +73,7 @@
         <button
           ref="button"
           :aria-controls="`${uid}-menu`"
-          :aria-disabled="disabled"
+          :aria-disabled="disabled || null"
           :aria-expanded="open ? 'true' : 'false'"
           :aria-labelledby="ariaLabeledBy"
           :class="`${carbonPrefix}--list-box__field`"
@@ -129,7 +129,7 @@
       </div>
       <div
         v-else-if="data.isHelper"
-        :aria-disabled="disabled"
+        :aria-disabled="disabled || null"
         :class="[
           `${carbonPrefix}--form__helper-text`,
           { [`${carbonPrefix}--form__helper-text--disabled`]: disabled },

--- a/src/components/CvDropdown/CvDropdownItem.vue
+++ b/src/components/CvDropdown/CvDropdownItem.vue
@@ -21,7 +21,7 @@
   >
     <a
       ref="link"
-      :aria-checked="dataSelected"
+      :aria-checked="`${dataSelected}`"
       :class="`${carbonPrefix}--dropdown-link`"
       href="javascript:void(0)"
       role="menuitemradio"

--- a/src/components/CvDropdown/__tests__/CvDropdown.spec.js
+++ b/src/components/CvDropdown/__tests__/CvDropdown.spec.js
@@ -70,7 +70,7 @@ describe('CvDropdown', () => {
         placeholder: placeholder,
         size: 'md',
         up: false,
-        value: undefined,
+        modelValue: undefined,
         warningMessage: '',
         light: false,
       },
@@ -88,7 +88,7 @@ describe('CvDropdown', () => {
 
     let mysteriousLabels = await result.findAllByText('The Armorer');
     expect(mysteriousLabels.length).toBe(1);
-    await result.rerender({ value: 'mysterious' });
+    await result.rerender({ modelValue: 'mysterious' });
     mysteriousLabels = await result.findAllByText('The Armorer');
     expect(mysteriousLabels.length).toBe(2);
 

--- a/src/components/CvLoading/CvLoading.vue
+++ b/src/components/CvLoading/CvLoading.vue
@@ -18,7 +18,7 @@
       :aria-labelledby="cvId"
       aria-live="assertive"
       role="progressbar"
-      :aria-busy="active || stopping"
+      :aria-busy="`${active || stopping}`"
     >
       <label :id="cvId" :class="`${carbonPrefix}--visually-hidden`">
         {{ description }}

--- a/src/components/CvMultiSelect/CvMultiSelect.stories.mdx
+++ b/src/components/CvMultiSelect/CvMultiSelect.stories.mdx
@@ -58,7 +58,7 @@ export const Template = args => ({
       title: args.title,
       label: args.label,
       highlight: args.highlight,
-      value: args.value,
+      modelValue: args.modelValue,
       selectionFeedback: args.selectionFeedback,
       filterable: args.filterable,
       light: args.light,
@@ -70,7 +70,7 @@ export const Template = args => ({
       myValue: myValue,
       onChange: action('change'),
       onFilter: action('filter'),
-      onVmodel: action('update:value'),
+      onVmodel: action('update:modelValue'),
     };
   },
   template: args.template,
@@ -93,7 +93,7 @@ const defaultTemplate = `
   :options="options"
   :selectionFeedback="selectionFeedback"
   :title="title"
-  :value="value"
+  :modelValue="modelValue"
   :warningMessage="warningMessage"
   @change="onChange"
   @filter="onFilter"
@@ -123,13 +123,13 @@ const vModelTemplate = `
   :label="label"
   :options="options"
   :title="title"
-  v-model:value="myValue"
+  v-model="myValue"
   @change="onChange"
   @filter="onFilter"
   >
   </cv-multi-select>
   <div style="margin-top:2rem">
-    <div>v-model:value</div>
+    <div>v-model</div>
     <select name="cars" id="cars" v-model="myValue" multiple>
       <option v-for="opt in options" :key="opt.value" :value="opt.value">{{opt.value}}</option>
     </select>
@@ -147,8 +147,6 @@ Migration notes:
 - Added the `warningMessage` option to match Carbon React
 - Setting `autoFilter` to true now implies `filterable`. Previous versions required `filterable` to
   be explicitly set to `true` for `autoFilter` to work properly.
-- The `v-model` is different in Vue 3 than Vue 2.If you specify it you will see a error deprecation message in the log.
-  Please use `v-model:value=something` instead.
 
 <Canvas>
   <Story
@@ -160,10 +158,8 @@ Migration notes:
           'filter',
           'helper-text',
           'invalid-message',
-          'modelValue',
           'template',
           'update:modelValue',
-          'update:value',
           'warning-message',
         ],
       },
@@ -210,7 +206,7 @@ Migration notes:
         control: 'inline-radio',
         options: [],
       },
-      value: {
+      modelValue: {
         control: 'multi-select',
         options: pkdValues,
       },
@@ -242,15 +238,13 @@ Migration notes:
           'invalid-message',
           'invalidMessage',
           'light',
-          'modelValue',
           'options',
           'selectionFeedback',
           'template',
           'update:modelValue',
-          'update:value',
-          'value',
           'warning-message',
           'warningMessage',
+          'modelValue'
         ],
       },
       docs: { source: { code: slotsTemplate } },
@@ -271,8 +265,6 @@ Migration notes:
 </Canvas>
 
 # v-model
-
-Note: Specifying `v-model="something"` will not work. Use `v-model:value=something` instead.
 
 <Canvas>
   <Story
@@ -300,8 +292,6 @@ Note: Specifying `v-model="something"` will not work. Use `v-model:value=somethi
           'selectionFeedback',
           'template',
           'update:modelValue',
-          'update:value',
-          'value',
           'warning-message',
           'warningMessage',
         ],
@@ -322,7 +312,7 @@ Note: Specifying `v-model="something"` will not work. Use `v-model:value=somethi
         control: 'inline-radio',
         options: [],
       },
-      value: {
+      modelValue: {
         control: 'multi-select',
         options: pkdValues,
       },

--- a/src/components/CvMultiSelect/CvMultiSelect.vue
+++ b/src/components/CvMultiSelect/CvMultiSelect.vue
@@ -65,7 +65,7 @@
         ref="elButton"
         type="button"
         :class="`${carbonPrefix}--list-box__field`"
-        :aria-disabled="disabled"
+        :aria-disabled="disabled || null"
         aria-haspopup="listbox"
         :aria-expanded="data.open ? 'true' : 'false'"
         :aria-owns="uid"

--- a/src/components/CvMultiSelect/CvMultiSelect.vue
+++ b/src/components/CvMultiSelect/CvMultiSelect.vue
@@ -342,23 +342,16 @@ const props = defineProps({
    * Provide text to be used in a <label> element that is tied to the multiselect via ARIA attributes.
    */
   title: { type: String, default: undefined },
-  /***
-   * Allow users to pass in arbitrary items from their collection that are pre-selected
-   */
-  value: { type: Array, default: () => [] },
   /**
    * Provide the text that is displayed and put the control in warning state
    */
   warningMessage: { type: String, default: undefined },
+  /***
+   * Allow users to pass in arbitrary items from their collection that are pre-selected
+   */
   modelValue: {
     type: Array,
-    validator: val => {
-      console.error(
-        `v-model for cv-multi-select is deprecated. Specify "v-model:value" instead [${val}]`
-      );
-      return true;
-    },
-    default: undefined,
+    default: () => [],
   },
   ...propsCvId,
   ...propsTheme,
@@ -379,13 +372,15 @@ const data = reactive({
   isWarning: false,
   isInvalid: false,
 });
-const emit = defineEmits(['update:value', 'change', 'filter']);
+const emit = defineEmits(['update:modelValue', 'change', 'filter']);
 watch(
   () => data.selectedItems,
   () => {
-    if (JSON.stringify(data.selectedItems) !== JSON.stringify(props.value)) {
+    if (
+      JSON.stringify(data.selectedItems) !== JSON.stringify(props.modelValue)
+    ) {
       emit('change', data.selectedItems);
-      emit('update:value', data.selectedItems);
+      emit('update:modelValue', data.selectedItems);
     }
   },
   {
@@ -409,7 +404,7 @@ const isFilterable = computed(() => {
 });
 
 function updateSelectedItems() {
-  data.selectedItems = props.value.filter(
+  data.selectedItems = props.modelValue.filter(
     /***
      * @param {string} item
      * @returns {boolean}
@@ -431,7 +426,7 @@ onUpdated(checkSlots);
 onMounted(updateOptions);
 onMounted(updateSelectedItems);
 
-watch(() => props.value, updateSelectedItems);
+watch(() => props.modelValue, updateSelectedItems);
 watch(() => props.options, updateOptions);
 watch(() => props.selectionFeedback, updateOptions);
 
@@ -462,7 +457,7 @@ const highlighted = computed({
   },
 });
 onMounted(() => {
-  highlighted.value = props.value ? props.value : props.highlight; // override highlight with value if provided
+  highlighted.value = props.modelValue ? props.modelValue : props.highlight; // override highlight with modelValue if provided
 });
 
 const internalFilter = computed({

--- a/src/components/CvMultiSelect/__tests__/CvMultiSelect.spec.js
+++ b/src/components/CvMultiSelect/__tests__/CvMultiSelect.spec.js
@@ -38,7 +38,7 @@ describe('CvMultiSelect', () => {
     const result = render(CvMultiSelect, {
       props: {
         options: pkdOptions,
-        value: pkdValues.slice(3, 6), // select 3 items
+        modelValue: pkdValues.slice(3, 6), // select 3 items
       },
       attrs: {
         class: 'ABC-class-123',
@@ -63,7 +63,7 @@ describe('CvMultiSelect', () => {
     const result = render(CvMultiSelect, {
       props: {
         options: pkdOptions,
-        value: initiallySelected,
+        modelValue: initiallySelected,
       },
       attrs: {
         class: 'ABC-class-123',
@@ -246,8 +246,8 @@ describe('CvMultiSelect', () => {
     const options = {
       props: {
         options: pkdOptions,
-        value: myValue,
-        'onUpdate:value': e => {
+        modelValue: myValue,
+        'onUpdate:modelValue': e => {
           myValue = e;
         },
       },

--- a/src/components/CvProgress/CvProgressStep.vue
+++ b/src/components/CvProgress/CvProgressStep.vue
@@ -6,7 +6,7 @@
       `cv-progress-step ${carbonPrefix}--progress-step`,
       `${carbonPrefix}--progress-step--${internalState}`,
     ]"
-    :aria-disabled="disabled"
+    :aria-disabled="disabled || null"
   >
     <button
       type="button"

--- a/src/components/CvSearch/CvSearch.stories.mdx
+++ b/src/components/CvSearch/CvSearch.stories.mdx
@@ -25,7 +25,7 @@ export const Template = args => ({
       clearAriaLabel: args.clearAriaLabel,
       formItem: args.formItem,
       expandable: args.expandable,
-      value: args.value,
+      modelValue: args.modelValue,
       myValue: myValue,
       onInput: action('input'),
     };
@@ -40,7 +40,7 @@ const defaultTemplate = `
   :disabled="disabled"
   :size="size"
   :expandable="expandable"
-  :value="value"
+  :modelValue="modelValue"
   :form-item="formItem"
   :aria-label="ariaLabel"
   :clear-aria-label="clearAriaLabel"
@@ -51,7 +51,7 @@ const defaultTemplate = `
 const vModelTemplate = `
 <div>
   <cv-search
-    v-model:value="myValue"
+    v-model="myValue"
     :light="light"
     :label="label"
     :placeholder="placeholder"
@@ -64,7 +64,7 @@ const vModelTemplate = `
     >
   </cv-search>
   <div style="margin-top:1rem; background-color: #888888;  padding:1rem">
-    <div style="padding:1rem">v-model value: {{ myValue }}</div>
+    <div style="padding:1rem">v-model: {{ myValue }}</div>
     <input type="search" v-model="myValue"/>
   </div>
 </div>
@@ -74,8 +74,6 @@ const vModelTemplate = `
 
 Migration notes:
 
-- The `v-model` is different in Vue 3 than Vue 2. If you specify it you will see an error deprecation message in the log.
-  Please use `v-model:value=something` instead.
 - The "toolbar" mode is removed in this version. Please use the `expandable` mode instead.
 
 <Canvas>
@@ -85,10 +83,8 @@ Migration notes:
       controls: {
         exclude: [
           'input',
-          'modelValue',
           'template',
           'update:modelValue',
-          'update:value',
           'large',
           'small',
           'toolbarAriaLabel',
@@ -122,9 +118,6 @@ Migration notes:
 
 # v-model
 
-- The `v-model` is different in Vue 3 than Vue 2.If you specify it you will see an error deprecation message in the log.
-  Please use `v-model:value=something` instead.
-
 <Canvas>
   <Story
     name="v-model"
@@ -132,10 +125,8 @@ Migration notes:
       controls: {
         exclude: [
           'input',
-          'modelValue',
           'template',
           'update:modelValue',
-          'update:value',
           'large',
           'small',
           'toolbarAriaLabel',

--- a/src/components/CvSearch/CvSearch.vue
+++ b/src/components/CvSearch/CvSearch.vue
@@ -151,17 +151,9 @@ const props = defineProps({
   /**
    * Optionally provide the default value of the `<input>`
    */
-  value: { type: String, default: undefined },
-  /**
-   * @deprecated use value
-   */
   modelValue: {
     type: String,
     default: undefined,
-    validator: () => {
-      console.warn('Deprecated: use v-model:value instead');
-      return true;
-    },
   },
   /**
    * Provide an optional placeholder text for the Search. Note: if the label and placeholder differ, VoiceOver on Mac will read both
@@ -184,14 +176,14 @@ const props = defineProps({
 const uid = useCvId(props, true);
 const isLight = useIsLight(props);
 
-const clearVisible = ref(props.value ? props.value.length : false);
-const internalSearchText = ref(props.value || props.modelValue);
+const clearVisible = ref(props.modelValue ? props.modelValue.length : false);
+const internalSearchText = ref(props.modelValue);
 const searchActive = ref(false);
 watch(
-  () => props.value,
+  () => props.modelValue,
   () => {
-    clearVisible.value = props.value ? props.value.length : false;
-    internalSearchText.value = props.value;
+    clearVisible.value = props.modelValue ? props.modelValue.length : false;
+    internalSearchText.value = props.modelValue;
   }
 );
 
@@ -204,14 +196,10 @@ const internalAriaLabelBy = computed(() => {
   else return undefined;
 });
 
-const emit = defineEmits(['input', 'update:value', 'update:modelValue']);
+const emit = defineEmits(['input', 'update:modelValue']);
 watch(internalSearchText, () => {
   emit('input', internalSearchText.value);
-  emit('update:value', internalSearchText.value);
-  if (props.modelValue) {
-    console.warn('Deprecated: use v-model:value instead');
-    emit('update:modelValue', internalSearchText.value);
-  }
+  emit('update:modelValue', internalSearchText.value);
 });
 function onClearClick() {
   internalSearchText.value = '';

--- a/src/components/CvTabs/CvTabs.vue
+++ b/src/components/CvTabs/CvTabs.vue
@@ -70,7 +70,7 @@
             :class="`${carbonPrefix}--tabs--scrollable__nav-link`"
             role="tab"
             :aria-controls="tab.uid"
-            :aria-disabled="disabledTabs.has(tab.uid)"
+            :aria-disabled="disabledTabs.has(tab.uid) || null"
             :aria-selected="selectedId === tab.uid"
             :tabindex="selectedId === tab.uid ? 0 : -1"
             type="button"

--- a/src/components/CvTabs/__tests__/__snapshots__/CvTabs.spec.js.snap
+++ b/src/components/CvTabs/__tests__/__snapshots__/CvTabs.spec.js.snap
@@ -7,9 +7,9 @@ exports[`CvTabs CvTabs - test slotted tab buttons to match snapshot 1`] = `
       </svg></button>
     <!--v-if-->
     <ul class="bx--tabs--scrollable__nav" role="tablist">
-      <li class="cv-tabs-button  bx--tabs--scrollable__nav-item bx--tabs__nav-item--selected bx--tabs--scrollable__nav-item--selected" role="presentation"><button id="tab-1-link" class="bx--tabs--scrollable__nav-link" role="tab" aria-controls="tab-1" aria-disabled="false" aria-selected="true" tabindex="0" type="button">Hello <strong style="color: red;">(*)</strong></button></li>
-      <li class="cv-tabs-button  bx--tabs--scrollable__nav-item" role="presentation"><button id="tab-2-link" class="bx--tabs--scrollable__nav-link" role="tab" aria-controls="tab-2" aria-disabled="false" aria-selected="false" tabindex="-1" type="button">Origin<strong style="color: orange;">(!)</strong></button></li>
-      <li class="cv-tabs-button  bx--tabs--scrollable__nav-item" role="presentation"><button id="tab-3-link" class="bx--tabs--scrollable__nav-link" role="tab" aria-controls="tab-3" aria-disabled="false" aria-selected="false" tabindex="-1" type="button">Tab 3 label</button></li>
+      <li class="cv-tabs-button  bx--tabs--scrollable__nav-item bx--tabs__nav-item--selected bx--tabs--scrollable__nav-item--selected" role="presentation"><button id="tab-1-link" class="bx--tabs--scrollable__nav-link" role="tab" aria-controls="tab-1" aria-selected="true" tabindex="0" type="button">Hello <strong style="color: red;">(*)</strong></button></li>
+      <li class="cv-tabs-button  bx--tabs--scrollable__nav-item" role="presentation"><button id="tab-2-link" class="bx--tabs--scrollable__nav-link" role="tab" aria-controls="tab-2" aria-selected="false" tabindex="-1" type="button">Origin<strong style="color: orange;">(!)</strong></button></li>
+      <li class="cv-tabs-button  bx--tabs--scrollable__nav-item" role="presentation"><button id="tab-3-link" class="bx--tabs--scrollable__nav-link" role="tab" aria-controls="tab-3" aria-selected="false" tabindex="-1" type="button">Tab 3 label</button></li>
     </ul>
     <!--v-if--><button aria-hidden="true" aria-label="scroll right" class="bx--tab--overflow-nav-button--hidden" tabindex="-1" type="button"><svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
         <path d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"></path>

--- a/src/components/CvTooltip/CvInteractiveTooltip.vue
+++ b/src/components/CvTooltip/CvInteractiveTooltip.vue
@@ -24,7 +24,7 @@
     <div
       :id="cvId"
       ref="popup"
-      :aria-hidden="!dataVisible"
+      :aria-hidden="`${!dataVisible}`"
       :data-floating-menu-direction="direction"
       :class="[
         `${carbonPrefix}--tooltip`,


### PR DESCRIPTION
## What did you do?
While doing a migration build of one of our apps I found 2 issues.
- Some aria attributes require a strings "true" or "false" but were instead set to boolean true or false. This raised a warning in the vue migration build
    - Similarly, the aria-disabled attribute should be true or should be omitted. This raised a warning in the vue migration build.
    - https://v3-migration.vuejs.org/breaking-changes/attribute-coercion.html#overview
- I misunderstood the [v-model change in Vue 3](https://v3-migration.vuejs.org/breaking-changes/v-model.html#overview). I corrected that in cv-dropdown, cv-multiselect, and cv-search



## Were docs updated if needed?

- [x] Yes
