### PR TITLE
fix: npm 20+ install

### DIFF
--- a/.storybook/postinstall.js
+++ b/.storybook/postinstall.js
@@ -13,7 +13,12 @@ const { readFileSync, writeFileSync } = require('fs');
  * https://github.com/storybookjs/storybook/issues/11971#issuecomment-1240831460
  */
 
-addCustomControls();
+try {
+  addCustomControls();
+  console.log('storybook custom controls added');
+} catch (e) {
+  console.warn('@carbon/vue [.storybook/postinstall]', e.message);
+}
 
 function addCustomControls() {
   const file = resolve(

--- a/devPreinstall.js
+++ b/devPreinstall.js
@@ -5,6 +5,7 @@ if (!isCi) {
   try {
     require('husky').install();
   } catch (e) {
-    if (e.code !== 'MODULE_NOT_FOUND') throw e;
+    if (e.code !== 'MODULE_NOT_FOUND')
+      console.warn('@carbon/vue [devPreinstall]', e.message);
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "types": "src/index.d.ts",
   "web-types": "dist/web-types.json",
   "scripts": {
-    "postinstall": "node prepare.js && node .storybook/postinstall.js",
-    "pack_postinstall": "ibmtelemetry --config=telemetry.yml",
+    "postinstall": "node devPreinstall.js && node .storybook/postinstall.js",
+    "pack_postinstall": "node ibmtelemetry --config=telemetry.yml || true",
     "prepack": "node packrat.js --disable",
     "postpack": "node packrat.js --enable",
     "build": "vue-cli-service build --target lib --name carbon-vue-3 ./src/index.js --no-clean",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "web-types": "dist/web-types.json",
   "scripts": {
     "postinstall": "node devPreinstall.js && node .storybook/postinstall.js",
-    "pack_postinstall": "node ibmtelemetry --config=telemetry.yml || true",
+    "pack_postinstall": "npx ibmtelemetry --config=telemetry.yml || true",
     "prepack": "node packrat.js --disable",
     "postpack": "node packrat.js --enable",
     "build": "vue-cli-service build --target lib --name carbon-vue-3 ./src/index.js --no-clean",


### PR DESCRIPTION
Contributes to #1576

## What did you do?
Possible fix for npm 20+ install issues.

## Why did you do it?

- renamed prepare.js to devPreinstall.js to better account for how it is used. (Name inspired pnpm lifecycle script.)
- Do not throw error in devPreinstall.js. Instead, issue warning.
- Try catch operations in .storybook/postinstall.js & log successful completion
- Add "node" in front of "ibmtelemetry". This should not be needed since node_modules/.bin/ibmtelemetry includes "#!/usr/bin/env node". But experimentally, this is required at least by npm 20+

## How have you tested it?

See "this fails" steps in #1576 
[carbon-vue-3.0.15-4a6cf.tgz](https://github.com/user-attachments/files/15538791/carbon-vue-3.0.15-4a6cf.tgz)

### npm 10 with node 20+
```sh
nvm use 20 # - Now using node v20.13.1 (npm v10.5.2)
npm create vite@latest app-name -- --template vue
cd add-name
npm install
# Ensure that Vue app itself is running.
Run npm add ./carbon-vue-3.0.15-4a6cf.tgz
```

### pnpm
```sh
nvm use 20 # - Now using node v20.13.1 (npm v10.5.2)
npm create vite@latest app-name-pnpm -- --template vue
cd add-name-pnpm
pnpm i
# Ensure that Vue app itself is running.
Run pnpm add ./carbon-vue-3.0.15-4a6cf.tgz
```

### yarn
```sh
nvm use 20 # - Now using node v20.13.1 (npm v10.5.2)
npm create vite@latest app-name-yarn -- --template vue
cd add-name-yarn
yarn
# Ensure that Vue app itself is running.
Run yarn add ./carbon-vue-3.0.15-4a6cf.tgz
```

### direct install npm 10 with node 20+ on macos & Ubuntu 22
```sh
nvm use 20 # - Now using node v20.13.1 (npm v10.5.2)
tar -xf carbon-vue-3.0.15-1c45c.tgz
cd package 
npm install --omit=dev
```

>
> @carbon/vue@3.0.15 postinstall
> npx ibmtelemetry --config=telemetry.yml || true
>
>Log file: /var/folders/x7/_hxvmlq51p36m3h6x4zm6r6r0000gn/T/ibmtelemetry-20240609T151905131Z-405315.log
>
>added 47 packages, and audited 48 packages in 1m
>
>9 packages are looking for funding
>  run `npm fund` for details
>
>found 0 vulnerabilities

## Were docs updated if needed?

- [x] N/A
