### PR TITLE
fix: dropdown menu fix for accessability announcement

### DIFF
--- a/src/components/CvDropdown/CvDropdown.vue
+++ b/src/components/CvDropdown/CvDropdown.vue
@@ -121,12 +121,22 @@
           </slot>
         </ul>
       </div>
-      <div v-if="data.isInvalid" :class="`${carbonPrefix}--form-requirement`">
+      <p
+        v-if="data.isInvalid"
+        :class="`${carbonPrefix}--form-requirement`"
+        role="alert"
+        aria-atomic="true"
+      >
         <slot name="invalid-message">{{ invalidMessage }}</slot>
-      </div>
-      <div v-else-if="isWarning" :class="`${carbonPrefix}--form-requirement`">
+      </p>
+      <p
+        v-else-if="isWarning"
+        :class="`${carbonPrefix}--form-requirement`"
+        role="alert"
+        aria-atomic="true"
+      >
         <slot name="warning-message">{{ warningMessage }}</slot>
-      </div>
+      </p>
       <div
         v-else-if="data.isHelper"
         :aria-disabled="disabled || null"


### PR DESCRIPTION

## What did you do?
Correct accessibility issue with dropdown menu.
Invalid text and warning text were not being announced in screen reader.

## Why did you do it?
Found during development by Alessio Mantegna. Fix also provided by Alessio.

## How have you tested it?
With screen reader in Safari.
Easiest place to test is with the slots story
http://localhost:6006/?path=/story/component-cvdropdown--slots
There you can toggle the warning and invalid slots and confirm they are announced.

## Were docs updated if needed?

- [x] N/A

