### PR TITLE
fix: make ids consistent

### DIFF
--- a/src/components/CvAccordion/CvAccordionItem.vue
+++ b/src/components/CvAccordion/CvAccordionItem.vue
@@ -1,10 +1,10 @@
 <template>
   <li
+    data-allow-mismatch="children"
     data-accordion-item
     class="cv-accordion-item"
     :class="[
       `${carbonPrefix}--accordion__item`,
-
       {
         [`${carbonPrefix}--accordion__item--disabled`]: disabled,
         [`${carbonPrefix}--accordion__item--active`]: isOpen,
@@ -23,17 +23,11 @@
       @click.prevent.stop="onClick"
     >
       <ChevronRight16 :class="`${carbonPrefix}--accordion__arrow`" />
-
       <p :class="`${carbonPrefix}--accordion__title`">
-        <!-- @slot title of the accordion item -->
-
         <slot name="title"></slot>
       </p>
     </button>
-
     <div :id="cvId" :class="`${carbonPrefix}--accordion__content`">
-      <!-- @slot content of accordion item -->
-
       <slot name="content"></slot>
     </div>
   </li>

--- a/src/components/CvDataTable/CvDataTable.vue
+++ b/src/components/CvDataTable/CvDataTable.vue
@@ -160,6 +160,7 @@
                   <cv-checkbox-skeleton v-if="isSkeleton" />
                   <cv-checkbox
                     v-else
+                    :id="`col-cb-${uid}`"
                     v-model="headingChecked"
                     :form-item="false"
                     value="headingCheck"
@@ -187,6 +188,7 @@
               <slot name="data">
                 <cv-data-table-row
                   v-for="(row, rowIndex) in data"
+                  :id="`${uid}-${rowIndex}`"
                   :key="`row:${rowIndex}`"
                   ref="dataRows"
                   :value="`${rowIndex}`"
@@ -211,6 +213,7 @@
     <cv-pagination
       v-if="pagination"
       v-bind="internalPagination"
+      :id="`pagination-${uid}`"
       :number-of-items="internalNumberOfItems"
       @change="$emit('pagination', $event)"
     >
@@ -361,12 +364,16 @@ const search = ref(null);
 /** @type {Ref<Set<String>>} */
 const expandingRowIds = ref(new Set());
 provide('expanding-row-ids', expandingRowIds);
+
+const tableExpandable = ref(props.expandable);
+provide('table-expandable', tableExpandable);
 onMounted(() => {
   if (props.expandable) expandingRowIds.value.add('table-expand-row');
 });
 watch(
   () => props.expandable,
   () => {
+    tableExpandable.value = props.expandable;
     if (props.expandable) expandingRowIds.value.add('table-expand-row');
     else expandingRowIds.value.delete('table-expand-row');
   }

--- a/src/components/CvDataTable/CvDataTableRow.vue
+++ b/src/components/CvDataTable/CvDataTableRow.vue
@@ -1,10 +1,11 @@
 <template>
   <tbody
-    v-if="dataSomeExpandingRows"
+    v-if="tableExpandable"
     :id="cvId"
     class="cv-data-table-row cv-data-table-row--expandable"
   >
     <cv-data-table-row-inner
+      :id="`${cvId}-ri`"
       ref="row"
       :row-id="cvId"
       v-bind="$attrs"
@@ -75,9 +76,11 @@ watch(
   () => (rowValue.value = props.value)
 );
 
+/** @type {Ref<boolean>} */
+const tableExpandable = inject('table-expandable', ref(false));
 /** @type {Ref<Set<String>>} */
 const expandingRowIds = inject('expanding-row-ids', ref(new Set()));
-const dataExpandable = ref(false);
+const dataExpandable = ref(tableExpandable.value);
 watch(dataExpandable, value => {
   if (value && !expandingRowIds.value.has('table-expand-row')) {
     console.warn(
@@ -86,9 +89,6 @@ watch(dataExpandable, value => {
   }
   if (dataExpandable.value) expandingRowIds.value.add(cvId.value);
   else expandingRowIds.value?.delete(cvId.value);
-});
-const dataSomeExpandingRows = computed(() => {
-  return expandingRowIds.value?.size > 0;
 });
 const attrs = useAttrs();
 const rowIds = inject('row-ids', ref(new Set()));

--- a/src/components/CvDataTable/_CvDataTableRowInner.vue
+++ b/src/components/CvDataTable/_CvDataTableRowInner.vue
@@ -29,6 +29,7 @@
       <cv-checkbox-skeleton v-if="isSkeleton" />
       <cv-checkbox
         v-else
+        :id="`row-checked-${id}`"
         ref="rowChecked"
         v-model="dataChecked"
         :form-item="false"
@@ -43,7 +44,7 @@
     </td>
     <slot />
     <td v-if="hasOverflowMenu" :class="`${carbonPrefix}--table-column-menu`">
-      <cv-overflow-menu v-bind="overflowMenuOptions">
+      <cv-overflow-menu v-bind="overflowMenuOptions" :id="`om-${id}`">
         <cv-overflow-menu-item
           v-for="(item, index) in overflowMenuButtons"
           :key="`${index}`"
@@ -75,7 +76,9 @@ import {
   useSlots,
   watch,
   inject,
+  useAttrs,
 } from 'vue';
+import { useCvId } from '../../use/cvId';
 
 const props = defineProps({
   ariaLabelForBatchCheckbox: { type: String, default: undefined },
@@ -88,6 +91,9 @@ const props = defineProps({
   value: { type: String, default: undefined },
   rowId: { type: String, default: undefined },
 });
+
+const attrs = useAttrs();
+const id = useCvId(attrs, true);
 
 const isSkeleton = inject('is-skeleton', ref(false));
 /** @type {Ref<UnwrapRef<Set<>>>} */

--- a/src/components/CvMultiSelect/CvMultiSelect.vue
+++ b/src/components/CvMultiSelect/CvMultiSelect.vue
@@ -168,6 +168,7 @@
             :title="item.label"
           >
             <cv-checkbox
+              :id="`${uid}-cb-${item.value}`"
               v-model="data.selectedItems"
               tabindex="-1"
               :form-item="false"

--- a/src/components/CvPagination/CvPagination.stories.mdx
+++ b/src/components/CvPagination/CvPagination.stories.mdx
@@ -30,6 +30,7 @@ export const Template = args => ({
 const defaultTemplate = `
   <cv-pagination
     @change="onChange"
+    id="pagination-story"
     :backward-text="backwardText"
     :forward-text="forwardText"
     :page-number-label="pageNumberLabel"

--- a/src/components/CvPagination/CvPagination.vue
+++ b/src/components/CvPagination/CvPagination.vue
@@ -2,6 +2,7 @@
   <div :class="`cv-pagination ${carbonPrefix}--pagination`" data-pagination>
     <div :class="`${carbonPrefix}--pagination__left`">
       <cv-select
+        :id="`${id}-select-page-size`"
         ref="pageSizeSelect"
         :class="`${carbonPrefix}--select__item-count`"
         :label="pageSizesLabel"
@@ -29,6 +30,7 @@
     <div :class="`${carbonPrefix}--pagination__right`">
       <cv-select
         v-if="numberOfItems !== Infinity"
+        :id="`${id}-select-page`"
         ref="pageSelect"
         :class="`${carbonPrefix}--select__page-number`"
         :label="pageNumberLabel"
@@ -82,10 +84,11 @@
 
 <script setup>
 import { carbonPrefix } from '../../global/settings';
-import { computed, nextTick, onMounted, ref, watch } from 'vue';
+import { computed, nextTick, onMounted, ref, useAttrs, watch } from 'vue';
 import { CaretLeft16, CaretRight16 } from '@carbon/icons-vue';
 import CvSelect from '../CvSelect';
 import CvSelectOption from '../CvSelect/CvSelectOption.vue';
+import { useCvId } from '../../use/cvId';
 
 const emit = defineEmits(['change']);
 
@@ -101,6 +104,8 @@ const props = defineProps({
   page: { type: Number, default: undefined },
   pageSizes: { type: Array, default: () => [10, 20, 30, 40, 50] },
 });
+const attrs = useAttrs();
+const id = useCvId(attrs, true);
 
 const firstItem = ref(1);
 const pageValue = ref(1);

--- a/vue.config.js
+++ b/vue.config.js
@@ -8,8 +8,8 @@ module.exports = {
       assetFilter: function (assetFilename) {
         return assetFilename.endsWith('min.js');
       },
-      maxEntrypointSize: 300000,
-      maxAssetSize: 300000,
+      maxEntrypointSize: 600000,
+      maxAssetSize: 600000,
     },
   },
   chainWebpack: config => {


### PR DESCRIPTION
Contributes to #

## What did you do?
Make id assignments consistent. For instance, in the data table an id can be assigned
```vue
<cv-data-table id="my-table" .../>
```
But the data table includes a pagination component but the data table component user cannot set the id for this. This leads to a nuxt hydration warning.

The fix is to use the id assigned to the table to set the id of the pagination component.
```vue
 <cv-pagination :id="`pagination-${uid}`" .../>
```

## Why did you do it?
Nuxt hydration complains about issues like this. The ds and other attributes should be consistent between the server and client but when the ids are randomly generated it causes a warning.

## How have you tested it?

Local nuxt project

## Were docs updated if needed?

- [ ] N/A
