### PR TITLE
fix: restore CvTag default color from Vue2

### DIFF
--- a/src/components/CvTag/CvTag.stories.js
+++ b/src/components/CvTag/CvTag.stories.js
@@ -31,7 +31,6 @@ const Template = (args, { argTypes }) => {
 
 export const Default = Template.bind({});
 Default.args = {
-  kind: 'red',
   label: 'This is a tag',
   filter: false,
 };
@@ -43,7 +42,6 @@ Default.parameters = storyParametersObject(
 
 export const Filter = Template.bind({});
 Filter.args = {
-  kind: 'teal',
   label: 'This is a tag',
   filter: true,
 };

--- a/src/components/CvTag/CvTag.vue
+++ b/src/components/CvTag/CvTag.vue
@@ -40,7 +40,7 @@ export default {
      */
     kind: {
       type: String,
-      default: 'red',
+      default: undefined,
       validator(val) {
         return tagKinds.includes(val);
       },
@@ -80,7 +80,9 @@ export default {
       if (props.skeleton) {
         classes.push(`${carbonPrefix}--skeleton`);
       } else {
-        classes.push(`${carbonPrefix}--tag--${props.kind}`);
+        if (props.kind) {
+          classes.push(`${carbonPrefix}--tag--${props.kind}`);
+        }
 
         if (props.filter) {
           classes.push(`${carbonPrefix}--tag--filter`);


### PR DESCRIPTION
Contributes to #1588

## What did you do?
Restored CvTag default color used in Vue2 

## Why did you do it?
To preserve consistency for when migrating from Vue2 to Vue3. Also red is not the color that is the best as default value (is not neutral)

## How have you tested it?
Run unit tests; visually on served Storybook
![image](https://github.com/carbon-design-system/carbon-components-vue/assets/20342514/e7e7ba04-58a8-4b7c-a6e6-025d752a14a3)


## Were docs updated if needed?

- [x] Yes
