### PR TITLE
fix: a11y tests for CvList, CvCheckbox, CvRadioButton, CvRadioGroup

### DIFF
--- a/src/components/CvCheckbox/CvCheckbox.vue
+++ b/src/components/CvCheckbox/CvCheckbox.vue
@@ -13,7 +13,6 @@
       type="checkbox"
       :class="`${carbonPrefix}--checkbox`"
       :checked="isChecked === true"
-      :aria-checked="`${isChecked}`"
       :value="value"
       :disabled="disabled || null"
       @focus="onFocus"
@@ -55,7 +54,12 @@ const props = defineProps({
   /**
    * Provide a label to provide a description of the Checkbox input that you are exposing to the user
    */
-  label: { type: String, default: null },
+  label: {
+    type: String,
+    default: null,
+    required: true,
+    validator: label => !!label.length,
+  },
   /**
    * Specify whether the "bx--form-item" style should be applied
    */

--- a/src/components/CvCheckbox/__tests__/CvCheckbox.accessibility.spec.js
+++ b/src/components/CvCheckbox/__tests__/CvCheckbox.accessibility.spec.js
@@ -1,0 +1,48 @@
+import { CvCheckbox } from '..';
+import { render } from '@testing-library/vue';
+
+describe('CvCheckbox - accessibility', () => {
+  it('CvCheckbox - basic', async () => {
+    const main = document.createElement('main');
+
+    const result = render(CvCheckbox, {
+      container: document.body.appendChild(main),
+      props: {
+        value: 'checkboxValue',
+        label: 'checkboxLabel',
+      },
+    });
+
+    await expect(result.container).toBeAccessible('cv-checkbox');
+  }, 10000);
+
+  it('CvCheckbox - with hidden label', async () => {
+    const main = document.createElement('main');
+
+    const result = render(CvCheckbox, {
+      container: document.body.appendChild(main),
+      props: {
+        value: 'checkboxValue',
+        label: 'checkboxLabel',
+        hideLabel: true,
+      },
+    });
+
+    await expect(result.container).toBeAccessible('cv-checkbox');
+  }, 10000);
+
+  it('CvCheckbox - checked', async () => {
+    const main = document.createElement('main');
+
+    const result = render(CvCheckbox, {
+      container: document.body.appendChild(main),
+      props: {
+        checked: true,
+        value: 'checkboxValue',
+        label: 'checkboxLabel',
+      },
+    });
+
+    await expect(result.container).toBeAccessible('cv-checkbox');
+  }, 10000);
+});

--- a/src/components/CvCheckbox/__tests__/CvCheckbox.spec.js
+++ b/src/components/CvCheckbox/__tests__/CvCheckbox.spec.js
@@ -8,7 +8,11 @@ describe('CvCheckbox', () => {
     const handler = jest.fn();
     // The render method returns a collection of utilities to query your component.
     const { emitted, getByRole } = render(CvCheckbox, {
-      props: { value: 'checkbox-1', class: 'ABC-class-123' },
+      props: {
+        value: 'checkbox-1',
+        class: 'ABC-class-123',
+        label: 'input label',
+      },
       attrs: {
         onkeydown: handler,
         'aria-label': ariaLabel,

--- a/src/components/CvList/__tests__/CvList.accessibility.spec.js
+++ b/src/components/CvList/__tests__/CvList.accessibility.spec.js
@@ -1,0 +1,32 @@
+import { CvList, CvListItem } from '..';
+import { render } from '@testing-library/vue';
+
+describe('CvList - accessibility', () => {
+  it('CvList - empty', async () => {
+    const main = document.createElement('main');
+    const result = render(CvList, {
+      container: document.body.appendChild(main),
+    });
+    await expect(result.container).toBeAccessible('cv-list');
+  }, 10000);
+
+  it('CvList - with content', async () => {
+    const main = document.createElement('main');
+
+    const result = render(
+      {
+        components: { CvList, CvListItem },
+        template: /* html */ `<cv-list>
+          <cv-list-item>List item 1</cv-list-item>
+          <cv-list-item>List item 2</cv-list-item>
+          <cv-list-item>List item 3</cv-list-item>
+        </cv-list>`,
+      },
+      {
+        container: document.body.appendChild(main),
+      }
+    );
+
+    await expect(result.container).toBeAccessible('cv-list');
+  }, 10000);
+});

--- a/src/components/CvRadioButton/CvRadioButton.stories.js
+++ b/src/components/CvRadioButton/CvRadioButton.stories.js
@@ -38,10 +38,27 @@ export default {
       type: 'boolean',
       table: {
         type: { summary: 'boolean' },
-        category: 'props',
+        category: 'CvRadioGroup - props',
       },
       description:
         'Property of CvRadioGroup component - stacks inside radio components vertically',
+    },
+    legendText: {
+      control: 'text',
+      table: {
+        type: { summary: 'text' },
+        category: 'CvRadioGroup - props',
+      },
+      description: 'Property of CvRadioGroup component',
+    },
+    hideLegend: {
+      type: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        category: 'CvRadioGroup - props',
+      },
+      description:
+        'Property of CvRadioGroup component - makes the legend visually hidden',
     },
   },
 };
@@ -105,6 +122,8 @@ const Template = (args, { argTypes }) => {
 export const Default = Template.bind({});
 Default.args = {
   vertical: false,
+  legendText: 'CvRadioGroup legend',
+  hideLegend: false,
 };
 Default.parameters = storyParametersObject(
   DefaultStoryParameters,

--- a/src/components/CvRadioButton/CvRadioButton.vue
+++ b/src/components/CvRadioButton/CvRadioButton.vue
@@ -18,10 +18,7 @@
     <!-- symbol causes problem in codepen? -->
     <label :for="cvId" :class="`${carbonPrefix}--radio-button__label`">
       <span :class="`${carbonPrefix}--radio-button__appearance`"></span>
-      <span
-        v-if="label"
-        :class="{ [`${carbonPrefix}--visually-hidden`]: hideLabel }"
-      >
+      <span :class="{ [`${carbonPrefix}--visually-hidden`]: hideLabel }">
         {{ label }}
       </span>
     </label>
@@ -35,7 +32,12 @@ import { useCvId, propsCvId, useMethods, useRadio } from '../../use';
 const props = defineProps({
   modelValue: { type: String, default: undefined },
   checked: Boolean,
-  label: { type: String, default: undefined },
+  label: {
+    type: String,
+    default: null,
+    required: true,
+    validator: label => !!label.length,
+  },
   value: { type: String, required: true },
   hideLabel: Boolean,
   labelLeft: Boolean,

--- a/src/components/CvRadioButton/CvRadioGroup.vue
+++ b/src/components/CvRadioButton/CvRadioGroup.vue
@@ -1,13 +1,22 @@
 <template>
   <div :class="`cv-radio-group ${carbonPrefix}--form-item`">
-    <div
+    <fieldset
       :class="[
         `${carbonPrefix}--radio-button-group`,
         { [`${carbonPrefix}--radio-button-group--vertical`]: vertical },
       ]"
     >
+      <legend
+        :class="[
+          `${carbonPrefix}--label`,
+          { [`${carbonPrefix}--visually-hidden`]: hideLegend },
+        ]"
+        dir="auto"
+      >
+        {{ legendText }}
+      </legend>
       <slot></slot>
-    </div>
+    </fieldset>
   </div>
 </template>
 
@@ -17,6 +26,13 @@ import { carbonPrefix } from '../../global/settings';
 
 defineProps({
   vertical: Boolean,
+  legendText: {
+    type: String,
+    default: null,
+    required: true,
+    validator: legend => !!legend.length,
+  },
+  hideLegend: Boolean,
 });
 
 const emit = defineEmits(['change']);

--- a/src/components/CvRadioButton/__tests__/CvRadioButton.accessibility.spec.js
+++ b/src/components/CvRadioButton/__tests__/CvRadioButton.accessibility.spec.js
@@ -1,4 +1,4 @@
-import { CvRadioButton } from '..';
+import { CvRadioButton, CvRadioGroup } from '..';
 import { render } from '@testing-library/vue';
 
 describe('CvRadioButton - accessibility', () => {
@@ -44,5 +44,65 @@ describe('CvRadioButton - accessibility', () => {
     });
 
     await expect(result.container).toBeAccessible('cv-radio-button');
+  }, 10000);
+});
+
+describe('CvRadioGroup - accessibility', () => {
+  it('CvRadioGroup - basic', async () => {
+    const main = document.createElement('main');
+
+    const result = render(
+      {
+        components: { CvRadioGroup, CvRadioButton },
+        template: /* html */ `<cv-radio-group legendText="radioButtonGroupLegend">
+        <cv-radio-button
+          label="radioButtonLabel1"
+          value="radioButtonValue1"
+        />
+        <cv-radio-button
+          label="radioButtonLabel2"
+          value="radioButtonValue2"
+        />
+        <cv-radio-button
+          label="radioButtonLabel3"
+          value="radioButtonValue3"
+        />
+      </cv-radio-group>`,
+      },
+      {
+        container: document.body.appendChild(main),
+      }
+    );
+
+    await expect(result.container).toBeAccessible('cv-radio-group');
+  }, 10000);
+
+  it('CvRadioGroup - with hidden legend', async () => {
+    const main = document.createElement('main');
+
+    const result = render(
+      {
+        components: { CvRadioGroup, CvRadioButton },
+        template: /* html */ `<cv-radio-group legendText="radioButtonGroupLegend" hide-legend>
+        <cv-radio-button
+          label="radioButtonLabel1"
+          value="radioButtonValue1"
+        />
+        <cv-radio-button
+          label="radioButtonLabel2"
+          value="radioButtonValue2"
+        />
+        <cv-radio-button
+          label="radioButtonLabel3"
+          value="radioButtonValue3"
+        />
+      </cv-radio-group>`,
+      },
+      {
+        container: document.body.appendChild(main),
+      }
+    );
+
+    await expect(result.container).toBeAccessible('cv-radio-group');
   }, 10000);
 });

--- a/src/components/CvRadioButton/__tests__/CvRadioButton.accessibility.spec.js
+++ b/src/components/CvRadioButton/__tests__/CvRadioButton.accessibility.spec.js
@@ -1,0 +1,48 @@
+import { CvRadioButton } from '..';
+import { render } from '@testing-library/vue';
+
+describe('CvRadioButton - accessibility', () => {
+  it('CvRadioButton - basic', async () => {
+    const main = document.createElement('main');
+
+    const result = render(CvRadioButton, {
+      container: document.body.appendChild(main),
+      attrs: {
+        value: 'radioButtonValue',
+        label: 'radioButtonLabel',
+      },
+    });
+
+    await expect(result.container).toBeAccessible('cv-radio-button');
+  }, 10000);
+
+  it('CvRadioButton - with hidden label', async () => {
+    const main = document.createElement('main');
+
+    const result = render(CvRadioButton, {
+      container: document.body.appendChild(main),
+      attrs: {
+        value: 'radioButtonValue',
+        label: 'radioButtonLabel',
+        hideLabel: true,
+      },
+    });
+
+    await expect(result.container).toBeAccessible('cv-radio-button');
+  }, 10000);
+
+  it('CvRadioButton - checked', async () => {
+    const main = document.createElement('main');
+
+    const result = render(CvRadioButton, {
+      container: document.body.appendChild(main),
+      attrs: {
+        checked: true,
+        value: 'radioButtonValue',
+        label: 'radioButtonLabel',
+      },
+    });
+
+    await expect(result.container).toBeAccessible('cv-radio-button');
+  }, 10000);
+});

--- a/src/components/CvRadioButton/__tests__/CvRadioButton.spec.js
+++ b/src/components/CvRadioButton/__tests__/CvRadioButton.spec.js
@@ -74,6 +74,7 @@ describe('CvRadioButton', () => {
   it('is not checked when checked and modelValue props are not set', async () => {
     const wrapper = shallowMount(CvRadioButton, {
       props: {
+        label: 'test label',
         labelLeft: false,
         id: '1',
         value: 'test value',
@@ -85,6 +86,7 @@ describe('CvRadioButton', () => {
   it('is checked when checked prop is set to true and modelValue prop is not set', async () => {
     const wrapper = shallowMount(CvRadioButton, {
       props: {
+        label: 'test label',
         labelLeft: false,
         id: '1',
         value: 'test value',
@@ -97,6 +99,7 @@ describe('CvRadioButton', () => {
   it('modelValue prop has higher priority than checked prop', async () => {
     const wrapper = shallowMount(CvRadioButton, {
       props: {
+        label: 'test label',
         labelLeft: false,
         id: '1',
         value: 'test value',

--- a/src/components/CvRadioButton/__tests__/CvRadioButton.spec.js
+++ b/src/components/CvRadioButton/__tests__/CvRadioButton.spec.js
@@ -117,7 +117,7 @@ describe('CvRadioGroup', () => {
   // ***************
   it('matches render when vertical', async () => {
     const wrapper = shallowMount(CvRadioGroup, {
-      props: { vertical: true },
+      props: { vertical: true, legendText: 'test legend' },
       slots: {
         default: '<div class="cv-radio-button-stub">RadioButtonStub</div>',
       },
@@ -127,7 +127,7 @@ describe('CvRadioGroup', () => {
 
   it('matches render when horizontal', async () => {
     const wrapper = shallowMount(CvRadioGroup, {
-      props: { vertical: false },
+      props: { vertical: false, legendText: 'test legend' },
       slots: {
         default: '<div class="cv-radio-button-stub">RadioButtonStub</div>',
       },
@@ -143,6 +143,9 @@ describe('CvRadioGroup', () => {
     const stubId = 'radioBtn';
     const radioButtonStub = `<div id="${stubId}"></div>`;
     const wrapper = shallowMount(CvRadioGroup, {
+      props: {
+        legendText: 'test legend',
+      },
       slots: {
         default: radioButtonStub,
       },

--- a/src/components/CvRadioButton/__tests__/__snapshots__/CvRadioButton.spec.js.snap
+++ b/src/components/CvRadioButton/__tests__/__snapshots__/CvRadioButton.spec.js.snap
@@ -12,16 +12,18 @@ exports[`CvRadioButton matches render with right label 1`] = `<div class="cv-rad
 
 exports[`CvRadioGroup matches render when horizontal 1`] = `
 <div class="cv-radio-group bx--form-item">
-  <div class="bx--radio-button-group">
+  <fieldset class="bx--radio-button-group">
+    <legend class="bx--label" dir="auto">test legend</legend>
     <div class="cv-radio-button-stub">RadioButtonStub</div>
-  </div>
+  </fieldset>
 </div>
 `;
 
 exports[`CvRadioGroup matches render when vertical 1`] = `
 <div class="cv-radio-group bx--form-item">
-  <div class="bx--radio-button-group bx--radio-button-group--vertical">
+  <fieldset class="bx--radio-button-group bx--radio-button-group--vertical">
+    <legend class="bx--label" dir="auto">test legend</legend>
     <div class="cv-radio-button-stub">RadioButtonStub</div>
-  </div>
+  </fieldset>
 </div>
 `;


### PR DESCRIPTION
Contributes to #1538 

## What did you do?

Add CvList, CvCheckbox, CvRadioButton, CvRadioGroup accessibility tests and fix components and tests if needed.

## Why did you do it?

To make component more accessible.

## How have you tested it?

With the `expect(...).toBeAccessible(...)` built in utility.

## Were docs updated if needed?

- [ ] N/A
- [ ] No
- [x] Yes

## CvRadioGroup

This component did not have a `fieldset`, `legend` pair, my solution was based on the [v10 react component](https://github.com/carbon-design-system/carbon/blob/v10/packages/react/src/components/RadioButtonGroup/RadioButtonGroup.js#L177).

The tamplate changed from this:
![image](https://github.com/carbon-design-system/carbon-components-vue/assets/63120277/7bb4e884-6cf9-4a18-bc8a-a7fe0ef53ea4)
To this:
![image](https://github.com/carbon-design-system/carbon-components-vue/assets/63120277/51cd30a0-b1ed-4bb4-a13b-5d8b86fd9a12)

