### PR TITLE
build: move dev postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
   "main": "dist/carbon-vue-3.umd.min.js",
   "types": "src/index.d.ts",
   "web-types": "dist/web-types.json",
+  "packrat": {
+    "prod_setup": "npx ibmtelemetry --config=telemetry.yml || true"
+  },
   "scripts": {
     "postinstall": "node devPreinstall.js && node .storybook/postinstall.js",
-    "pack_postinstall": "npx ibmtelemetry --config=telemetry.yml || true",
     "prepack": "node packrat.js --disable",
     "postpack": "node packrat.js --enable",
     "build": "vue-cli-service build --target lib --name carbon-vue-3 ./src/index.js --no-clean",

--- a/packrat.js
+++ b/packrat.js
@@ -1,32 +1,28 @@
+/* eslint no-console: 0 */
+
 const PackageJson = require('@npmcli/package-json');
+
+const devPostinstall = 'dev_setup';
+const packPostinstall = 'prod_setup';
 
 async function prepack() {
   const pkgJson = await PackageJson.load('./');
-  pkgJson.content.scripts['dev_postinstall'] =
+  pkgJson.content['packrat'][devPostinstall] =
     pkgJson.content.scripts['postinstall'];
   pkgJson.content.scripts['postinstall'] =
-    pkgJson.content.scripts['pack_postinstall'];
-  pkgJson.content.scripts['pack_postinstall'] = 'echo removed by packrat.js';
+    pkgJson.content['packrat'][packPostinstall];
   await pkgJson.save();
-  // eslint-disable-next-line no-console
-  console.log('scripts:', {
-    postinstall: pkgJson.content.scripts['postinstall'],
-    dev_postinstall: pkgJson.content.scripts['dev_postinstall'],
-  });
+  console.log('postinstall:', pkgJson.content.scripts['postinstall']);
+  console.log(pkgJson.content['packrat']);
 }
 async function postpack() {
   const pkgJson = await PackageJson.load('./');
-  pkgJson.content.scripts['pack_postinstall'] =
-    pkgJson.content.scripts['postinstall'];
   pkgJson.content.scripts['postinstall'] =
-    pkgJson.content.scripts['dev_postinstall'];
-  delete pkgJson.content.scripts['dev_postinstall'];
+    pkgJson.content['packrat'][devPostinstall];
+  delete pkgJson.content['packrat'][devPostinstall];
   await pkgJson.save();
-  // eslint-disable-next-line no-console
-  console.log('scripts:', {
-    postinstall: pkgJson.content.scripts['postinstall'],
-    pack_postinstall: pkgJson.content.scripts['pack_postinstall'],
-  });
+  console.log('postinstall:', pkgJson.content.scripts['postinstall']);
+  console.log(pkgJson.content['packrat']);
 }
 
 if (process.argv.length !== 3) {
@@ -41,18 +37,16 @@ if (process.argv.length !== 3) {
   console.error('usage: node packrat.js');
   console.error('Options');
   console.error('\t--enable   Enable pack (production) postinstall hook');
-  console.error('\t\trename postinstall to dev_postinstall');
-  console.error('\t\trename pack_postinstall to postinstall');
+  console.error(`\t\trename postinstall to ${devPostinstall}`);
+  console.error(`\t\trename ${packPostinstall} to postinstall`);
   console.error('\t--disable  Disable pack (production) postinstall hook');
-  console.error('\t\trename postinstall to pack_postinstall');
-  console.error('\t\trename dev_postinstall to postinstall');
+  console.error(`\t\trename postinstall to ${packPostinstall}`);
+  console.error(`\t\trename ${devPostinstall} to postinstall`);
   process.exit(1);
 }
 
 if (process.argv[2] === '--disable') {
-  // eslint-disable-next-line no-console
   prepack().then(() => console.log('updated package.json'));
 } else if (process.argv[2] === '--enable') {
-  // eslint-disable-next-line no-console
   postpack().then(() => console.log('updated package.json'));
 } else console.error('unknown argument', process.argv[2]);

--- a/packrat.js
+++ b/packrat.js
@@ -37,11 +37,10 @@ if (process.argv.length !== 3) {
   console.error('usage: node packrat.js');
   console.error('Options');
   console.error('\t--enable   Enable pack (production) postinstall hook');
-  console.error(`\t\trename postinstall to ${devPostinstall}`);
-  console.error(`\t\trename ${packPostinstall} to postinstall`);
+  console.error(`\t\tmove postinstall to "packrat".${devPostinstall}`);
+  console.error(`\t\tcopy "packrat".${packPostinstall} to postinstall`);
   console.error('\t--disable  Disable pack (production) postinstall hook');
-  console.error(`\t\trename postinstall to ${packPostinstall}`);
-  console.error(`\t\trename ${devPostinstall} to postinstall`);
+  console.error(`\t\tmove "packrat".${devPostinstall} to postinstall`);
   process.exit(1);
 }
 


### PR DESCRIPTION
Contributes to #1576 

## What did you do?

1. Move the local development postinstall (hooks for husky etc) out of the scripts area of package.json during packaging
2. Copy the package / prod postinstall (ibm telemetry) from "packrat" area of package.json to "scripts" during packaging

Since the dev postinstall is no longer in scripts there is no way for npm to find and run it. Right?
I think npm 10 may be running everything with a "_postinstall" suffix so another alternative would be to rename the "dev_postinstall"  to something else. Moving completely out of scripts area seems safer.
[carbon-vue-3.0.17-8eb61.tgz](https://github.com/user-attachments/files/16174354/carbon-vue-3.0.17-8eb61.tgz)

## Why did you do it?

node 20/npm 10 issues

## How have you tested it?

locally with local package tgz package

## Were docs updated if needed?

- [ ] N/A
