### PR TITLE
chore: remove NODE_AUTH_TOKEN from release action

### DIFF
--- a/.github/workflows/release-v3.yml
+++ b/.github/workflows/release-v3.yml
@@ -55,7 +55,6 @@ jobs:
       - name: Publish
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
         run: |
           yarn lerna version patch --ignore-changes src/index.js --create-release github --yes
           npm publish --provenance


### PR DESCRIPTION
Contributes to #1785 

## What did you do?
Removes node_auth_token from release

## Why did you do it?
we are now using the OIDC auth which no longer requires credentials ref: https://docs.npmjs.com/trusted-publishers

I think we are ready to use OIDC, so I am removing the token for a first test before I do a complete clean up.

## How have you tested it?

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
