### PR TITLE
fix: prevent non-numeric input on firefox and Safari

### DIFF
--- a/src/components/CvNumberInput/CvNumberInput.vue
+++ b/src/components/CvNumberInput/CvNumberInput.vue
@@ -98,7 +98,7 @@
 </template>
 
 <script setup>
-import { computed, ref, useSlots } from 'vue';
+import { computed, ref, useSlots, nextTick } from 'vue';
 import Add16 from '@carbon/icons-vue/es/add/16';
 import Subtract16 from '@carbon/icons-vue/es/subtract/16';
 import WarningFilled16 from '@carbon/icons-vue/es/warning--filled/16';
@@ -114,7 +114,7 @@ const props = defineProps({
   disabled: Boolean,
   modelValue: {
     type: [String, Number],
-    default: '',
+    default: undefined,
   },
   formItem: {
     type: Boolean,
@@ -190,18 +190,23 @@ const modelValueType = typeof props.modelValue;
 const valuesToNaN = ['', null, undefined];
 
 const formatInputValueType = value => {
-  if (modelValueType === 'string') return value.toString();
+  if (modelValueType === 'string') return Number(value).toString();
   // According to Vue2 component if there is no value NaN is emitted
   return valuesToNaN.includes(value) ? NaN : Number(value);
 };
 
+const displayValue = ref(props.modelValue || props.min);
 const internalValue = computed({
   get() {
-    return props.modelValue;
+    return props.modelValue || displayValue.value;
   },
   set(value) {
-    const valueFormatted = formatInputValueType(value);
-    onInput(valueFormatted);
+    displayValue.value = formatInputValueType(value);
+    if (Number.isNaN(displayValue.value) || displayValue.value === 'NaN') {
+      displayValue.value = 0;
+      nextTick(() => (displayValue.value = NaN));
+    }
+    onInput(displayValue.value);
   },
 });
 

--- a/src/components/CvNumberInput/CvNumberInput.vue
+++ b/src/components/CvNumberInput/CvNumberInput.vue
@@ -98,7 +98,7 @@
 </template>
 
 <script setup>
-import { computed, ref, useSlots, nextTick } from 'vue';
+import { computed, ref, useSlots } from 'vue';
 import Add16 from '@carbon/icons-vue/es/add/16';
 import Subtract16 from '@carbon/icons-vue/es/subtract/16';
 import WarningFilled16 from '@carbon/icons-vue/es/warning--filled/16';
@@ -202,9 +202,8 @@ const internalValue = computed({
   },
   set(value) {
     displayValue.value = formatInputValueType(value);
-    if (Number.isNaN(displayValue.value) || displayValue.value === 'NaN') {
-      displayValue.value = 0;
-      nextTick(() => (displayValue.value = NaN));
+    if (typeof value === 'string') {
+      input.value.value = '';
     }
     onInput(displayValue.value);
   },


### PR DESCRIPTION
Contributes to #1710 

## What did you do?

 prevent non-numeric input on firefox and Safari

## Why did you do it?

Match React component where similar issue does not exist.

## How have you tested it?

Storybook in FF and Safari

## Were docs updated if needed?

- [ ] N/A


