### PR TITLE
fix: protect watcher against null calendar

### DIFF
--- a/src/components/CvDatePicker/CvDatePicker.vue
+++ b/src/components/CvDatePicker/CvDatePicker.vue
@@ -311,7 +311,7 @@ watch(
   () => props.calOptions,
   () => {
     for (const [key, value] of Object.entries(props.calOptions)) {
-      calendar.value.set(key, value);
+      calendar.value?.set(key, value);
     }
   },
   { deep: true }


### PR DESCRIPTION
Contributes to issue reported via slack

## What did you do?
Protect the date picker calOptions watcher 

## Why did you do it?
Looks like from the stack there might be a timing issue where the calendar is still null but the calOptions is updated.

## How have you tested it?
Code inspection

## Were docs updated if needed?

- [ ] N/A
