### PR TITLE
fix: data table batch actions

### DIFF
--- a/src/components/CvCheckbox/CvCheckbox.stories.js
+++ b/src/components/CvCheckbox/CvCheckbox.stories.js
@@ -15,7 +15,7 @@ export default {
   argTypes: {
     ...storybookControlsFromProps(propsCvCheck),
     value: {
-      type: 'string',
+      type: { raw: 'string', required: true },
       description:
         'The value associated with the input (this is also the value that is sent on submit)',
       table: {
@@ -68,6 +68,7 @@ const Template = args => {
 
 export const Default = Template.bind({});
 Default.args = { label: 'checkbox', value: 'check-1' };
+Default.parameters = { controls: { sort: 'requiredFirst' } };
 Default.parameters = storyParametersObject(
   Default.parameters,
   template,
@@ -81,7 +82,7 @@ const templateVModel = `<div>
 </cv-checkbox>
 <div style="margin-top:1rem; background-color: #888888;  padding:1rem"><div style="font-size: 150%">Sample interaction</div>
 <label for="checkbox">V-model: Check 1:</label>
-<input id="checkbox" type="checkbox" @change="(ev) => {modelValue = ev.currentTarget.checked}" />
+<input id="checkbox" type="checkbox" v-model="modelValue" />
 <div>Checked: <span style="font-weight: bold;">{{modelValue}}</span></div>
 </div>
 </div>
@@ -103,6 +104,7 @@ vModel.args = {
   label: 'checkbox',
   value: 'check-1',
 };
+vModel.parameters = { controls: { sort: 'requiredFirst' } };
 vModel.parameters = storyParametersObject(
   vModel.parameters,
   templateVModel,

--- a/src/components/CvDataTable/CvDataTable.stories.mdx
+++ b/src/components/CvDataTable/CvDataTable.stories.mdx
@@ -178,6 +178,7 @@ const skeletonTemplate = `
 - aria-label-expand-row: Aria label for expanding row expansion button. default: 'Expand current row'
 - aria-label-collapse-row: Aria label for expanding row collapse button. default: 'Collapse current row'
 - expanded: initial state of the expanded row
+- value: this is the value assign to the checkbox for tables with batch actions.
 
 **Migration notes:**
 
@@ -190,9 +191,6 @@ completion for it. See [discussion](https://github.com/vuejs/core/issues/3432) f
 `search` emit is still emitted it is just not defined directly on the component.
 - The React does not seem to have an "autoWidth" property. It is still supported here but likely the better choice is `staticWidth`.
 - Row sizes in the React component are 'xs', 'sm', 'md', 'lg', & 'xl'. The rowSizes from Vue2 are still supported.
-- The Vue 3 implementation uses an internal store to manage the state of the table. You can see updates
-to the state by setting the debug variable in the local storage. `localStorage.debug="cv:data-table-store"`
-and then reloading the page.
 - If you were using something like `this.$refs.tableEditPath.batchActive = true` to force batch actions to show even
 when no items were select, please now use the new property `stickyBatchActive`.
 

--- a/src/components/CvDataTable/CvDataTable.stories.mdx
+++ b/src/components/CvDataTable/CvDataTable.stories.mdx
@@ -21,8 +21,10 @@ const testData = ref([
   { index:"6", name:"Fortran", year:1957, oo:"No", purpose:"Engineering applications", standard:"ANSI", desc: "Fortran was originally developed by IBM in the 1950s for scientific and engineering applications, and subsequently came to dominate scientific computing."},
   { index:"7", name:"Go", year:2009, oo:"Maybe", purpose:"Networked applications", standard:"Go Spec", desc: "Go's designers were primarily motivated by their shared dislike of C++."},
 ]);
+const sortOpts = ref({index: "0", order: "none", name: "name"})
 function sortTestData(opts) {
   action('sort')(opts)
+  sortOpts.value = opts
   if (opts.order === 'none')
     return testData.value.sort((a, b) => a.index.localeCompare(b.index, 'en', { sensitivity: 'base' }));
   let direction = 1
@@ -31,6 +33,14 @@ function sortTestData(opts) {
     return testData.value.sort((a, b) => direction * a.name.localeCompare(b.name, 'en', { sensitivity: 'base' }));
   else if (opts.name === 'year')
     return testData.value.sort((a, b) => direction * (a.year - b.year));
+}
+// duplicate the test data
+const originalTestData = ref(JSON.parse(JSON.stringify(testData.value)))
+function searchTestData(opts) {
+  action('search')(opts)
+  if (!opts) testData.value = JSON.parse(JSON.stringify(originalTestData.value))
+  else testData.value = originalTestData.value.filter(data => data.name.indexOf(opts) > -1)
+  return sortTestData(sortOpts.value)
 }
 
 <Meta title={`${sbCompPrefix}/CvDataTable`} component={CvDataTable} />
@@ -59,7 +69,7 @@ setup() {
       template: undefined},
     trashIcon: TrashCanIcon,
     onSort: sortTestData,
-    onSearch: action('search'),
+    onSearch: searchTestData,
     onRowSelectChange: action('row-select-change'),
     onRowSelectChanges: action('row-select-changes'),
     onOverflowMenuClick: action('overflow-menu-click'),
@@ -77,6 +87,7 @@ setup() {
     skeletonTitle: args.title,
     skeletonHelper: args.helperText,
     testData,
+    originalTestData
     };
 },
 // And then the `args` are bound to your component with `v-bind="args"`
@@ -135,6 +146,7 @@ const expandingRowsTemplate = defaultTemplate.replace(
   "<!-- Add optional expanding data here -->",
   `<template #expandedContent>{{row.desc}}</template>`)
   .replace('@search="onSearch"', '')
+  .replace('testData', 'originalTestData')
 const skeletonTemplate = `
 <cv-data-table-skeleton
   :columns="skeletonCols"
@@ -160,7 +172,10 @@ const skeletonTemplate = `
 - Sorting, filtering and pagination are the responsibility of the component user. This component raises events to facilitate this.
   For example the test data is sorted like this but this is very specific to this data. Users will need to provide their own sort and filtering.
   ```javascript
+  // sort example
+  const sortOpts = ref({index: "0", order: "none", name: "name"})
   function sortTestData(opts) {
+    sortOpts.value = opts // remember this so it can be used in filtering
     if (opts.order === 'none')
       return testData.value.sort((a, b) => a.index.localeCompare(b.index, 'en', { sensitivity: 'base' }));
     let direction = 1
@@ -169,6 +184,12 @@ const skeletonTemplate = `
       return testData.value.sort((a, b) => direction * a.name.localeCompare(b.name, 'en', { sensitivity: 'base' }));
     else if (opts.name === 'year')
       return testData.value.sort((a, b) => direction * (a.year - b.year));
+  }
+  // filter example
+  function searchTestData(opts) {
+    if (!opts) testData.value = allData.value
+    else testData.value = allData.value.filter(data => data.name.indexOf(opts) > -1)
+    return sortTestData(sortOpts.value)
   }
   ```
 - The search bar appears only if the search event is listened for.

--- a/src/components/CvDataTable/CvDataTable.stories.mdx
+++ b/src/components/CvDataTable/CvDataTable.stories.mdx
@@ -36,8 +36,10 @@ function sortTestData(opts) {
 }
 // duplicate the test data
 const originalTestData = ref(JSON.parse(JSON.stringify(testData.value)))
+const searchOpts = ref("")
 function searchTestData(opts) {
   action('search')(opts)
+  searchOpts.value = opts
   if (!opts) testData.value = JSON.parse(JSON.stringify(originalTestData.value))
   else testData.value = originalTestData.value.filter(data => data.name.indexOf(opts) > -1)
   return sortTestData(sortOpts.value)
@@ -87,7 +89,8 @@ setup() {
     skeletonTitle: args.title,
     skeletonHelper: args.helperText,
     testData,
-    originalTestData
+    originalTestData,
+    searchOpts
     };
 },
 // And then the `args` are bound to your component with `v-bind="args"`
@@ -102,6 +105,7 @@ const defaultTemplate = `
   @overflow-menu-click="onOverflowMenuClick"
   @row-expanded="onRowExpanded"
   @pagination="onPagination"
+  :initialSearchValue="searchOpts"
   >
   <template v-if="useBatchActions" #batch-actions>
     <cv-button :icon="trashIcon" @click="onDelete">Delete</cv-button>

--- a/src/components/CvDataTable/CvDataTable.vue
+++ b/src/components/CvDataTable/CvDataTable.vue
@@ -541,7 +541,8 @@ watch(
   () => store.state[uid.value],
   () => {
     const rows = store.rows(uid);
-    headingChecked.value = dataRowsSelected.value.length === rows.length;
+    headingChecked.value =
+      rows.length > 0 && dataRowsSelected.value.length === rows.length;
   },
   { deep: true }
 );

--- a/src/components/CvDataTable/CvDataTableRow.vue
+++ b/src/components/CvDataTable/CvDataTableRow.vue
@@ -8,6 +8,7 @@
       ref="row"
       :row-id="cvId"
       v-bind="$attrs"
+      :value="value"
       :expanding-row="dataExpandable"
       :expanded="dataExpanded"
       @expanded-change="onExpandedChange"
@@ -30,6 +31,7 @@
   <cv-data-table-row-inner
     v-else
     v-bind="$attrs"
+    :value="value"
     :id="cvId"
     ref="row"
     class="cv-data-table-row"
@@ -59,6 +61,9 @@ import store from './cvDataTableStore';
 import { getBus } from '../../global/component-utils/event-bus';
 
 const props = defineProps({
+  /** The value associated with the input (required for tables with batch actions) */
+  value: { type: String, default: undefined },
+  /** This row will be initially expanded */
   expanded: Boolean,
   ...propsCvId,
 });
@@ -142,6 +147,6 @@ function onCheckedChange(val) {
     id: cvId.value,
     isChecked: val,
   });
-  bus?.emit('cv:check-change', { value: attrs.value, checked: val });
+  bus?.emit('cv:check-change', { value: props.value, checked: val });
 }
 </script>

--- a/src/components/CvDataTable/CvDataTableRow.vue
+++ b/src/components/CvDataTable/CvDataTableRow.vue
@@ -31,9 +31,9 @@
   <cv-data-table-row-inner
     v-else
     v-bind="$attrs"
-    :value="value"
     :id="cvId"
     ref="row"
+    :value="value"
     class="cv-data-table-row"
     :row-id="cvId"
     @checked-change="onCheckedChange"


### PR DESCRIPTION
Contributes to #1615 

## What did you do?
Prevent batch actions from showing for empty tables

## Why did you do it?
Batch actions should not show for empty tables. This is a regression from 3.0.14 as noted in #1615 

## How have you tested it?
Implemented the table search function in the story book. Also tested in hello carbon vue app. 

## Were docs updated if needed?

- [x] Yes
