### PR TITLE
fix: fixes related to migration/compat build

### DIFF
--- a/src/components/CvDatePicker/CvDatePicker.vue
+++ b/src/components/CvDatePicker/CvDatePicker.vue
@@ -48,7 +48,6 @@
             :pattern="pattern"
             :placeholder="placeholder"
             @change="handleUpdateEvent"
-            @click="handleClick"
           />
           <Calendar16
             v-if="['single', 'range'].includes(getKind)"
@@ -136,9 +135,6 @@ const dateWrapper = ref(null);
 const date = ref(null);
 const todate = ref(null);
 
-const cvId = useCvId(props, true, 'date-picker-');
-const isLight = useIsLight(props);
-
 let calendar;
 
 const props = defineProps({
@@ -168,6 +164,9 @@ const props = defineProps({
   ...propsCvId,
   ...propsCvTheme,
 });
+
+const cvId = useCvId(props, true, 'date-picker-');
+const isLight = useIsLight(props);
 
 const emit = defineEmits(['update:modelValue']);
 

--- a/src/components/CvDatePicker/CvDatePicker.vue
+++ b/src/components/CvDatePicker/CvDatePicker.vue
@@ -42,8 +42,8 @@
             data-date-picker-input
             role="datepicker"
             :data-invalid="isInvalid || null"
-            :disabled="disabled"
-            :data-date-picker-input-from="getKind === 'range'"
+            :disabled="disabled || null"
+            :data-date-picker-input-from="`${getKind === 'range'}`"
             :class="`${carbonPrefix}--date-picker__input`"
             :pattern="pattern"
             :placeholder="placeholder"
@@ -87,9 +87,9 @@
             type="text"
             data-date-picker-input
             role="todatepicker"
-            :data-date-picker-input-to="kind === 'range'"
+            :data-date-picker-input-to="`${kind === 'range'}`"
             :data-invalid="isInvalid || null"
-            :disabled="disabled"
+            :disabled="disabled || null"
             :class="`${carbonPrefix}--date-picker__input`"
             :pattern="pattern"
             :placeholder="placeholder"

--- a/src/components/CvModal/CvModal.vue
+++ b/src/components/CvModal/CvModal.vue
@@ -8,7 +8,7 @@
         `cv-modal ${carbonPrefix}--modal`,
         {
           'is-visible': dataVisible,
-          [`${carbonPrefix}--modal--danger`]: kind === 'danger',
+          [`${carbonPrefix}--modal--danger`]: kind === MODAL_KIND_DANGER,
         },
       ]"
       tabindex="-1"
@@ -119,6 +119,15 @@
 </template>
 
 <script setup>
+import {
+  MODAL_KIND_DANGER,
+  MODAL_KIND_PRIMARY,
+  MODAL_KINDS,
+  MODAL_SIZE_EXTRA_SMALL,
+  MODAL_SIZE_LARGE,
+  MODAL_SIZE_SMALL,
+  MODAL_SIZES,
+} from './index';
 import CvButton from '../CvButton/CvButton.vue';
 import { carbonPrefix } from '../../global/settings';
 import { props as propsCvId, useCvId } from '../../use/cvId';
@@ -155,7 +164,11 @@ const props = defineProps({
   kind: {
     type: String,
     default: '',
-    validator: val => ['', 'danger'].includes(val),
+    validator: val => {
+      const valid = MODAL_KINDS.includes(val);
+      if (!valid) console.warn('valid kinds:', MODAL_KINDS);
+      return valid;
+    },
   },
   /**
    * boolean value if true the component user is expected to close the modal via visible property.
@@ -187,8 +200,11 @@ const props = defineProps({
    */
   size: {
     type: String,
-    validator: val =>
-      ['', 'xs', 'sm', 'small', 'md', 'large', 'lg'].includes(val),
+    validator: val => {
+      const valid = MODAL_SIZES.includes(val);
+      if (!valid) console.warn('valid sizes:', MODAL_SIZES);
+      return valid;
+    },
     default: '',
   },
   /**
@@ -333,22 +349,22 @@ const dialogAttrs = computed(() => {
   return attrs;
 });
 const primaryKind = computed(() => {
-  if (props.kind === 'danger') {
-    return 'danger';
+  if (props.kind === MODAL_KIND_DANGER) {
+    return MODAL_KIND_DANGER;
   } else {
-    return 'primary';
+    return MODAL_KIND_PRIMARY;
   }
 });
 const internalSize = computed(() => {
   switch (props.size) {
-    case 'xs':
-      return 'xs';
-    case 'sm':
+    case MODAL_SIZE_EXTRA_SMALL:
+      return MODAL_SIZE_EXTRA_SMALL;
+    case MODAL_SIZE_SMALL:
     case 'small':
-      return 'sm';
-    case 'lg':
+      return MODAL_SIZE_SMALL;
+    case MODAL_SIZE_LARGE:
     case 'large':
-      return 'lg';
+      return MODAL_SIZE_LARGE;
     default:
       return '';
   }
@@ -397,5 +413,11 @@ function onOtherBtnClick(ev) {
 }
 onBeforeUnmount(() => {
   if (dataVisible.value) hide();
+});
+
+// exposing methods
+defineExpose({
+  show,
+  hide,
 });
 </script>

--- a/src/components/CvModal/__tests__/CvModal.spec.js
+++ b/src/components/CvModal/__tests__/CvModal.spec.js
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import CvModal from '../CvModal.vue';
+import { MODAL_KIND_DANGER, MODAL_SIZE_LARGE } from '@/components/CvModal';
 
 describe('CvModal', () => {
   it('CvModal - test default and attrs', async () => {
@@ -86,9 +87,9 @@ describe('CvModal', () => {
 
     await result.rerender({
       visible: true,
-      kind: 'danger',
+      kind: MODAL_KIND_DANGER,
       primaryButtonDisabled: true,
-      size: 'lg',
+      size: MODAL_SIZE_LARGE,
       hasFormContent: true,
     });
 

--- a/src/components/CvModal/index.js
+++ b/src/components/CvModal/index.js
@@ -1,3 +1,31 @@
 import CvModal from './CvModal.vue';
-export { CvModal };
+
+const MODAL_SIZE_EXTRA_SMALL = 'xs';
+const MODAL_SIZE_SMALL = 'sm';
+const MODAL_SIZE_MEDIUM = 'md';
+const MODAL_SIZE_LARGE = 'lg';
+const MODAL_SIZES = [
+  '',
+  MODAL_SIZE_EXTRA_SMALL,
+  MODAL_SIZE_SMALL,
+  'small',
+  MODAL_SIZE_MEDIUM,
+  'medium',
+  'large',
+  MODAL_SIZE_LARGE,
+];
+const MODAL_KIND_PRIMARY = 'primary';
+const MODAL_KIND_DANGER = 'danger';
+const MODAL_KINDS = ['', MODAL_KIND_PRIMARY, MODAL_KIND_DANGER];
+
+export {
+  CvModal,
+  MODAL_SIZES,
+  MODAL_SIZE_EXTRA_SMALL,
+  MODAL_SIZE_SMALL,
+  MODAL_SIZE_LARGE,
+  MODAL_KINDS,
+  MODAL_KIND_PRIMARY,
+  MODAL_KIND_DANGER,
+};
 export default CvModal;

--- a/src/components/CvMultiSelect/CvMultiSelect.vue
+++ b/src/components/CvMultiSelect/CvMultiSelect.vue
@@ -426,8 +426,8 @@ onUpdated(checkSlots);
 onMounted(updateOptions);
 onMounted(updateSelectedItems);
 
-watch(() => props.modelValue, updateSelectedItems);
-watch(() => props.options, updateOptions);
+watch(() => props.modelValue, updateSelectedItems, { deep: true });
+watch(() => props.options, updateOptions, { deep: true });
 watch(() => props.selectionFeedback, updateOptions);
 
 const highlighted = computed({

--- a/src/components/CvNotification/CvInlineNotification.stories.js
+++ b/src/components/CvNotification/CvInlineNotification.stories.js
@@ -1,7 +1,8 @@
 import { action } from '@storybook/addon-actions';
-import { sbCompPrefix } from '../../global/storybook-utils';
+import { sbCompPrefix, storySourceCode } from '../../global/storybook-utils';
 
 import { CvInlineNotification, CvNotificationConsts } from '.';
+import DocumentationTemplate from './CvInlineNotificationTemplate.mdx';
 
 export default {
   title: `${sbCompPrefix}/CvInlineNotification`,
@@ -59,6 +60,11 @@ export default {
       control: { type: 'boolean' },
     },
   },
+  parameters: {
+    docs: {
+      page: DocumentationTemplate,
+    },
+  },
 };
 
 const template = `<cv-inline-notification v-bind="args" @action="onAction" @close="onClose" />`;
@@ -79,6 +85,10 @@ const Template = args => {
 export const Info = Template.bind({});
 Info.args = {
   kind: CvNotificationConsts.notificationKinds[0],
+  primary: true,
+};
+Info.parameters = {
+  docs: { source: { code: storySourceCode(template, Info.args) } },
 };
 
 export const InfoSquare = Template.bind({});
@@ -86,15 +96,24 @@ InfoSquare.storyName = 'Info square';
 InfoSquare.args = {
   kind: CvNotificationConsts.notificationKinds[1],
 };
+InfoSquare.parameters = {
+  docs: { source: { code: storySourceCode(template, InfoSquare.args) } },
+};
 
 export const Success = Template.bind({});
 Success.args = {
   kind: CvNotificationConsts.notificationKinds[2],
 };
+Success.parameters = {
+  docs: { source: { code: storySourceCode(template, Success.args) } },
+};
 
 export const Warning = Template.bind({});
 Warning.args = {
   kind: CvNotificationConsts.notificationKinds[3],
+};
+Warning.parameters = {
+  docs: { source: { code: storySourceCode(template, Warning.args) } },
 };
 
 export const WarningAlt = Template.bind({});
@@ -102,8 +121,46 @@ WarningAlt.storyName = 'Warning (alt)';
 WarningAlt.args = {
   kind: CvNotificationConsts.notificationKinds[4],
 };
+WarningAlt.parameters = {
+  docs: { source: { code: storySourceCode(template, WarningAlt.args) } },
+};
 
 export const Error = Template.bind({});
 Error.args = {
   kind: CvNotificationConsts.notificationKinds[5],
+};
+Error.parameters = {
+  docs: { source: { code: storySourceCode(template, Error.args) } },
+};
+
+const templateSlots = `
+  <cv-inline-notification v-bind="args">
+    <template #title>
+      <h2>Big title</h2>
+    </template>
+    <template #subtitle>
+    Lorem ipsum dolor sit amet, <a href="#">consectetur adipisicing elit</a>, seed do eiusmod tempor <strong>incididunt ut labore</strong> et dolore magna aliqua.
+    </template>
+  </cv-inline-notification>`;
+const SlotTemplate = args => {
+  return {
+    components: { CvInlineNotification },
+    template: templateSlots,
+    setup() {
+      return {
+        onAction: action('action'),
+        onClose: action('close'),
+        args,
+      };
+    },
+  };
+};
+export const Slots = SlotTemplate.bind({});
+Slots.args = {
+  kind: CvNotificationConsts.notificationKinds[0],
+  actionLabel: '',
+  hideCloseButton: true,
+};
+Slots.parameters = {
+  docs: { source: { code: storySourceCode(templateSlots, Slots.args) } },
 };

--- a/src/components/CvNotification/CvInlineNotification.vue
+++ b/src/components/CvNotification/CvInlineNotification.vue
@@ -15,10 +15,14 @@
       />
       <div :class="`${carbonPrefix}--inline-notification__text-wrapper`">
         <p :class="`${carbonPrefix}--inline-notification__title`">
-          {{ title }}
+          <slot name="title">
+            {{ title }}
+          </slot>
         </p>
         <div :class="`${carbonPrefix}--inline-notification__subtitle`">
-          {{ subTitle }}
+          <slot name="subtitle">
+            {{ subTitle }}
+          </slot>
         </div>
       </div>
     </div>
@@ -35,6 +39,7 @@
       {{ actionLabel }}
     </button>
     <button
+      v-if="!hideCloseButton"
       type="button"
       :aria-label="closeAriaLabel"
       :class="`${carbonPrefix}--inline-notification__close-button`"
@@ -66,7 +71,7 @@ export default {
       type: String,
       default: '',
     },
-    /** Notification sub title (supports HTML) */
+    /** Notification subtitle */
     subTitle: {
       type: String,
       default: '',
@@ -83,6 +88,11 @@ export default {
     },
     /** Use lower contrast version of the notification */
     lowContrast: {
+      type: Boolean,
+      default: false,
+    },
+    /** Set to true to hide the code button */
+    hideCloseButton: {
       type: Boolean,
       default: false,
     },

--- a/src/components/CvNotification/CvInlineNotificationTemplate.mdx
+++ b/src/components/CvNotification/CvInlineNotificationTemplate.mdx
@@ -1,0 +1,16 @@
+import { Meta, Title,  Primary, Stories } from '@storybook/addon-docs';
+
+<Meta isTemplate />
+
+<Title />
+
+Migration notes:
+
+- **Breaking**. The `subTitle` property no longer renders html. Please use the `subtitle` slot instead.
+- The `title` content can now be provided in the `title` slot.
+
+<Primary />
+
+<Controls />
+
+<Stories />

--- a/src/components/CvSearch/CvSearch.vue
+++ b/src/components/CvSearch/CvSearch.vue
@@ -1,7 +1,7 @@
 <template>
   <component
     :is="formItem ? 'div' : CvEmpty"
-    :class="`cv-search ${carbonPrefix}--form-item`"
+    :class="[`cv-search`, `${carbonPrefix}--form-item`, $attrs.class]"
   >
     <div
       ref="elSearch"

--- a/src/components/CvTabs/CvTabs.vue
+++ b/src/components/CvTabs/CvTabs.vue
@@ -71,7 +71,7 @@
             role="tab"
             :aria-controls="tab.uid"
             :aria-disabled="disabledTabs.has(tab.uid) || null"
-            :aria-selected="selectedId === tab.uid"
+            :aria-selected="`${selectedId === tab.uid}`"
             :tabindex="selectedId === tab.uid ? 0 : -1"
             type="button"
             @click="onTabClick(tab.uid)"
@@ -187,7 +187,7 @@ function maybeSelectFirstTab() {
   if (index > -1) selectedId.value = tabs.value[index].uid;
 }
 onMounted(maybeSelectFirstTab);
-watch(tabs, maybeSelectFirstTab);
+watch(tabs, maybeSelectFirstTab, { deep: true });
 watch(selectedId, () => {
   nextTick(() => {
     doTabClick(selectedId.value);


### PR DESCRIPTION
## What did you do?

- avoid more warning related to attributes using boolean values. Attributes that need "true" or "false" string now use strings. Attributes that are supposed to be removed if the boolean is false now use "boolean || null"
- add constants for modal kinds and size. This fits  with strategy in #591 
- issue console warning for validation failure in modal
- watching an array require "deep" to be set to true
- The inline notification subtitle supports html in Vue 2 but not Vue 3. Add a slot for user (like me) who need this feature. Also added slot for `title`. Also add doc for the slots to the storybook.

## Why did you do it?

Compiling another app with vue migration/compatibility mode revealed these issues

## Were docs updated if needed?

- [x] Yes
