### PR TITLE
fix(dropdown): rerender with same value

### DIFF
--- a/src/components/CvDropdown/CvDropdown.vue
+++ b/src/components/CvDropdown/CvDropdown.vue
@@ -296,6 +296,7 @@ const emit = defineEmits(['update:modelValue', 'change']);
 watch(
   () => props.modelValue,
   () => {
+    if (props.modelValue === dataValue.value) return;
     dataValue.value = props.modelValue;
     dataCaption.value = undefined;
   }

--- a/src/components/CvDropdown/__tests__/CvDropdown.spec.js
+++ b/src/components/CvDropdown/__tests__/CvDropdown.spec.js
@@ -199,4 +199,79 @@ describe('CvDropdown', () => {
     expect(result.emitted('change')?.length).toBe(1);
     expect(result.emitted('change')[0][0]).toBe('Foundation');
   });
+
+  it('CvDropdown - same value rerender', async () => {
+    // Rerendering with the same modelValue that is already selected must not clear the
+    // displayed caption. Previously, the modelValue watcher fired on every prop update
+    // and reset dataCaption to undefined, reverting the button label to
+    // the placeholder even when the value had not changed.
+    window.focus = () => {};
+    const placeholder = 'Choose an option';
+
+    const result = render(CvDropdown, {
+      props: {
+        placeholder,
+        modelValue: 'nite-owl',
+      },
+      slots: { default: slotItems },
+    });
+
+    // Read caption text directly from the button span to avoid false positives from the
+    // same label appearing inside the hidden menu list.
+    const getCaption = () =>
+      result.container
+        .querySelector('[data-test="internalCaption"]')
+        ?.textContent?.trim();
+
+    await result.findByText('Bo-Katan Kryze');
+    expect(getCaption()).toBe('Bo-Katan Kryze');
+    expect(result.queryByText(placeholder)).toBeNull();
+
+    // User selects a different item
+    const user = userEvent.setup();
+    const button = await result.findByRole('button');
+    await user.click(button);
+    const menuItems = await result.findAllByRole('menuitemradio');
+    await user.click(menuItems[0]); // Din Djarin / value: mando
+
+    expect(getCaption()).toBe('Din Djarin');
+    expect(result.queryByText(placeholder)).toBeNull();
+
+    // Parent rerenders passing back the same modelValue — caption must remain stable
+    await result.rerender({ modelValue: 'mando' });
+
+    expect(result.queryByText(placeholder)).toBeNull();
+    expect(getCaption()).toBe('Din Djarin');
+  });
+
+  it('CvDropdown - same value rerender from initial', async () => {
+    // Variant: modelValue is provided at initial render,
+    // then the parent rerenders with the identical modelValue.
+    window.focus = () => {};
+    const placeholder = 'Choose an option';
+
+    const result = render(CvDropdown, {
+      props: {
+        placeholder,
+        modelValue: 'baby-yoda',
+      },
+      slots: { default: slotItems },
+    });
+
+    const getCaption = () =>
+      result.container
+        .querySelector('[data-test="internalCaption"]')
+        ?.textContent?.trim();
+
+    // findByText waits for child items to mount and populate the caption via provide/inject
+    await result.findByText('Din Grogu');
+    expect(getCaption()).toBe('Din Grogu');
+    expect(result.queryByText(placeholder)).toBeNull();
+
+    // Parent rerenders with the same modelValue. Caption must not revert
+    await result.rerender({ modelValue: 'baby-yoda' });
+
+    expect(result.queryByText(placeholder)).toBeNull();
+    expect(getCaption()).toBe('Din Grogu');
+  });
 });


### PR DESCRIPTION
Contributes to #

Hello, it is my first time contributing to your project, please let me know if there is anything that i could be doing differently or have made any mistakes. Thanks in advance.

## What did you do?
Added a guard to the `modelValue` watcher in `CvDropdown` so it skips updating when the new value is identical to the one already selected.

## Why did you do it?
The watcher previously cleared the internal caption on every prop update, even when the value hadn't changed. This caused the displayed label to revert to the placeholder text whenever a parent component rerendered with the same modelValue

I found this out because my application does optimistic frontend update before receiving the true updated data from the backend. In my case backend returned the same value that was already optimistically updated and the dropdown displayed the placeholder.

## How have you tested it?
Added two tests, they failed before and now they pass. Also tested in my real world application and it works as expected now.

## Were docs updated if needed?

- [x] N/A
- [ ] No
- [ ] Yes
