### PR TITLE
feat: fix CvDropdown overflow flashing when expanding

### DIFF
--- a/src/components/CvDropdown/CvDropdown.vue
+++ b/src/components/CvDropdown/CvDropdown.vue
@@ -36,8 +36,9 @@
           `${carbonPrefix}--label`,
           { [`${carbonPrefix}--label--disabled`]: disabled },
         ]"
-      >{{ label }}</label
       >
+        {{ label }}
+      </label>
 
       <div
         ref="listBox"
@@ -119,8 +120,8 @@
         >
           <slot>
             <cv-dropdown-item v-for="item in items" :key="item" :value="item">{{
-                item
-              }}</cv-dropdown-item>
+              item
+            }}</cv-dropdown-item>
           </slot>
         </ul>
       </div>
@@ -414,7 +415,7 @@ function onClick(ev) {
     while (
       !target.classList.contains(`${carbonPrefix}--dropdown-link`) &&
       dropList.value?.contains(target)
-      ) {
+    ) {
       target = target.parentNode; // try next one up
     }
 


### PR DESCRIPTION
Contributes to #1761

## What did you do?
Fix CvDropdown <UL> flashing the scrollbar when expanding

## Why did you do it?
Because we use the component and it is actually not great visually

## How have you tested it?
With integrated tests, storybook, and manually

## Were docs updated if needed?

- [X] N/A
- [ ] No
- [ ] Yes
