### PR TITLE
fix(storybook): brandUrl point to main root

### DIFF
--- a/.storybook/theme.js
+++ b/.storybook/theme.js
@@ -20,6 +20,6 @@ export default create({
 
   brandTitle: '@carbon/vue3',
   brandUrl:
-    'https://github.com/carbon-design-system/carbon-components-vue/tree/main/packages/v3',
+    'https://github.com/carbon-design-system/carbon-components-vue/tree/main',
   brandTarget: '_blank',
 });


### PR DESCRIPTION
## What did you do?

Updated storybook brandUrl.

## Why did you do it?

It still pointed to `packages/v3`, but `v3` is in `root` now.

## How have you tested it?

Build storybook locally, and clicked the brand name

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
