### PR TITLE
ci(storybook): skip install step for vue2 storybook

### DIFF
--- a/.github/workflows/deploy-vue-storybook.yml
+++ b/.github/workflows/deploy-vue-storybook.yml
@@ -49,12 +49,11 @@ jobs:
           ref: vue2
           clean: false
           path: vue2
-      - name: Install vue2 dependencies
-        # Use ignore-engines because some dependencies are locked to old Node versions,
-        # and we are no longer updating Vue 2 version
-        run: |
-          cd ${GITHUB_WORKSPACE}/vue2
-          yarn install --offline --ignore-engines
+      # Don't install dependencies, as we have them in the repository already, and we can't install them in Node >= 18
+      # - name: Install vue2 dependencies
+      #   run: |
+      #     cd ${GITHUB_WORKSPACE}/vue2
+      #     yarn install --offline --ignore-engines
       - name: Build Vue 2 storybook
         run: |
           cd ${GITHUB_WORKSPACE}/vue2


### PR DESCRIPTION
## What did you do?
Disabling dependency install step for Vue 2 storybook action.

## Why did you do it?
Install is failing, and as far as I can tell, we already have the dependencies. So it might be possible to just skip it and use the dependencies already available in the repository.

## How have you tested it?
I did not... need to get it merged so I can try.

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
