### PR TITLE
fix: for date picker, remove invalid aria role and add aria-description

### DIFF
--- a/src/components/CvDatePicker/CvDatePicker.vue
+++ b/src/components/CvDatePicker/CvDatePicker.vue
@@ -40,7 +40,8 @@
             ref="date"
             type="text"
             data-date-picker-input
-            role="datepicker"
+            data-testid="datepicker"
+            :aria-description="placeholder"
             :data-invalid="isInvalid || null"
             :disabled="disabled || null"
             :data-date-picker-input-from="`${getKind === 'range'}`"
@@ -85,7 +86,8 @@
             ref="todate"
             type="text"
             data-date-picker-input
-            role="todatepicker"
+            data-testid="todatepicker"
+            :aria-description="placeholder"
             :data-date-picker-input-to="`${kind === 'range'}`"
             :data-invalid="isInvalid || null"
             :disabled="disabled || null"

--- a/src/components/CvDatePicker/__tests__/CvDatePicker.spec.js
+++ b/src/components/CvDatePicker/__tests__/CvDatePicker.spec.js
@@ -17,7 +17,7 @@ describe('CvDatePicker', () => {
       },
     });
 
-    const datepicker = await result.findByRole('datepicker');
+    const datepicker = await result.findByTestId('datepicker');
 
     const user = userEvent.setup();
 
@@ -56,7 +56,7 @@ describe('CvDatePicker', () => {
       },
     });
 
-    const datepicker = await result.findByRole('datepicker');
+    const datepicker = await result.findByTestId('datepicker');
 
     const user = userEvent.setup();
 
@@ -118,8 +118,8 @@ describe('CvDatePicker', () => {
       },
     });
 
-    const datepicker = await result.findByRole('datepicker');
-    const todatepicker = await result.findByRole('todatepicker');
+    const datepicker = await result.findByTestId('datepicker');
+    const todatepicker = await result.findByTestId('todatepicker');
 
     const user = userEvent.setup();
 


### PR DESCRIPTION
Contributes to #1700

## What did you do?
```diff
             data-date-picker-input
-            role="datepicker"
+            data-testid="datepicker"
+            :aria-description="placeholder"
             :data-invalid="isInvalid || null"
```
See also w3 aria guidance https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/

## Why did you do it?

See issue

## How have you tested it?

Updated tests to find the component by test id

## Were docs updated if needed?

- [ ] N/A
- [ ] No
- [ ] Yes
