### PR TITLE
ci(storybook): ignore engines during Vue 2 storybook install

### DIFF
--- a/.github/workflows/deploy-vue-storybook.yml
+++ b/.github/workflows/deploy-vue-storybook.yml
@@ -50,9 +50,11 @@ jobs:
           clean: false
           path: vue2
       - name: Install vue2 dependencies
+        # Use ignore-engines because some dependencies are locked to old Node versions,
+        # and we are no longer updating Vue 2 version
         run: |
           cd ${GITHUB_WORKSPACE}/vue2
-          yarn install --offline
+          yarn install --offline --ignore-engines
       - name: Build Vue 2 storybook
         run: |
           cd ${GITHUB_WORKSPACE}/vue2


### PR DESCRIPTION
## What did you do?
Adding `--ignore-engines` when installing Vue 2 dependencies for storybook deployment.

## Why did you do it?
Storybook deployment is failing due to Vue2 branch having some dependencies that requires Node <= 17, which is no longer supported in actions. But this should not be a hard requirement.

## How have you tested it?
I did not... I need to get the PR in so I can try to run it.

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
