### PR TITLE
feat: cv-file-uploader update to current File object coming from event to internalFile

### DIFF
--- a/src/components/CvFileUploader/CvFileUploader.vue
+++ b/src/components/CvFileUploader/CvFileUploader.vue
@@ -204,6 +204,7 @@ function addFiles(files) {
       internalFile.state = newFile.state;
       internalFile.invalidMessageTitle = newFile.invalidMessageTitle;
       internalFile.invalidMessage = newFile.invalidMessage;
+      internalFile.file = file
     } else {
       internalFiles.value.push(newFile);
     }

--- a/src/components/CvFileUploader/CvFileUploader.vue
+++ b/src/components/CvFileUploader/CvFileUploader.vue
@@ -204,7 +204,7 @@ function addFiles(files) {
       internalFile.state = newFile.state;
       internalFile.invalidMessageTitle = newFile.invalidMessageTitle;
       internalFile.invalidMessage = newFile.invalidMessage;
-      internalFile.file = file
+      internalFile.file = file;
     } else {
       internalFiles.value.push(newFile);
     }


### PR DESCRIPTION
Contributes to #1607 

### What did you do?
Updated to current File object coming from event to internalFile so that if a file has been modified the internalFiles are updated

### Why did you do it?
I have case where the user may add a .docx file with the same name but modified, and the current component is not updating with the modified file.

### How have you tested it?
With local test environment

### Were docs updated if needed?

- [x] N/A
