### PR TITLE
fix: cvoverflowmenu focus

### DIFF
--- a/src/components/CvOverflowMenu/CvOverflowMenu.vue
+++ b/src/components/CvOverflowMenu/CvOverflowMenu.vue
@@ -233,7 +233,7 @@ function doFocus() {
           tryOn.disabled
         )
       ) {
-        focusOn = focusOnList[0].parentElement;
+        focusOn = tryOn;
         break;
       }
     }


### PR DESCRIPTION
Contributes to #

## What did you do?
Fixing Cv-Overflow-Menu focus issue.
## Why did you do it?
When the first element was disabled then the focus was on a different element not on the menu
## How have you tested it?
User test
## Were docs updated if needed?
N/A
- [ ] N/A
- [ ] No
- [ ] Yes
