### PR TITLE
fix: cv-data-table related named components export

### DIFF
--- a/src/components/CvDataTable/index.js
+++ b/src/components/CvDataTable/index.js
@@ -1,3 +1,16 @@
 import CvDataTable from './CvDataTable.vue';
-export { CvDataTable };
+import CvDataTableAction from './CvDataTableAction.vue';
+import CvDataTableCell from './CvDataTableCell.vue';
+import CvDataTableHeading from './CvDataTableHeading.vue';
+import CvDataTableRow from './CvDataTableRow.vue';
+import CvDataTableSkeleton from './CvDataTableSkeleton.vue';
+
+export {
+  CvDataTable,
+  CvDataTableAction,
+  CvDataTableCell,
+  CvDataTableHeading,
+  CvDataTableSkeleton,
+  CvDataTableRow,
+};
 export default CvDataTable;


### PR DESCRIPTION
Contributes to #1714 

## What did you do?
Just exported the CvDataTable related named components

## How have you tested it?
Changing the index.js file in node_modules after install. 

## Were docs updated if needed?
- [ ] N/A
- [X] No
- [ ] Yes
