### PR TITLE
fix: created index.js for cv-grid and related components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/vue",
   "license": "Apache-2.0",
-  "version": "3.0.17-wp01",
+  "version": "3.0.17",
   "description": "A collection of components for the Carbon Design System built using Vue.js",
   "packageManager": "yarn@3.2.0",
   "main": "dist/carbon-vue-3.umd.min.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/vue",
   "license": "Apache-2.0",
-  "version": "3.0.17",
+  "version": "3.0.17-wp01",
   "description": "A collection of components for the Carbon Design System built using Vue.js",
   "packageManager": "yarn@3.2.0",
   "main": "dist/carbon-vue-3.umd.min.js",

--- a/src/components/CvGrid/index.js
+++ b/src/components/CvGrid/index.js
@@ -1,0 +1,5 @@
+import CvColumn from './CvColumn.vue';
+import CvGrid from './CvFormGroup.vue';
+import CvRow from './CvRow.vue';
+
+export { CvColumn, CvGrid, CvRow };

--- a/src/components/CvGrid/index.js
+++ b/src/components/CvGrid/index.js
@@ -1,5 +1,5 @@
 import CvColumn from './CvColumn.vue';
-import CvGrid from './CvFormGroup.vue';
+import CvGrid from './CvGrid.vue';
 import CvRow from './CvRow.vue';
 
 export { CvColumn, CvGrid, CvRow };

--- a/src/components/CvGrid/index.js
+++ b/src/components/CvGrid/index.js
@@ -3,3 +3,4 @@ import CvGrid from './CvGrid.vue';
 import CvRow from './CvRow.vue';
 
 export { CvColumn, CvGrid, CvRow };
+export default CvGrid;


### PR DESCRIPTION
This PR fixes #1608.
I just added the CvGrid's index.js that was missing. It was not possibile to import and use CvGrid and its components otherwise.