### PR TITLE
fix: replicate missing `cv-` classes from Vue2 repo

### DIFF
--- a/src/components/CvBreadcrumb/CvBreadcrumb.vue
+++ b/src/components/CvBreadcrumb/CvBreadcrumb.vue
@@ -1,6 +1,7 @@
 <template>
   <nav :aria-label="ariaLabel">
     <ol
+      class="cv-breadcrumb"
       :class="[
         `${carbonPrefix}--breadcrumb`,
         { [`${carbonPrefix}--breadcrumb--no-trailing-slash`]: noTrailingSlash },

--- a/src/components/CvBreadcrumb/CvBreadcrumbItem.vue
+++ b/src/components/CvBreadcrumb/CvBreadcrumbItem.vue
@@ -1,5 +1,6 @@
 <template>
   <li
+    class="cv-breadcrumb-item"
     :class="[
       `${carbonPrefix}--breadcrumb-item`,
       { [`${carbonPrefix}--breadcrumb-item--current`]: isCurrentPage },

--- a/src/components/CvButton/CvButton.vue
+++ b/src/components/CvButton/CvButton.vue
@@ -1,5 +1,6 @@
 <template>
   <button
+    class="cv-button"
     :class="buttonClasses"
     :disabled="disabled || skeleton"
     @click="$emit('click', $event)"

--- a/src/components/CvButton/CvButtonSet.vue
+++ b/src/components/CvButton/CvButtonSet.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    class="cv-button-set"
     :class="[
       `${carbonPrefix}--btn-set`,
       { [`${carbonPrefix}--btn-set--stacked`]: stacked },

--- a/src/components/CvButton/CvIconButton.vue
+++ b/src/components/CvButton/CvIconButton.vue
@@ -1,5 +1,6 @@
 <template>
   <button
+    class="cv-button"
     :class="[
       buttonClasses,
       `${carbonPrefix}--tooltip__trigger`,

--- a/src/components/CvCodeSnippet/CvCodeSnippet.vue
+++ b/src/components/CvCodeSnippet/CvCodeSnippet.vue
@@ -1,7 +1,12 @@
 <template>
-  <component :is="component" v-bind="subProps" @copy="handleCopy"
-    ><slot
-  /></component>
+  <component
+    :is="component"
+    v-bind="subProps"
+    class="cv-code-snippet"
+    @copy="handleCopy"
+  >
+    <slot />
+  </component>
 </template>
 
 <script>

--- a/src/components/CvCodeSnippet/_CviCodeSnippetInline.vue
+++ b/src/components/CvCodeSnippet/_CviCodeSnippetInline.vue
@@ -48,6 +48,7 @@ export default {
   setup(props, { emit }) {
     const codeId = useCvId();
     const classes = computed(() => [
+      'cv-code-snippet-inline',
       `${carbonPrefix}--snippet`,
       `${carbonPrefix}--snippet--inline`,
       {

--- a/src/components/CvCodeSnippet/_CviCodeSnippetMultiline.vue
+++ b/src/components/CvCodeSnippet/_CviCodeSnippetMultiline.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    class="cv-code-snippet-multiline"
     :class="[
       `${carbonPrefix}--snippet`,
       `${carbonPrefix}--snippet--multi`,

--- a/src/components/CvCodeSnippet/_CviCodeSnippetOneline.vue
+++ b/src/components/CvCodeSnippet/_CviCodeSnippetOneline.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    class="cv-code-snippet-oneline"
     :class="[
       `${carbonPrefix}--snippet`,
       `${carbonPrefix}--snippet--single`,

--- a/src/components/CvCodeSnippet/__tests__/CvCodeSnippetSkeleton.spec.js
+++ b/src/components/CvCodeSnippet/__tests__/CvCodeSnippetSkeleton.spec.js
@@ -20,6 +20,8 @@ describe('CvCodeSnippet', () => {
       const outsideDiv = wrapper.find('div');
       expect(new Set(outsideDiv.classes())).toEqual(
         new Set([
+          'cv-code-snippet',
+          'cv-code-snippet-oneline',
           `${carbonPrefix}--snippet`,
           `${carbonPrefix}--snippet--single`,
         ])
@@ -54,7 +56,12 @@ describe('CvCodeSnippet', () => {
 
       const outsideDiv = wrapper.find('div');
       expect(new Set(outsideDiv.classes())).toEqual(
-        new Set([`${carbonPrefix}--snippet`, `${carbonPrefix}--snippet--multi`])
+        new Set([
+          'cv-code-snippet',
+          'cv-code-snippet-multiline',
+          `${carbonPrefix}--snippet`,
+          `${carbonPrefix}--snippet--multi`,
+        ])
       );
 
       const buttonTag = wrapper.find('button');
@@ -110,6 +117,8 @@ describe('CvCodeSnippet', () => {
 
       expect(new Set(divTag.classes())).toEqual(
         new Set([
+          'cv-code-snippet',
+          'cv-code-snippet-multiline',
           `${carbonPrefix}--snippet`,
           `${carbonPrefix}--snippet--multi`,
           `${carbonPrefix}--snippet--expand`,
@@ -123,7 +132,12 @@ describe('CvCodeSnippet', () => {
       await nextTick();
 
       expect(new Set(divTag.classes())).toEqual(
-        new Set([`${carbonPrefix}--snippet`, `${carbonPrefix}--snippet--multi`])
+        new Set([
+          'cv-code-snippet',
+          `${carbonPrefix}--snippet`,
+          `${carbonPrefix}--snippet--multi`,
+          'cv-code-snippet-multiline',
+        ])
       );
 
       await wrapper.setProps({
@@ -147,6 +161,8 @@ describe('CvCodeSnippet', () => {
       const buttonTag = wrapper.find('button');
       expect(new Set(buttonTag.classes())).toEqual(
         new Set([
+          'cv-code-snippet',
+          'cv-code-snippet-inline',
           `${carbonPrefix}--copy`,
           `${carbonPrefix}--snippet`,
           `${carbonPrefix}--snippet--inline`,

--- a/src/components/CvComboBox/CvComboBox.vue
+++ b/src/components/CvComboBox/CvComboBox.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="root"
+    class="cv-combo-box"
     :class="`${carbonPrefix}--list-box__wrapper`"
     @focusout="onFocusOut"
   >

--- a/src/components/CvList/CvList.vue
+++ b/src/components/CvList/CvList.vue
@@ -1,6 +1,7 @@
 <template>
   <component
     :is="listType"
+    class="cv-list"
     :class="{
       [`${carbonPrefix}--list--nested`]: nested,
       [`${carbonPrefix}--list--ordered`]: isActuallyOrdered,

--- a/src/components/CvList/CvListItem.vue
+++ b/src/components/CvList/CvListItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <li :class="`${carbonPrefix}--list__item`"><slot /></li>
+  <li class="cv-list-item" :class="`${carbonPrefix}--list__item`"><slot /></li>
 </template>
 
 <script>

--- a/src/components/CvList/__tests__/CvList.spec.js
+++ b/src/components/CvList/__tests__/CvList.spec.js
@@ -13,7 +13,7 @@ describe('CvList', () => {
 
     const listTag = wrapper.find('ul');
     expect(new Set(listTag.classes())).toEqual(
-      new Set([`${carbonPrefix}--list--unordered`])
+      new Set(['cv-list', `${carbonPrefix}--list--unordered`])
     );
   });
 
@@ -26,7 +26,7 @@ describe('CvList', () => {
 
     const listTag = wrapper.find('ol');
     expect(new Set(listTag.classes())).toEqual(
-      new Set([`${carbonPrefix}--list--ordered`])
+      new Set(['cv-list', `${carbonPrefix}--list--ordered`])
     );
   });
 
@@ -40,6 +40,7 @@ describe('CvList', () => {
     const listTag = wrapper.find('ul');
     expect(new Set(listTag.classes())).toEqual(
       new Set([
+        'cv-list',
         `${carbonPrefix}--list--unordered`,
         `${carbonPrefix}--list--nested`,
       ])
@@ -62,6 +63,7 @@ describe('CvList', () => {
     const unorderedChildListTag = wrapper.find('ul ul');
     expect(new Set(unorderedChildListTag.classes())).toEqual(
       new Set([
+        'cv-list',
         `${carbonPrefix}--list--nested`,
         `${carbonPrefix}--list--unordered`,
       ])
@@ -86,6 +88,7 @@ describe('CvList', () => {
     const orderedChildListTag = wrapper.find('ol ol');
     expect(new Set(orderedChildListTag.classes())).toEqual(
       new Set([
+        'cv-list',
         `${carbonPrefix}--list--nested`,
         `${carbonPrefix}--list--ordered`,
       ])
@@ -107,6 +110,7 @@ describe('CvList', () => {
     const unorderedListChildListTag = unorderedWrapper.find('ul ul');
     expect(new Set(unorderedListChildListTag.classes())).toEqual(
       new Set([
+        'cv-list',
         `${carbonPrefix}--list--nested`,
         `${carbonPrefix}--list--unordered`,
       ])
@@ -129,6 +133,7 @@ describe('CvList', () => {
     const orderedListChildListTag = orderedWrapper.find('ol ul');
     expect(new Set(orderedListChildListTag.classes())).toEqual(
       new Set([
+        'cv-list',
         `${carbonPrefix}--list--nested`,
         `${carbonPrefix}--list--unordered`,
       ])

--- a/src/components/CvNotification/CvInlineNotification.vue
+++ b/src/components/CvNotification/CvInlineNotification.vue
@@ -2,6 +2,7 @@
   <div
     role="alert"
     :kind="kind"
+    class="cv-inline-notification"
     :class="[
       `${carbonPrefix}--inline-notification`,
       `${carbonPrefix}--inline-notification--${kind}`,

--- a/src/components/CvNotification/CvToastNotification.vue
+++ b/src/components/CvNotification/CvToastNotification.vue
@@ -2,6 +2,7 @@
   <div
     role="alert"
     :kind="kind"
+    class="cv-notification"
     :class="[
       `${carbonPrefix}--toast-notification`,
       `${carbonPrefix}--toast-notification--${kind}`,

--- a/src/components/CvNotification/__tests__/CvInlineNotification.spec.js
+++ b/src/components/CvNotification/__tests__/CvInlineNotification.spec.js
@@ -12,6 +12,7 @@ describe('CvInlineNotification', () => {
 
     expect(new Set(wrapper.classes())).toEqual(
       new Set([
+        'cv-inline-notification',
         `${carbonPrefix}--inline-notification`,
         `${carbonPrefix}--inline-notification--info`,
       ])
@@ -26,6 +27,7 @@ describe('CvInlineNotification', () => {
       await wrapper.setProps({ kind });
       expect(new Set(divTag.classes())).toEqual(
         new Set([
+          'cv-inline-notification',
           `${carbonPrefix}--inline-notification`,
           `${carbonPrefix}--inline-notification--${kind}`,
         ])

--- a/src/components/CvNotification/__tests__/CvToastNotification.spec.js
+++ b/src/components/CvNotification/__tests__/CvToastNotification.spec.js
@@ -12,6 +12,7 @@ describe('CvToastNotification', () => {
 
     expect(new Set(wrapper.classes())).toEqual(
       new Set([
+        'cv-notification',
         `${carbonPrefix}--toast-notification`,
         `${carbonPrefix}--toast-notification--info`,
       ])
@@ -26,6 +27,7 @@ describe('CvToastNotification', () => {
       await wrapper.setProps({ kind });
       expect(new Set(divTag.classes())).toEqual(
         new Set([
+          'cv-notification',
           `${carbonPrefix}--toast-notification`,
           `${carbonPrefix}--toast-notification--${kind}`,
         ])

--- a/src/components/CvTag/CvTag.vue
+++ b/src/components/CvTag/CvTag.vue
@@ -73,7 +73,7 @@ export default {
     });
 
     const tagClasses = computed(() => {
-      const classes = [`${carbonPrefix}--tag`];
+      const classes = [`cv-tag ${carbonPrefix}--tag`];
 
       if (props.small) classes.push(`${carbonPrefix}--tag--sm`);
 


### PR DESCRIPTION
Contributes to #1581

## What did you do?
Replicated missing `cv-` classes that were present on the components in Vue2

## Why did you do it?
To minimise amount of changes we need to do when migrating to Vue3

## How have you tested it?
run updated tests

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
