### PR TITLE
fix: reset filter value when prop options change

### DIFF
--- a/src/components/CvComboBox/CvComboBox.vue
+++ b/src/components/CvComboBox/CvComboBox.vue
@@ -278,6 +278,7 @@ watch(
 watch(
   () => props.options,
   () => {
+    filter.value = '';
     updateOptions();
   }
 );


### PR DESCRIPTION
Contributes to no issue

## What did you do?
Reset the filter value when prop options change

## Why did you do it?
Because when the options array change the previous filter usually doesn't match the new options

## How have you tested it?
In local with Chrome and Firefox

## Were docs updated if needed?
There was no need

- [  ] N/A

