### PR TITLE
ci: ensure we have a new npm version during release for trusted relationship

### DIFF
--- a/.github/workflows/release-v3.yml
+++ b/.github/workflows/release-v3.yml
@@ -30,6 +30,9 @@ jobs:
           node-version: 18
           registry-url: https://registry.npmjs.org
 
+      # Ensure npm 11.5.1 or later for trusted publishing
+      - run: npm install -g npm@11
+
       - name: Install dependencies
         run: yarn
 


### PR DESCRIPTION
Contributes to #1785 

## What did you do?
install latest npm 11 during release action

## Why did you do it?

it seems like trusted relationship only works on very recent versions of npm, which is not the one provided by default in our action


## How have you tested it?

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
