### PR TITLE
feat: add size property to text and number input 

### DIFF
--- a/src/components/CvNumberInput/CvNumberInput.stories.js
+++ b/src/components/CvNumberInput/CvNumberInput.stories.js
@@ -1,6 +1,7 @@
 import { ref } from 'vue';
 import { storyParametersObject } from '../../global/storybook-utils';
 import CvNumberInput from './CvNumberInput.vue';
+import { sizeTypes } from './const';
 
 export default {
   title: 'Component/CvNumberInput',
@@ -54,6 +55,10 @@ export default {
         category: 'attributes',
       },
       description: '`step` attribute for input HTML element',
+    },
+    size: {
+      type: 'select',
+      options: Array.from(sizeTypes),
     },
     // props
     formItem: {

--- a/src/components/CvNumberInput/CvNumberInput.vue
+++ b/src/components/CvNumberInput/CvNumberInput.vue
@@ -155,8 +155,7 @@ const props = defineProps({
   /** Specify the size of the Text Input. Currently, supports the following:
    `sm`,
    `md`,
-   `lg`,
-   `xl` */
+   `lg` */
   size: {
     type: String,
     default: undefined,

--- a/src/components/CvNumberInput/CvNumberInput.vue
+++ b/src/components/CvNumberInput/CvNumberInput.vue
@@ -10,6 +10,9 @@
         {
           [`${carbonPrefix}--number--light`]: isLight,
           [`${carbonPrefix}--number--helpertext`]: isHelper,
+          [`${carbonPrefix}--number--sm`]: size === 'sm',
+          [`${carbonPrefix}--number--md`]: size === 'md',
+          [`${carbonPrefix}--number--lg`]: size === 'lg',
           [`cv-number-input`]: !formItem,
         },
       ]"
@@ -105,6 +108,7 @@ import { props as propsTheme } from '../../use/cvTheme';
 import { useCvInputHelpers } from '../../use/cvInput';
 import { carbonPrefix } from '../../global/settings';
 import CvWrapper from '../CvWrapper/CvWrapper';
+import { sizeTypes } from './const';
 
 const props = defineProps({
   disabled: Boolean,
@@ -147,6 +151,16 @@ const props = defineProps({
   step: {
     type: [String, Number],
     default: undefined,
+  },
+  /** Specify the size of the Text Input. Currently, supports the following:
+   `sm`,
+   `md`,
+   `lg`,
+   `xl` */
+  size: {
+    type: String,
+    default: undefined,
+    validator: value => sizeTypes.has(value),
   },
   warnText: {
     type: String,

--- a/src/components/CvNumberInput/const.js
+++ b/src/components/CvNumberInput/const.js
@@ -1,0 +1,1 @@
+export const sizeTypes = new Set(['sm', 'md', 'lg']);

--- a/src/components/CvTextInput/CvTextInput.stories.js
+++ b/src/components/CvTextInput/CvTextInput.stories.js
@@ -2,6 +2,7 @@ import { storyParametersObject } from '../../global/storybook-utils';
 
 import { CvTextInput, CvTextInputSkeleton } from '.';
 import { ref } from 'vue';
+import { sizeTypes, inputTypes } from './const';
 
 export default {
   title: 'Component/CvTextInput',
@@ -92,17 +93,13 @@ export default {
         category: 'props',
       },
     },
+    size: {
+      type: 'select',
+      options: Array.from(sizeTypes),
+    },
     type: {
-      type: 'string',
-      table: {
-        type: { summary: 'string' },
-        category: 'props',
-        defaultValue: { summary: 'text' },
-      },
-      options: ['text', 'password'],
-      control: {
-        type: 'select',
-      },
+      type: 'select',
+      options: Array.from(inputTypes),
     },
     warnText: {
       type: 'string',

--- a/src/components/CvTextInput/CvTextInput.vue
+++ b/src/components/CvTextInput/CvTextInput.vue
@@ -44,6 +44,10 @@
             [`${carbonPrefix}--text-input--light`]: isLight,
             [`${carbonPrefix}--text-input--warning`]: isWarn,
             [`${carbonPrefix}--password-input`]: isPassword,
+            [`${carbonPrefix}--text-input--sm`]: size === 'sm',
+            [`${carbonPrefix}--text-input--md`]: size === 'md',
+            [`${carbonPrefix}--text-input--lg`]: size === 'lg',
+            [`${carbonPrefix}--text-input--xl`]: size === 'xl',
           },
         ]"
         v-bind="$attrs"
@@ -115,7 +119,7 @@ import {
 import { carbonPrefix } from '../../global/settings';
 import { useCvId, props as propsCvId } from '../../use/cvId';
 import { useIsLight, props as propsTheme } from '../../use/cvTheme';
-import { inputTypes } from './const';
+import { inputTypes, sizeTypes } from './const';
 
 const props = defineProps({
   /**
@@ -150,6 +154,16 @@ const props = defineProps({
    * Toggle password visibility
    */
   passwordVisible: { type: Boolean, default: undefined },
+  /** Specify the size of the Text Input. Currently, supports the following:
+   `sm`,
+   `md`,
+   `lg`,
+   `xl` */
+  size: {
+    type: String,
+    default: undefined,
+    validator: value => sizeTypes.has(value),
+  },
   /**
    * Input type, only `text` and `password` are available
    */

--- a/src/components/CvTextInput/const.js
+++ b/src/components/CvTextInput/const.js
@@ -1,2 +1,3 @@
 // Currently available types for CvTextInput
 export const inputTypes = new Set(['password', 'text']);
+export const sizeTypes = new Set(['sm', 'md', 'lg', 'xl']);


### PR DESCRIPTION
Contributes to #1669

## What did you do?
Add the size property for these inputs  to match react version

## Why did you do it?
These were missing

## How have you tested it?

## Were docs updated if needed?

- [x] Yes
