### PR TITLE
feat: cv-multi-select add title attribute to options

### DIFF
--- a/src/components/CvMultiSelect/CvMultiSelect.vue
+++ b/src/components/CvMultiSelect/CvMultiSelect.vue
@@ -163,7 +163,10 @@
           @mousemove="onMousemove(item.value)"
           @mousedown.prevent
         >
-          <div :class="`${carbonPrefix}--list-box__menu-item__option`" :title="item.label">
+          <div
+            :class="`${carbonPrefix}--list-box__menu-item__option`"
+            :title="item.label"
+          >
             <cv-checkbox
               v-model="data.selectedItems"
               tabindex="-1"

--- a/src/components/CvMultiSelect/CvMultiSelect.vue
+++ b/src/components/CvMultiSelect/CvMultiSelect.vue
@@ -163,7 +163,7 @@
           @mousemove="onMousemove(item.value)"
           @mousedown.prevent
         >
-          <div :class="`${carbonPrefix}--list-box__menu-item__option`">
+          <div :class="`${carbonPrefix}--list-box__menu-item__option`" :title="item.label">
             <cv-checkbox
               v-model="data.selectedItems"
               tabindex="-1"


### PR DESCRIPTION
Contributes to #1648

## What did you do?
It adds the title attribute to div to allow user to read all content from a label that exceeds the component width size

## Why did you do it?
I have a case with a list of options that the label is exceeding the width so the user can't read all the content
![image](https://github.com/user-attachments/assets/7f69a301-6f38-4e60-b575-4c8b75d3e10c)

## How have you tested it?
With local test environment

## Were docs updated if needed?
- [x] N/A
