### PR TITLE
fix: CvComboBox arrows navigation failing due to missing value access to Proxy

### DIFF
--- a/src/components/CvComboBox/CvComboBox.vue
+++ b/src/components/CvComboBox/CvComboBox.vue
@@ -342,7 +342,7 @@ function doMove(up) {
         newHighlight = currentHighlight + 1;
       }
     }
-    highlighted.value = dataOptions[newHighlight].value;
+    highlighted.value = dataOptions.value[newHighlight].value;
   }
 }
 function updateOptions() {


### PR DESCRIPTION
Contributes to #1604

## What did you do?
Fixed code, where access to Proxy was missing a 'value'


## Were docs updated if needed?
- [x] N/A
