### PR TITLE
fix(CvPagination): stop stale change re-emits, add opt-in controlled mode and i18n formatters

### DIFF
--- a/src/components/CvPagination/CvPagination.stories.mdx
+++ b/src/components/CvPagination/CvPagination.stories.mdx
@@ -3,9 +3,29 @@ import { CvPagination } from '.';
 import { sbCompPrefix } from '../../global/storybook-utils';
 import { action } from '@storybook/addon-actions';
 import { ref } from 'vue';
-const myPage=ref(1);
-const myPageSizes=ref([5,7,10,11,13])
-const myNumItems=ref(13)
+const myPage = ref(1);
+const myPageSizes = ref([5, 7, 10, 11, 13]);
+const myNumItems = ref(13);
+const controlledPage = ref(1);
+const controlledPageSize = ref(10);
+const maxAllowedPage = ref(3);
+const onUpdatePageAction = action('update:page');
+const onUpdatePageSizeAction = action('update:page-size');
+function onUpdatePage(page) {
+  onUpdatePageAction(page);
+  // simulate a parent that constrains the page: requests past
+  // maxAllowedPage are declined by simply not assigning them back.
+  if (page <= maxAllowedPage.value) {
+    controlledPage.value = page;
+  }
+}
+function onUpdatePageSize(pageSize) {
+  onUpdatePageSizeAction(pageSize);
+  controlledPageSize.value = pageSize;
+}
+const spanishRangeTextFormatter = ({ start, end, items }) =>
+  `Del ${start} al ${end} de ${items}`;
+const germanPageOfPagesFormatter = ({ pages }) => `von ${pages} Seiten`;
 
 <Meta title={`${sbCompPrefix}/CvPagination`} component={CvPagination} />
 
@@ -21,6 +41,13 @@ export const Template = args => ({
       myPage,
       myPageSizes,
       myNumItems,
+      controlledPage,
+      controlledPageSize,
+      maxAllowedPage,
+      onUpdatePage,
+      onUpdatePageSize,
+      spanishRangeTextFormatter,
+      germanPageOfPagesFormatter,
       onChange: action('change'),
     };
   },
@@ -75,10 +102,42 @@ const slotsTemplate = `
   </template>
   </cv-pagination>
 `;
+const controlledTemplate = `
+  <cv-pagination
+    @change="onChange"
+    v-model:page="controlledPage"
+    v-model:page-size="controlledPageSize"
+    @update:page="onUpdatePage"
+    @update:page-size="onUpdatePageSize"
+    :number-of-items="103">
+  </cv-pagination>
+  <div style="margin-top:2rem; background-color: #888888; padding:1rem">
+    <h3>Parent-owned state</h3>
+    <p>page: {{controlledPage}}, page size: {{controlledPageSize}}</p>
+    <p>
+      Requests for a page beyond max-allowed-page are declined by this
+      story (the parent simply doesn't assign the requested page back) -
+      the displayed page stays put instead of drifting or getting stuck.
+    </p>
+    max allowed page:
+    <button @click="maxAllowedPage--">-</button>
+    {{maxAllowedPage}}
+    <button @click="maxAllowedPage++">+</button>
+  </div>
+`;
+const formattersTemplate = `
+  <cv-pagination
+    @change="onChange"
+    :number-of-items="103"
+    :range-text-formatter="spanishRangeTextFormatter"
+    :page-of-pages-formatter="germanPageOfPagesFormatter">
+  </cv-pagination>
+`;
 
 # CvPagination
 
 Migration notes:
+
 - If you specify `pageNumberLabel` a trailing colon (:) is no longer automatically appended to the text
 
 <Canvas>
@@ -111,13 +170,12 @@ Migration notes:
     argTypes={{
       page: { control: false },
       pageSizes: { control: false },
-      numberOfItems: { control: false }
+      numberOfItems: { control: false },
     }}
   >
     {Template.bind({})}
   </Story>
 </Canvas>
-
 
 Use slots to set the range text and "of n pages" text. A good use case for this is internationalization.
 
@@ -126,13 +184,7 @@ Use slots to set the range text and "of n pages" text. A good use case for this 
     name="Slots"
     parameters={{
       controls: {
-        exclude: [
-          'default',
-          'template',
-          'data',
-          'change',
-          'of-n-pages',
-        ],
+        exclude: ['default', 'template', 'data', 'change', 'of-n-pages'],
       },
       docs: { source: { code: slotsTemplate } },
     }}
@@ -158,10 +210,71 @@ Use slots to set the range text and "of n pages" text. A good use case for this 
       backwardsButtonDisabled: false,
       forwardsButtonDisabled: false,
       actualItemsOnPage: Infinity,
-      locale: 'en'
+      locale: 'en',
     }}
-    argTypes={{
+    argTypes={{}}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+Bind `v-model:page` and/or `v-model:page-size` to opt in to controlled mode:
+the component no longer moves on its own, it emits `update:page` /
+`update:page-size` and only shows the new value once the parent assigns it
+back through the prop. This lets a parent veto a page change - useful when
+loading the next page's data can fail, or is gated behind other state.
+
+<Canvas>
+  <Story
+    name="Controlled"
+    parameters={{
+      controls: {
+        exclude: [
+          'default',
+          'template',
+          'data',
+          'range-text',
+          'change',
+          'of-n-pages',
+        ],
+      },
+      docs: { source: { code: controlledTemplate } },
     }}
+    args={{
+      data: {},
+      template: controlledTemplate,
+    }}
+    argTypes={{}}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+Use `rangeTextFormatter` and `pageOfPagesFormatter` to translate the range
+and page-count text without reimplementing the `range-text` / `of-n-pages`
+slots.
+
+<Canvas>
+  <Story
+    name="Formatters"
+    parameters={{
+      controls: {
+        exclude: [
+          'default',
+          'template',
+          'data',
+          'range-text',
+          'change',
+          'of-n-pages',
+        ],
+      },
+      docs: { source: { code: formattersTemplate } },
+    }}
+    args={{
+      data: {},
+      template: formattersTemplate,
+    }}
+    argTypes={{}}
   >
     {Template.bind({})}
   </Story>

--- a/src/components/CvPagination/CvPagination.vue
+++ b/src/components/CvPagination/CvPagination.vue
@@ -84,13 +84,20 @@
 
 <script setup>
 import { carbonPrefix } from '../../global/settings';
-import { computed, nextTick, onMounted, ref, useAttrs, watch } from 'vue';
+import {
+  computed,
+  getCurrentInstance,
+  onMounted,
+  ref,
+  useAttrs,
+  watch,
+} from 'vue';
 import { CaretLeft16, CaretRight16 } from '@carbon/icons-vue';
 import CvSelect from '../CvSelect';
 import CvSelectOption from '../CvSelect/CvSelectOption.vue';
 import { useCvId } from '../../use/cvId';
 
-const emit = defineEmits(['change']);
+const emit = defineEmits(['change', 'update:page', 'update:pageSize']);
 
 const props = defineProps({
   backwardsButtonDisabled: { type: Boolean, default: false },
@@ -102,16 +109,35 @@ const props = defineProps({
   numberOfItems: { type: Number, default: Infinity },
   actualItemsOnPage: { type: Number, default: Infinity },
   page: { type: Number, default: undefined },
+  pageSize: { type: Number, default: undefined },
   pageSizes: { type: Array, default: () => [10, 20, 30, 40, 50] },
 });
 const attrs = useAttrs();
 const cvId = useCvId(attrs, true);
 
+// Read once at setup time: whether the parent bound a v-model listener for
+// this prop. vnode.props is a plain object Vue replaces on patch, not
+// something Vue's reactivity system tracks, so this can't be a computed()
+// that reacts to listeners being added/removed later - it only reflects
+// how the component was initially used.
+const instance = getCurrentInstance();
+const pageControlled = 'onUpdate:page' in (instance.vnode.props || {});
+const pageSizeControlled = 'onUpdate:pageSize' in (instance.vnode.props || {});
+
 const firstItem = ref(1);
-const pageValue = ref(1);
-const pageSizeValue = ref(10);
+const internalPage = ref(1);
+const internalPageSize = ref(10);
 const pageCount = ref(1);
 const pages = ref([1]);
+
+const pageValue = computed(() =>
+  pageControlled && props.page !== undefined ? props.page : internalPage.value
+);
+const pageSizeValue = computed(() =>
+  pageSizeControlled && props.pageSize !== undefined
+    ? props.pageSize
+    : internalPageSize.value
+);
 
 const noWayBack = computed(() => {
   return props.backwardsButtonDisabled || pageValue.value === 1;
@@ -162,16 +188,23 @@ const internalValue = computed(() => {
 });
 
 function adjustValues() {
-  pageSizeValue.value = newPageSizeValue(props.pageSizes);
+  if (!pageSizeControlled) {
+    internalPageSize.value = newPageSizeValue(props.pageSizes);
+  }
   pageCount.value = newPageCount(props.numberOfItems, pageSizeValue.value);
-  pageValue.value = newPageValue(props.page, pageCount.value);
+  if (!pageControlled) {
+    internalPage.value = newPageValue(props.page, pageCount.value);
+  }
   pages.value = newPagesArray(pageCount.value);
   firstItem.value = newFirstItem(pageValue.value, pageSizeValue.value);
 }
 onMounted(() => {
   adjustValues();
-  // always emit on mount
-  emit('change', internalValue.value);
+  // always emit on mount, unless both page and pageSize are fully
+  // controlled by the parent, in which case nothing here was derived.
+  if (!pageControlled || !pageSizeControlled) {
+    emit('change', internalValue.value);
+  }
 });
 watch(
   () => props.pageSizes,
@@ -186,36 +219,46 @@ watch(
   () => adjustValues()
 );
 
+function propose(nextPage, nextPageSize) {
+  if (!pageControlled) {
+    internalPage.value = nextPage;
+  }
+  if (!pageSizeControlled) {
+    internalPageSize.value = nextPageSize;
+  }
+  firstItem.value = newFirstItem(nextPage, nextPageSize);
+
+  if (pageControlled && nextPage !== pageValue.value) {
+    emit('update:page', nextPage);
+  }
+  if (pageSizeControlled && nextPageSize !== pageSizeValue.value) {
+    emit('update:pageSize', nextPageSize);
+  }
+  emit('change', {
+    start: firstItem.value,
+    page: nextPage,
+    length: nextPageSize,
+  });
+}
 function onPageChange(newVal) {
-  pageValue.value = parseInt(newVal, 10);
-  firstItem.value = newFirstItem(pageValue.value, pageSizeValue.value);
-  emit('change', internalValue.value);
+  propose(parseInt(newVal, 10), pageSizeValue.value);
 }
 function onPageSizeChange(newVal) {
-  pageSizeValue.value = parseInt(newVal, 10);
-  pageCount.value = newPageCount(props.numberOfItems, pageSizeValue.value);
-  pages.value = newPagesArray(pageCount.value);
-  // what page is firstItem on
-  nextTick(() => {
-    // setting pageValue immediately seems to cause a problem - test set pageSize to 40, page to 3, set pageSize to 10
-    // this previously resulted in 1 being set on Chrome (other browsers untested)
-    pageValue.value = Math.ceil(firstItem.value / pageSizeValue.value);
-    firstItem.value = newFirstItem(pageValue.value, pageSizeValue.value);
-    emit('change', internalValue.value);
-  });
+  const nextPageSize = parseInt(newVal, 10);
+  const nextPageCount = newPageCount(props.numberOfItems, nextPageSize);
+  pageCount.value = nextPageCount;
+  pages.value = newPagesArray(nextPageCount);
+  const nextPage = Math.ceil(firstItem.value / nextPageSize);
+  propose(nextPage, nextPageSize);
 }
 function onPrevPage() {
   if (pageValue.value > 1) {
-    pageValue.value--;
-    firstItem.value = newFirstItem(pageValue.value, pageSizeValue.value);
-    emit('change', internalValue.value);
+    propose(pageValue.value - 1, pageSizeValue.value);
   }
 }
 function onNextPage() {
   if (pageValue.value < pageCount.value) {
-    pageValue.value++;
-    firstItem.value = newFirstItem(pageValue.value, pageSizeValue.value);
-    emit('change', internalValue.value);
+    propose(pageValue.value + 1, pageSizeValue.value);
   }
 }
 function newPageValue(page, lastPage) {

--- a/src/components/CvPagination/CvPagination.vue
+++ b/src/components/CvPagination/CvPagination.vue
@@ -191,10 +191,6 @@ function onPageChange(newVal) {
   firstItem.value = newFirstItem(pageValue.value, pageSizeValue.value);
   emit('change', internalValue.value);
 }
-watch(
-  () => props.numberOfItems,
-  () => onPageSizeChange(pageSizeValue.value)
-);
 function onPageSizeChange(newVal) {
   pageSizeValue.value = parseInt(newVal, 10);
   pageCount.value = newPageCount(props.numberOfItems, pageSizeValue.value);

--- a/src/components/CvPagination/CvPagination.vue
+++ b/src/components/CvPagination/CvPagination.vue
@@ -111,6 +111,8 @@ const props = defineProps({
   page: { type: Number, default: undefined },
   pageSize: { type: Number, default: undefined },
   pageSizes: { type: Array, default: () => [10, 20, 30, 40, 50] },
+  rangeTextFormatter: { type: Function, default: undefined },
+  pageOfPagesFormatter: { type: Function, default: undefined },
 });
 const attrs = useAttrs();
 const cvId = useCvId(attrs, true);
@@ -153,6 +155,9 @@ const ofNPagesProps = computed(() => {
 });
 const pageOfPages = computed(() => {
   const { pages, items } = ofNPagesProps.value;
+  if (props.pageOfPagesFormatter) {
+    return props.pageOfPagesFormatter({ pages, items, page: pageValue.value });
+  }
   if (items !== Infinity) {
     return `of ${pages} pages`;
   }
@@ -173,6 +178,9 @@ const rangeProps = computed(() => {
 const rangeText = computed(() => {
   const { start, end, items } = rangeProps.value;
 
+  if (props.rangeTextFormatter) {
+    return props.rangeTextFormatter({ start, end, items });
+  }
   if (items !== Infinity) {
     return `${start}-${end} of ${items} items`;
   } else {

--- a/src/components/CvPagination/__tests__/CvPagination.spec.js
+++ b/src/components/CvPagination/__tests__/CvPagination.spec.js
@@ -231,4 +231,29 @@ describe('CvPagination', () => {
     await result.findByText('of 3 pages');
     expect(result.emitted('change')?.length).toBe(1);
   });
+
+  it('rangeTextFormatter and pageOfPagesFormatter override the rendered text when supplied', async () => {
+    const numberOfItems = 1223;
+    const result = render(CvPagination, {
+      props: {
+        numberOfItems,
+        rangeTextFormatter: ({ start, end, items }) =>
+          `Del ${start} al ${end} de ${items}`,
+        pageOfPagesFormatter: ({ pages }) => `von ${pages} Seiten`,
+      },
+    });
+
+    await result.findByText(`Del 1 al 10 de ${numberOfItems}`);
+    await result.findByText('von 123 Seiten');
+  });
+
+  it('omitting the formatters reproduces the default English text exactly', async () => {
+    const numberOfItems = 1223;
+    const result = render(CvPagination, {
+      props: { numberOfItems },
+    });
+
+    await result.findByText(`1-10 of ${numberOfItems} items`);
+    await result.findByText('of 123 pages');
+  });
 });

--- a/src/components/CvPagination/__tests__/CvPagination.spec.js
+++ b/src/components/CvPagination/__tests__/CvPagination.spec.js
@@ -165,4 +165,70 @@ describe('CvPagination', () => {
     expect(result.emitted('change')?.length).toBe(2);
     expect(result.emitted('change')[1][0].length).toBe(20);
   });
+
+  it('with v-model:page (onUpdate:page listener present), clicking forward emits update:page and only moves once the prop updates', async () => {
+    const result = render(CvPagination, {
+      props: {
+        numberOfItems: 30,
+        page: 1,
+        'onUpdate:page': val => result.rerender({ page: val }),
+      },
+    });
+    const [, forward] = await result.findAllByRole('button');
+
+    const user = userEvent.setup();
+    await user.click(forward);
+
+    expect(result.emitted('update:page')?.length).toBe(1);
+    expect(result.emitted('update:page')[0]).toEqual([2]);
+
+    const pageSelect = await result.findByLabelText('Page number:');
+    expect(pageSelect.value).toBe('2');
+  });
+
+  it('with v-model:page and a parent that ignores the event, the rendered page does not drift and does not get stuck', async () => {
+    const result = render(CvPagination, {
+      props: {
+        numberOfItems: 30,
+        page: 1,
+        'onUpdate:page': () => {},
+      },
+    });
+    const [, forward] = await result.findAllByRole('button');
+
+    const user = userEvent.setup();
+    await user.click(forward);
+    expect(result.emitted('update:page')?.length).toBe(1);
+
+    // parent ignored the request; re-asserting the same page value must not
+    // leave the component stuck unable to propose page 2 again.
+    await result.rerender({ page: 1 });
+    await user.click(forward);
+    expect(result.emitted('update:page')?.length).toBe(2);
+    expect(result.emitted('update:page')[1]).toEqual([2]);
+  });
+
+  it('with both v-model:page and v-model:pageSize, mounting emits no change', async () => {
+    const result = render(CvPagination, {
+      props: {
+        numberOfItems: 30,
+        page: 1,
+        pageSize: 10,
+        'onUpdate:page': () => {},
+        'onUpdate:pageSize': () => {},
+      },
+    });
+
+    await result.findByText('of 3 pages');
+    expect(result.emitted('change')).toBeUndefined();
+  });
+
+  it('uncontrolled usage (plain :page, no listener) behaves identically to today, including the mount emit', async () => {
+    const result = render(CvPagination, {
+      props: { numberOfItems: 30, page: 1 },
+    });
+
+    await result.findByText('of 3 pages');
+    expect(result.emitted('change')?.length).toBe(1);
+  });
 });

--- a/src/components/CvPagination/__tests__/CvPagination.spec.js
+++ b/src/components/CvPagination/__tests__/CvPagination.spec.js
@@ -117,4 +117,52 @@ describe('CvPagination', () => {
     await result.findByText(`From 1 to 10 out of ${numberOfItems}`);
     await result.findByText(`out of 123 pages`);
   });
+
+  it('does not emit change when numberOfItems changes on its own', async () => {
+    const result = render(CvPagination, {
+      props: { numberOfItems: 10 },
+    });
+
+    await result.findByText(`of 1 pages`);
+    expect(result.emitted('change')?.length).toBe(1); // mount emit only
+
+    await result.rerender({ numberOfItems: 100 });
+    await result.findByText(`of 10 pages`);
+    expect(result.emitted('change')?.length).toBe(1);
+  });
+
+  it('emits exactly one change for a user action followed by a later numberOfItems change', async () => {
+    const result = render(CvPagination, {
+      props: { numberOfItems: 30 },
+    });
+    const [, forward] = await result.findAllByRole('button');
+
+    const user = userEvent.setup();
+    await user.click(forward);
+    expect(result.emitted('change')?.length).toBe(2);
+
+    await result.rerender({ numberOfItems: 100 });
+    await result.findByText(`of 10 pages`);
+    expect(result.emitted('change')?.length).toBe(2);
+  });
+
+  it('reports the new page size, not the abandoned one, when numberOfItems changes afterwards', async () => {
+    const result = render(CvPagination, {
+      props: {
+        numberOfItems: 200,
+        page: 5,
+        pageSizes: [10, 20],
+      },
+    });
+    const select = await result.findByLabelText('Items per page:');
+
+    const user = userEvent.setup();
+    await user.selectOptions(select, ['20']);
+    expect(result.emitted('change')?.length).toBe(2);
+    expect(result.emitted('change')[1][0].length).toBe(20);
+
+    await result.rerender({ numberOfItems: 100 });
+    expect(result.emitted('change')?.length).toBe(2);
+    expect(result.emitted('change')[1][0].length).toBe(20);
+  });
 });


### PR DESCRIPTION
Description:

## What did you do?

Fixed CvPagination re-emitting a change event with stale data when numberOfItems changes by itself. Also added an opt-in controlled mode with **v-model:page** and **v-model:page-size**, plus optional rangeTextFormatter and **pageOfPagesFormatter** props for i18n.

Added a few stories to cover the new controlled mode and formatters.

## Why did you do it?

The numberOfItems watcher was triggering **change** as if the user had picked a new page size, even when the data was simply updated.

Also, page and pageSize were only used as initial values. This meant a parent couldn't really reject a page change (the component could silently get out of sync and eventually get stuck)

The new formatter props make it possible to translate the range/page text without having to reimplement the slots.

## How have you tested it?

Added tests covering all three changes  (12/12 passing)

The full suite is still green (70 suites / 502 tests) with lint + build + build-web-types all passing.

Also did a quick manual check in Chrome via Storybook to make sure the old page-size-reset bug (the one the removed nextTick workaround was guarding against) is actually gone, and everything works.

## Were docs updated if needed?

- [ ] N/A
- [ ] No
- [x] Yes
