### PR TITLE
chore: enable provenance statements and export updates

### DIFF
--- a/.github/workflows/release-v3.yml
+++ b/.github/workflows/release-v3.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   Release:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4 # https://github.com/actions/checkout
@@ -32,12 +34,21 @@ jobs:
         run: yarn
 
       - name: Continuous integration check & build
-        run: yarn ci-check
+        id: ci-check
+        run: |
+          yarn ci-check
+          git diff --quiet src/index.js || echo EXPORTS_UPDATED=true >> "$GITHUB_OUTPUT"
+          echo "### Changed exports" >> $GITHUB_STEP_SUMMARY
+          echo "```diff" >> $GITHUB_STEP_SUMMARY
+          git diff src/index.js  >> $GITHUB_STEP_SUMMARY
+          echo "```" >> $GITHUB_STEP_SUMMARY
 
-      #- name: Commit exports
-      #  run: |
-      #    git add src/index.js
-      #    git commit -m "new exports"
+      - name: Commit exports
+        if: ${{ steps.ci-check.outputs.EXPORTS_UPDATED == 'true' }}
+        run: |
+          git add src/index.js
+          git commit -m "new exports"
+          git push
 
       # Dry run - `yarn lerna version prepatch --no-git-tag-version --no-push --yes`
       # With dist tag - `run: yarn lerna publish prepatch --dist-tag next --yes`
@@ -45,4 +56,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-        run: yarn lerna publish patch --ignore-changes src/index.js --create-release github --yes
+        run: |
+          yarn lerna version patch --ignore-changes src/index.js --create-release github --yes
+          npm publish --provenance
+

--- a/addNamedComponentExports.js
+++ b/addNamedComponentExports.js
@@ -11,6 +11,7 @@ const NEW_LINE_ENTITY = '\n';
 const COMPONENTS_PATH = path.join(__dirname, './src/components/');
 const FILE_ENCODING = 'utf8';
 const INDEX_FILE_PATH = path.join(__dirname, './src/index.js');
+const INDEX_EXPORT_MARKER = '// AUTO-GENERATED EXPORTS - DO NOT EDIT BELOW';
 
 /**
  * regex from index.js extended by: not starting from underscore
@@ -29,11 +30,21 @@ let componentsExports = [];
 function addNamedComponentExports(dir) {
   readFilesFromPath(dir);
 
-  const indexFileContent = fs.readFileSync(INDEX_FILE_PATH, FILE_ENCODING);
+  let indexFileContent = fs.readFileSync(INDEX_FILE_PATH, FILE_ENCODING);
   const exportsContent = componentsExports.join(NEW_LINE_ENTITY);
-  const fileContentToSave = indexFileContent + exportsContent + NEW_LINE_ENTITY;
 
   if (exportsWereAddedToIndex(indexFileContent, exportsContent)) return;
+
+  // remove existing exports
+  const automaticExports = indexFileContent.indexOf(INDEX_EXPORT_MARKER);
+  if (automaticExports > -1) {
+    indexFileContent = indexFileContent.substring(
+      0,
+      automaticExports + INDEX_EXPORT_MARKER.length + NEW_LINE_ENTITY.length
+    );
+  }
+
+  const fileContentToSave = indexFileContent + exportsContent + NEW_LINE_ENTITY;
 
   fs.writeFileSync(INDEX_FILE_PATH, fileContentToSave, FILE_ENCODING);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,8 @@ export default {
     }
   },
 };
+
+// AUTO-GENERATED EXPORTS - DO NOT EDIT BELOW
 export { default as CvAccordion } from './components/CvAccordion/CvAccordion.vue';
 export { default as CvAccordionItem } from './components/CvAccordion/CvAccordionItem.vue';
 export { default as CvAccordionSkeleton } from './components/CvAccordion/CvAccordionSkeleton.vue';


### PR DESCRIPTION
Contributes to #1553 

## What did you do?
- add `npm publish --provenance` per description in 1553
- add-components-exports is meant run on every publish but was blocked a bit by lerna. Now it will be run.

## How have you tested it?
- Tested locally as best I can but unfortunately due to the nature of  `npm publish --provenance`, I need to merge this and do final testing live. 
- I read a lot of docs about the provenance update and I am able to use this in dry-run mode locally.

## Were docs updated if needed?

- [x] N/A
