### PR TITLE
fix: correct sucessfully→successfully typo in release.sh

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,7 +1,7 @@
 echo
 printf "Releease checklist"
 echo
-read  -n 1 -p "Has http://vue.carbondesignsystem.com been sucessfully deployed with the updates [yN]? " answer1
+read  -n 1 -p "Has http://vue.carbondesignsystem.com been successfully deployed with the updates [yN]? " answer1
 [ -z "$answer1" ] && answer1="n"  # if 'no' have to be default choice
 
 if [ "$answer1" != "y" ] && [ "$answer1" != "Y" ]


### PR DESCRIPTION
## Summary
Corrected the `sucessfully` → `successfully` typo in the deployment confirmation prompt (release.sh line 4).

## Changes
- release.sh: Fixed user prompt typo

## Testing
- Shell script syntax check performed