### PR TITLE
fix: unfocus CvCheckbox (add missing 'value' access to ref)

### DIFF
--- a/src/components/CvCheckbox/CvCheckbox.vue
+++ b/src/components/CvCheckbox/CvCheckbox.vue
@@ -80,10 +80,10 @@ const props = defineProps({
 // Track focus
 let hasFocus = ref(false);
 function onFocus() {
-  hasFocus = true;
+  hasFocus.value = true;
 }
 function onBlur() {
-  hasFocus = false;
+  hasFocus.value = false;
 }
 
 const cvId = useCvId(props);


### PR DESCRIPTION
Contributes to #1594

## What did you do?
Fix: unfocus checkbox style on blur

## Why did you do it?
Te code was broken

## How have you tested it?
Visually, run unit tests for CvCheckbox

## Were docs updated if needed?
- [x] N/A
